### PR TITLE
patch: 504 error & telegram api error on deleting messages

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -64,7 +64,7 @@ async function main() {
         from_id: context.message.from.id,
         from_username: context.message.from.username,
         is_bot: context.message.from.is_bot,
-        from_name: [context.message.from.first_name, context.message.from.last_name].join(' '),
+        from_name: `${context.message.from.first_name} ${context.message.from.last_name}`,
       });
       scope.setTags({
         chat_id: context.message.chat.id,

--- a/src/services/snap/utils.js
+++ b/src/services/snap/utils.js
@@ -20,6 +20,11 @@ export async function generateImage(code) {
     timeout: {
       request: 30_000,
     },
+    retry: {
+      limit: 3,
+      methods: ['POST'],
+      statusCodes: [429, 500, 502, 503, 504],
+    },
   });
 
   return body;


### PR DESCRIPTION
small fix for `/snap` commands:

- it shouldn't delete the code snippet and `/snap` commands on private chats
- immediate return if there's no reply to the message
- fix 504 gateway timeout error on carbonara API by giving 3 times timeout chance

it's a small fix, I assign dicha and artileda to review this, but one approval should be ok I guess. thanks.