### PR TITLE
feat: handler for wikipedia, stackexchange and foodnetwork

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/laodeai_fixture/* linguist-vendored

--- a/src/services/laodeai/foodnetwork.js
+++ b/src/services/laodeai/foodnetwork.js
@@ -1,0 +1,51 @@
+/**
+ * Process Food Network from Cheerio readout
+ * @param {import('cheerio').CheerioAPI} $
+ * @returns {{ type: 'text' | 'error', content: String}}
+ */
+export function foodnetwork($) {
+  const output = $('.o-Recipe')
+    .map((_, el) => {
+      const title = $(el)
+        .find('.recipe-lead .m-RecipeSummary .assetTitle .o-AssetTitle__a-HeadlineText')
+        .first()
+        .text();
+      // This part might be useful later, I'm not deleting it for now.
+      // const meta = $(el)
+      //   .find('.recipe-lead .recipeInfo .o-RecipeInfo > ul > li')
+      //   .map((_, el) => $(el).text().trim().replace(/\n/g, ''))
+      //   .toArray()
+      //   .join('\n');
+      const ingredients = $(el)
+        .find('.recipe-body .bodyLeft .o-Ingredients__m-Body .o-Ingredients__a-Ingredient--CheckboxLabel')
+        .map((_, el) => $(el).text())
+        .toArray();
+      const directions = $(el)
+        .find('.recipe-body .bodyRight .o-Method__m-Body > ol > li')
+        .map((_, el) => $(el).text())
+        .toArray();
+      return { title, ingredients, directions };
+    })
+    .toArray();
+
+  if (output && Object.values(output).length > 0) {
+    const formatted = output
+      .map(
+        (o) =>
+          `<b>${o.title}</b>\n\n<b>Ingredients:</b>\n${o.ingredients
+            .filter((v) => v.toLowerCase() !== 'deselect all')
+            .map((v, i) => `${i + 1}. ${v}`)
+            .join('\n')}\n\n<b>Directions</b>:\n${o.directions.map((v, i) => `${i + 1}. ${v.trim()}`).join('\n')}`,
+      )
+      .join('');
+    return {
+      type: 'text',
+      content: formatted.replace(/\r\n/g, '\n'),
+    };
+  }
+
+  return {
+    type: 'error',
+    content: '',
+  };
+}

--- a/src/services/laodeai/index.js
+++ b/src/services/laodeai/index.js
@@ -6,12 +6,44 @@ import { generateImage } from '../snap/utils.js';
 import { stackoverflow } from './stackoverflow.js';
 import { gist } from './gist.js';
 import { wikipedia } from './wikipedia.js';
+import { wikihow } from './wikihow.js';
+import { stackexchange } from './stackexchange.js';
+import { sanitize } from '../../utils/sanitize.js';
+import { foodnetwork } from './foodnetwork.js';
 
 // list of handlers, also used to filter valid sites
 const VALID_SOURCES = {
   'stackoverflow.com': stackoverflow,
   'gist.github.com': gist,
   'en.wikipedia.org': wikipedia,
+  'wikihow.com': wikihow,
+  'foodnetwork.com': foodnetwork,
+  'serverfault.com': stackexchange,
+  'superuser.com': stackexchange,
+  'askubuntu.com': stackexchange,
+  // I know this is kind of dumb, so..
+  // FIXME: Use regexp! Or not, I don't know which is better
+  'gamedev.stackexchange.com': stackexchange,
+  'gaming.stackexchange.com': stackexchange,
+  'webapps.stackexchange.com': stackexchange,
+  'photo.stackexchange.com': stackexchange,
+  'stats.stackexchange.com': stackexchange,
+  // For weebs out there
+  'anime.stackexchange.com': stackexchange,
+  'japanese.stackexchange.com': stackexchange,
+  // Ok lets get back to normal people
+  'cooking.stackexchange.com': stackexchange,
+  'webmasters.stackexchange.com': stackexchange,
+  'english.stackexchange.com': stackexchange,
+  'math.stackexchange.com': stackexchange,
+  'apple.stackexchange.com': stackexchange,
+  'diy.stackexchange.com': stackexchange,
+  'ux.stackexchange.com': stackexchange,
+  'cstheory.stackexchange.com': stackexchange,
+  'money.stackexchange.com': stackexchange,
+  'softwareengineering.stackexchange.com': stackexchange,
+  'scifi.stackexchange.com': stackexchange,
+  'workplace.stackexchange.com': stackexchange,
 };
 
 /**
@@ -36,7 +68,7 @@ async function laodeai(context) {
       return new URL(decodeURIComponent(href));
     })
     .get()
-    .filter((url) => VALID_SOURCES[url.hostname]);
+    .filter((url) => VALID_SOURCES[url.hostname.replace('www.', '')]);
 
   if (validSources.length < 1) {
     await context.reply("Uhh, I don't have an answer for that, sorry.");
@@ -53,7 +85,7 @@ async function laodeai(context) {
       });
       if (statusCode !== 200) return null;
 
-      return { url: url.href, ...VALID_SOURCES[url.hostname](cheerio.load(body)) };
+      return { url: url.href, ...VALID_SOURCES[url.hostname.replace('www.', '')](cheerio.load(body)) };
     }),
   );
 
@@ -71,7 +103,7 @@ async function laodeai(context) {
     case 'text': {
       let content = result.content;
       if (content.length > 500) {
-        content = `${content.substring(0, 500)}...\n\nSee more on: ${result.url}`;
+        content = `${sanitize(content.substring(0, 500))}...\n\nSee more on: ${result.url}`;
       }
 
       await context.telegram.sendMessage(context.message.chat.id, content, { parse_mode: 'HTML' });

--- a/src/services/laodeai/stackexchange.js
+++ b/src/services/laodeai/stackexchange.js
@@ -1,0 +1,21 @@
+import { sanitize } from '../../utils/sanitize.js';
+
+/**
+ * Process Stackexchange from Cheerio readout
+ * @param {import('cheerio').CheerioAPI} $
+ * @returns {{ type: 'text' | 'error', content: String}}
+ */
+export function stackexchange($) {
+  const acceptedText = $('.answer .post-layout .answercell .s-prose', '#answers').first().html();
+  if (acceptedText) {
+    return {
+      type: 'text',
+      content: sanitize(acceptedText).trim().replace(/\r\n/g, '\n'),
+    };
+  }
+
+  return {
+    type: 'error',
+    content: '',
+  };
+}

--- a/src/services/laodeai/wikihow.js
+++ b/src/services/laodeai/wikihow.js
@@ -1,0 +1,38 @@
+/**
+ * Process Wikihow from Cheerio readout
+ * @param {import('cheerio').CheerioAPI} $
+ * @returns {{ type: 'text' | 'error', content: String}}
+ */
+export function wikihow($) {
+  const output = $('.steps', '.mw-parser-output')
+    .map((_, el) => {
+      const block = $(el).find('h3 .altblock').first().text();
+      const headline = $(el).find('h3 .mw-headline').first().text();
+      const heading = `${block} ${headline}`;
+      const steps = $(el)
+        .find('.section_text > ol > li')
+        .map((_, el) => $(el).find('.step b').text())
+        .toArray();
+      return { heading, steps };
+    })
+    .toArray();
+
+  if (output && Object.values(output).length > 0) {
+    const formatted = output
+      .map(
+        (o) =>
+          `<b>${o.heading.trim().replace(/\n+/g, ' ')}</b>\n${o.steps.map((s, i) => `${i + 1}. ${s}`).join('\n')}\n`,
+      )
+      .join('\n');
+
+    return {
+      type: 'text',
+      content: formatted.replace(/\r\n/g, '\n'),
+    };
+  }
+
+  return {
+    type: 'error',
+    content: '',
+  };
+}

--- a/src/services/laodeai/wikipedia.js
+++ b/src/services/laodeai/wikipedia.js
@@ -1,3 +1,5 @@
+import { sanitize } from '../../utils/sanitize.js';
+
 /**
  * Process Wikipedia from Cheerio readout
  * @param {import('cheerio').CheerioAPI} $
@@ -5,7 +7,7 @@
  */
 export function wikipedia($) {
   const paragraphs = $('#bodyContent .mw-body-content .mw-parser-output p', '.mw-body')
-    .map((i, el) => $(el).text())
+    .map((i, el) => $(el).html())
     .toArray()
     .slice(0, 3)
     .join('\n');
@@ -13,7 +15,7 @@ export function wikipedia($) {
   if (paragraphs) {
     return {
       type: 'text',
-      content: paragraphs
+      content: sanitize(paragraphs)
         .replace(/\[(\d+|update)\]/g, '')
         .replace(/\r\n/g, '\n')
         .trim(),

--- a/tests/laodeai.test.js
+++ b/tests/laodeai.test.js
@@ -331,12 +331,6 @@ test('should be able to parse foodnetwork output', () => {
     output.content,
     `<b>Spaghetti alla Carbonara</b>
 
-Level:    Intermediate
-Total:           25 min
-Prep:           15 min
-Cook:           10 min
-Yield:    4 to 6 servings
-
 <b>Ingredients:</b>
 1. 1 pound dry spaghetti
 2. 2 tablespoons extra-virgin olive oil

--- a/tests/laodeai.test.js
+++ b/tests/laodeai.test.js
@@ -7,6 +7,9 @@ import cheerio from 'cheerio';
 import { stackoverflow } from '../src/services/laodeai/stackoverflow.js';
 import { gist } from '../src/services/laodeai/gist.js';
 import { wikipedia } from '../src/services/laodeai/wikipedia.js';
+import { wikihow } from '../src/services/laodeai/wikihow.js';
+import { stackexchange } from '../src/services/laodeai/stackexchange.js';
+import { foodnetwork } from '../src/services/laodeai/foodnetwork.js';
 
 test('should be able to parse a stackoverflow code output', () => {
   const file = readFileSync(
@@ -252,6 +255,109 @@ test('should be able to parse wikipedia output', () => {
 test('should return error on empty wikipedia html', () => {
   const html = cheerio.load('<body></body>');
   const output = wikipedia(html);
+  assert.equal(output, { type: 'error', content: '' });
+});
+
+test('should be able to parse wikihow output', () => {
+  const file = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), './laodeai_fixture/wikihow.html'));
+  const html = cheerio.load(file);
+  const output = wikihow(html);
+  assert.equal(output.type, 'text');
+  assert.equal(
+    output.content,
+    `<b>Method 1 of 3:  Treating Momentary Ringing in the Ears</b>
+1. Try the skull-thumping trick.
+2. Try waiting it out.
+3. Avoid loud noises and protect your ears when you are exposed to noise.
+
+<b>Method 2 of 3:  Treating Chronic Ringing in the Ears</b>
+1. See your doctor about treating underlying conditions.
+2. Look into biofeedback therapy for your tinnitus.
+3. Treat tinnitus with noise-suppression tactics.
+4. Take medications to relieve some of the tinnitus symptoms.
+5. Try ginkgo extract.
+
+<b>Method 3 of 3:  Preventing Tinnitus</b>
+1. Avoid situations in which damage to the cochlea could cause tinnitus.
+2. Find an outlet for your stress.
+3. Consume less alcohol and nicotine.
+`,
+  );
+});
+
+test('should return error on empty wikihow html', () => {
+  const html = cheerio.load('<body></body>');
+  const output = wikihow(html);
+  assert.equal(output, { type: 'error', content: '' });
+});
+
+test('should be able to parse stackexchange output', () => {
+  const file = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), './laodeai_fixture/stackexchange.html'));
+  const html = cheerio.load(file);
+  const output = stackexchange(html);
+  assert.equal(output.type, 'text');
+  assert.equal(
+    output.content,
+    `Dear <a href="https://twitter.com/colmmacuait">@colmmacuait</a>, I think that if you type "man" at 0001 hours it should print "gimme gimme gimme". <a href="https://twitter.com/hashtag/abba?src=hash">#abba</a> 
+ <a href="https://twitter.com/marnanel/status/132280557190119424"><strong>@marnanel</strong> - 3 November 2011</a> 
+
+
+er, that was my fault, I suggested it. Sorry.
+
+Pretty much the whole story is in the commit. The maintainer of man is a good friend of mine, and one day six years ago I jokingly said to him that if you invoke man after midnight it should print "<em>gimme gimme gimme</em>", because of the Abba song called "<em>Gimme gimme gimme a man after midnight</em>":
+
+Well, he did actually <a href="https://git.savannah.nongnu.org/cgit/man-db.git/commit/src/man.c?id=002a6339b1fe8f83f4808022a17e1aa379756d99">put it</a> <a href="https://git.savannah.nongnu.org/cgit/man-db.git/commit/src/man.c?id=91c495389105a4cb6214fe176f703f498e4f0d91">in</a>. A few people were amused to discover it, and we mostly forgot about it until today.
+
+<a href="https://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030/405874#comment726280_405874">I can't speak for Col</a>, obviously, but I didn't expect this to ever cause any problems: what sort of test would break on parsing the output of man with no page specified? I suppose I shouldn't be surprised that one turned up eventually, but it did take six years.
+
+(The <a href="https://git.savannah.nongnu.org/cgit/man-db.git/commit/src/man.c?id=002a6339b1fe8f83f4808022a17e1aa379756d99">commit message</a> calls me Thomas, which is my legal first name though I don't use it online much.) 
+
+<strong>This issue has been fixed with commit <a href="https://git.savannah.gnu.org/cgit/man-db.git/commit/?id=84bde8d8a9a357bd372793d25746ac6b49480525">84bde8</a>:</strong> Running man with <code>man -w</code> will no longer trigger this easter egg.`,
+  );
+});
+
+test('should return error on empty stackexchange html', () => {
+  const html = cheerio.load('<body></body>');
+  const output = stackexchange(html);
+  assert.equal(output, { type: 'error', content: '' });
+});
+
+test('should be able to parse foodnetwork output', () => {
+  const file = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), './laodeai_fixture/foodnetwork.html'));
+  const html = cheerio.load(file);
+  const output = foodnetwork(html);
+  assert.equal(output.type, 'text');
+  assert.equal(
+    output.content,
+    `<b>Spaghetti alla Carbonara</b>
+
+Level:    Intermediate
+Total:           25 min
+Prep:           15 min
+Cook:           10 min
+Yield:    4 to 6 servings
+
+<b>Ingredients:</b>
+1. 1 pound dry spaghetti
+2. 2 tablespoons extra-virgin olive oil
+3. 4 ounces pancetta or slab bacon, cubed or sliced into small strips
+4. 4 garlic cloves, finely chopped
+5. 2 large eggs
+6. 1 cup freshly grated Parmigiano-Reggiano, plus more for serving
+7. Freshly ground black pepper
+8. 1 handful fresh flat-leaf parsley, chopped
+
+<b>Directions</b>:
+1. Prepare the sauce while the pasta is cooking to ensure that the spaghetti will be hot and ready when the sauce is finished; it is very important that the pasta is hot when adding the egg mixture, so that the heat of the pasta cooks the raw eggs in the sauce.
+2. Bring a large pot of salted water to a boil, add the pasta and cook for 8 to 10 minutes or until tender yet firm (as they say in Italian "al dente.") Drain the pasta well, reserving 1/2 cup of the starchy cooking water to use in the sauce if you wish.
+3. Meanwhile, heat the olive oil in a deep skillet over medium flame. Add the pancetta and saute for about 3 minutes, until the bacon is crisp and the fat is rendered. Toss the garlic into the fat and saute for less than 1 minute to soften.
+4. Add the hot, drained spaghetti to the pan and toss for 2 minutes to coat the strands in the bacon fat. Beat the eggs and Parmesan together in a mixing bowl, stirring well to prevent lumps. Remove the pan from the heat and pour the egg/cheese mixture into the pasta, whisking quickly until the eggs thicken, but do not scramble (this is done off the heat to ensure this does not happen.) Thin out the sauce with a bit of the reserved pasta water, until it reaches desired consistency. Season the carbonara with several turns of freshly ground black pepper and taste for salt. Mound the spaghetti carbonara into warm serving bowls and garnish with chopped parsley. Pass more cheese around the table.`,
+  );
+});
+
+test('should return error on empty foodnetwork html', () => {
+  const html = cheerio.load('<body></body>');
+  const output = foodnetwork(html);
   assert.equal(output, { type: 'error', content: '' });
 });
 

--- a/tests/laodeai_fixture/foodnetwork.html
+++ b/tests/laodeai_fixture/foodnetwork.html
@@ -1,0 +1,7892 @@
+
+<!DOCTYPE HTML>
+<html  lang="en">
+
+
+
+
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    
+
+
+
+   
+
+  
+
+   
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+<!-- perftest_asyncCSS: 0 -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+
+  <!-- critical styles -->
+  <style type="text/css" data-sni-css-critical>
+@charset "UTF-8";
+
+.is-Hidden,[data-logged-in],[data-logged-out]{display:none!important}.u-LoadMoreSrc{display:none}html.js-support:not(.core-js) [data-truncate]{display:none}.has-LazyLoadedBackground{display:block;width:100%;height:100%;background-size:cover;background-position:50%}.has-LazyLoadedBackground img{opacity:0}html{-moz-box-sizing:border-box;box-sizing:border-box}html *{-moz-box-sizing:inherit;box-sizing:inherit}body{max-width:960px;margin-left:auto;margin-right:auto}a,abbr,acronym,address,applet,article,aside,audio,b,big,blockquote,body,canvas,caption,center,cite,code,dd,del,details,dfn,div,dl,dt,em,embed,fieldset,figcaption,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,html,i,iframe,img,ins,kbd,label,legend,li,mark,menu,nav,object,ol,output,p,pre,q,ruby,s,samp,section,small,span,strike,strong,sub,summary,sup,table,tbody,td,tfoot,th,thead,time,tr,tt,u,ul,var,video{margin:0;padding:0;border:0;font-size:100%;font:inherit;vertical-align:baseline}article,aside,details,figcaption,figure,footer,header,hgroup,menu,nav,section{display:block}body{line-height:1}ol,ul{list-style:none}blockquote,q{quotes:none}blockquote:after,blockquote:before,q:after,q:before{content:"";content:none}table{border-collapse:collapse;border-spacing:0}html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}img{height:auto}*{box-sizing:border-box}:after,:before{box-sizing:border-box}#CQ *{box-sizing:content-box}#CQ :after,#CQ :before{box-sizing:content-box}html{-webkit-tap-highlight-color:transparent;-webkit-font-smoothing:subpixel-antialiased}button,input,select,textarea{font-family:inherit;font-size:inherit;line-height:inherit}input::-ms-clear{display:none}img{vertical-align:middle}body{max-width:none;min-width:1024px;line-height:1.35;color:#1c1c1c;background:#f5f5f5;font-size:15px;font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif}@media print{body{font-size:13pt;font-family:Helvetica Neue,Helvetica,Arial,sans-serif}}.container-site{max-width:994px;margin:0 auto}.container-site:after,.container-site:before{content:"";display:table;clear:both}.container-site{position:relative;background:#f5f5f5;box-shadow:none}@media (min-width:1024px){.container-site{max-width:none;width:994px}.container-site.is-Fluid{width:auto;min-width:994px;max-width:1280px;background:transparent;box-shadow:none}.votePage .container-site.is-Fluid{background-color:#fff}.votePage .container-site.is-Fluid .col-md-18{width:70.5%}.votePage .container-site.is-Fluid .col-md-10{width:29.5%}}.container-site{padding:14px;width:994px}body{margin:0 auto;width:auto}.container{position:relative}.container:after,.container:before{content:"";display:table;clear:both}.container{width:994px}.container.is-Fluid{width:auto;min-width:994px;max-width:1280px}.container--wide{width:100%;min-width:994px;max-width:1280px}.container,.container-fluid{margin-right:auto;margin-left:auto}.rightRail{float:left;width:336px;margin-left:14px}a{background:transparent;color:#e6003d;text-decoration:none}a:hover{color:red;text-decoration:underline}a:active,a:focus,a:hover{outline:0}b,strong{font-weight:400;font-family:FranklinGothicURW-Dem,Helvetica,Arial,sans-serif}em,i{font-style:italic}p{margin-bottom:10.5px}#bigbox-rr-ad,.bigbox-height-enforced{box-sizing:content-box;min-height:250px}#dfp_leaderboard{min-height:90px}#bigbox-rr-ad.is-AdCollapsed,#dfp_leaderboard.is-AdCollapsed,.is-AdCollapsed,.o-Leaderboard.is-AdCollapsed{min-height:inherit}.bigbox-ad{position:relative;margin:0 0 14px;padding:0;text-align:center}.bigbox-ad .ad-text{margin-top:7px;text-transform:capitalize;font-size:12px;font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;color:#999}.bigbox-ad{display:table-cell;vertical-align:middle}.bigbox-ad.rr-ad{display:block;clear:both}.o-ArticleStream div[data-has-ad=dfp_leaderboard_body]{margin-top:56px;margin-bottom:49px}#_fw_container_900x650slot{display:none}#photo-gallery.interstitial-show .rsArrow.force-show,.pv-content-wrapper.interstitial-show .rsArrow.force-show{display:block!important}.a-Icon{width:30px;height:30px}.a-LazyImage{display:none}.js-support .a-LazyImage{display:block}.a-Loader{width:65px;height:10px;margin:auto;position:absolute;top:0;left:0;bottom:0;right:0}.a-Loader div{float:left;height:10px;width:10px;margin-left:3.5px;opacity:0;animation-name:bounce_loadingdot;animation-duration:2s;animation-iteration-count:infinite;animation-direction:linear;border-radius:5px}.a-Loader div:nth-child(1n){background:#faa}.a-Loader div:nth-child(2n){background:#f55;animation-delay:.25s}.a-Loader div:nth-child(3n){background:red;animation-delay:.5s}.a-Loader div:nth-child(4n){background:#dd0101;animation-delay:.75s}@-moz-keyframes bounce_loadingdot{50%{opacity:1}}@-webkit-keyframes bounce_loadingdot{50%{opacity:1}}@-o-keyframes bounce_loadingdot{50%{opacity:1}}@keyframes bounce_loadingdot{50%{opacity:1}}.is-Subtle .a-Loader div:nth-child(1n){background:#d2d1d1}.is-Subtle .a-Loader div:nth-child(2n){background:#d2d1d1}.is-Subtle .a-Loader div:nth-child(3n){background:#d2d1d1}.is-Subtle .a-Loader div:nth-child(4n){background:#d2d1d1}.rsPreloader{width:100%;height:100%}.o-AssetTitle{clear:both}.o-AssetTitle__a-Headline{margin:7px 0;font-size:48px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;line-height:1;color:#1c1c1c}.videoPlaylistPage .o-AssetTitle__a-Headline{margin-top:0;margin-bottom:28px;font-size:28px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;line-height:1;font-weight:400}.videoPlaylistPage .o-AssetTitle__a-HeadlineText{position:relative;top:21px}.o-FooterFresh{position:relative;margin:21px 0 0;background:#292929;text-align:center}.o-FooterFresh li{display:inline-block;position:relative}.o-FooterFresh{padding:42px 14px}.o-FooterFresh__m-Body{max-width:1280px;margin:0 auto}.o-FooterFresh__m-Info a,.o-FooterFresh__m-Info a:visited{font-size:12px;color:#ababaa}.o-FooterFresh__m-Info .m-DropdownMenu{font-size:15px}.o-FooterFresh__m-Info .m-DropdownMenu a,.o-FooterFresh__m-Info .m-DropdownMenu a:visited{display:block;padding:3.5px 0}.o-FooterFresh__m-Info .m-DropdownMenu li{position:relative}.o-FooterFresh__m-Info .m-DropdownMenu{background:#fff;min-width:180px;max-height:300px;overflow-x:auto;padding:7px 14px;border-radius:3px}.o-FooterFresh__m-Info .m-DropdownMenu li{border-bottom:1px dotted #333;padding:7px 0 3.5px}.o-FooterFresh__m-Info .m-DropdownMenu li a,.o-FooterFresh__m-Info .m-DropdownMenu li a:visited{color:#1c1c1c}.o-FooterFresh__m-Info .m-DropdownMenu li a:active,.o-FooterFresh__m-Info .m-DropdownMenu li a:hover{color:#1c1c1c}.o-FooterFresh__m-Info .m-DropdownMenu li:last-child{border-bottom:none}.o-FooterFresh__m-Info .m-DropdownMenu{display:none;position:absolute;z-index:10000;max-height:none;margin-top:0;overflow-x:visible;left:50%;bottom:100%;text-align:left;box-shadow:0 -1px 6px rgba(0,0,0,.25)}.o-FooterFresh__m-Info.is-Open .m-DropdownMenu,.o-FooterFresh__m-Info.is-Open .o-FooterFresh__m-Info li.is-Expanded .m-DropdownMenu,.o-FooterFresh__m-Info .m-DropdownMenu li,.o-FooterFresh__m-Info li.is-Expanded .m-DropdownMenu,.o-FooterFresh__m-Info li.is-Expanded .o-FooterFresh__m-Info.is-Open .m-DropdownMenu{display:block}html:not(.core-js) .o-FooterFresh__m-Info:hover .m-DropdownMenu,html:not(.core-js) .o-FooterFresh__m-Info:hover .o-FooterFresh__m-Info li:hover .m-DropdownMenu,html:not(.core-js) .o-FooterFresh__m-Info li:hover .m-DropdownMenu,html:not(.core-js) .o-FooterFresh__m-Info li:hover .o-FooterFresh__m-Info:hover .m-DropdownMenu{display:block}.o-FooterFresh__m-Info .has-DropdownMenu{margin-right:14px;padding-right:14px;border-right:1px solid #333}.o-FooterFresh__m-Info .has-DropdownMenu:after{display:inline-block;font-style:normal;font-weight:400;line-height:1;text-transform:none;-webkit-font-feature-settings:"liga";-moz-font-feature-settings:"liga";-ms-font-feature-settings:"liga" 1;-o-font-feature-settings:"liga";font-feature-settings:"liga";font-family:fn-icons;content:"";color:#999;font-size:10px}.o-FooterFresh__m-Info .has-DropdownMenu:after:hover{text-decoration:none}.o-FooterFresh__m-Info .has-DropdownMenu:hover{color:#fff}.o-FooterFresh .m-Body__m-PromoList{font-size:15px}.o-FooterFresh .m-Body__m-PromoList a,.o-FooterFresh .m-Body__m-PromoList a:visited{padding:4px;color:#fff}.o-FooterFresh .m-Body__m-PromoList a:hover,.o-FooterFresh .m-Body__m-PromoList a:visited:hover{color:#fff}.o-FooterFresh .m-Body__m-PromoList li{padding:0 7px;margin-bottom:7px}.o-FooterFresh .o-FooterFresh__m-Brands{position:relative}.o-FooterFresh .o-FooterFresh__m-Brands a:active,.o-FooterFresh .o-FooterFresh__m-Brands a:hover{cursor:pointer}.o-FooterFresh .o-FooterFresh__m-Brands>a{cursor:default;font-size:12px;color:#999}.o-FooterFresh .has-DropdownMenu{margin-right:14px;padding-right:14px;border-right:1px solid #333}.o-FooterFresh .has-DropdownMenu:after{display:inline-block;font-style:normal;font-weight:400;line-height:1;text-transform:none;-webkit-font-feature-settings:"liga";-moz-font-feature-settings:"liga";-ms-font-feature-settings:"liga" 1;-o-font-feature-settings:"liga";font-feature-settings:"liga";font-family:fn-icons;content:"";color:#999;font-size:10px}.o-FooterFresh .has-DropdownMenu:after:hover{text-decoration:none}.o-FooterFresh .has-DropdownMenu:hover{color:#fff}.o-FooterFresh .o-FooterFresh__a-Copyright{font-size:12px;color:#999}.o-FooterFresh .m-Body__m-PromoList{margin-bottom:14px}
+
+</style>
+  <!-- end critical styles -->
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+  
+
+    <!-- recipe critical styles-->
+    <style type="text/css" data-sni-css-critical>
+
+@charset "UTF-8";@font-face{font-family:FranklinGothicURW-Boo;src:url(/etc/clientlibs/assets/v2/css/fonts/franklin-gothic-urw-book-webfont-full/franklin-gothic-urw-book.woff2) format("woff2"),url(/etc/clientlibs/assets/v2/css/fonts/franklin-gothic-urw-book-webfont-full/franklin-gothic-urw-book.woff) format("woff"),url(/etc/clientlibs/assets/v2/css/fonts/franklin-gothic-urw-book-webfont-full/franklin-gothic-urw-book.svg#youworkforthem) format("svg");font-weight:400;font-style:normal;font-display:fallback}@font-face{font-family:Franklin Gothic URW Cond Medium;src:url(/etc/clientlibs/assets/v2/css/fonts/franklin-gothic-urw-cond-medium-webfont-lite/franklin-gothic-urw-cond-medium.woff) format("woff"),url(/etc/clientlibs/assets/v2/css/fonts/franklin-gothic-urw-cond-medium-webfont-lite/franklin-gothic-urw-cond-medium.svg#ywftsvg) format("svg");font-weight:400;font-style:normal;font-display:fallback}@font-face{font-family:FranklinGothicURW-Dem;src:url(/etc/clientlibs/assets/v2/css/fonts/franklin-gothic-urw-demi-webfont-full/franklin-gothic-urw-demi.woff2) format("woff2"),url(/etc/clientlibs/assets/v2/css/fonts/franklin-gothic-urw-demi-webfont-full/franklin-gothic-urw-demi.woff) format("woff"),url(/etc/clientlibs/assets/v2/css/fonts/franklin-gothic-urw-demi-webfont-full/franklin-gothic-urw-demi.svg#youworkforthem) format("svg");font-weight:700;font-style:normal;font-display:fallback}@font-face{font-family:fn-icons;src:url(/etc/clientlibs/assets/v2/css/fonts/fn-icons-1.3/fonts/fn-icons.woff) format("woff"),url(/etc/clientlibs/assets/v2/css/fonts/fn-icons-1.3/fonts/fn-icons.woff2) format("woff2"),url(/etc/clientlibs/assets/v2/css/fonts/fn-icons-1.3/fonts/fn-icons.svg#fn-icons) format("svg");font-weight:400;font-style:normal;font-display:fallback}.o-Header .a-Icon--Menu{width:20px;height:16px;stroke:#1c1c1c}.o-Header .a-Icon--Profile,.o-Header .a-Icon--Profile-hover{width:25px;height:25px}.o-Header [data-type=button-header-profile]{width:25px;height:25px;border-radius:100%;overflow:hidden}.o-Header [data-type=button-header-profile]:hover{cursor:pointer}.o-Header [data-type=button-header-profile] img{width:25px;height:25px}.o-Header__m-Navigation .a-Icon--saves{fill:none;stroke:#1c1c1c}.o-Header__m-Navigation .a-Icon--saves:hover{fill:#e6003d}.o-Header__m-Navigation .a-Icon--shopping-list{fill:none;color:transparent;stroke:#1c1c1c}.o-Header__m-Navigation .a-Icon--shopping-list:hover{color:#ff626a}.o-Header__m-Navigation .a-Icon--shopping-list:hover #cart{fill:#ff626a}@media only screen and (min-device-width:738px){.o-Header{position:relative;z-index:11;display:flex;align-items:center;flex-direction:column;background:#fff;box-shadow:0 0 10px 1px hsla(0,0%,84.3%,.5)}.o-Header__m-Area{width:100%;max-width:1280px;z-index:2}}@media only screen and (min-device-width:738px) and (min-width:1025px) and (min-device-width:1025px){.o-Header__m-Area--Main .o-Header__m-Area.m-Area__m-Container{min-width:994px}}@media only screen and (min-device-width:738px){.o-Header [data-module=header]{display:flex;flex-direction:row;height:80px}.o-Header [data-module=header] .o-Header__m-DropdownMenu{display:none}.o-Header [data-module=header] .o-Header__m-Area.m-Area__m-Container{display:flex;align-items:center;height:inherit;width:100%;margin:0 auto;padding:0 29px}.o-Header [data-module=header] .o-Header__m-Navigation:hover>.a-Icon--close,.o-Header [data-module=header] .o-Header__m-Navigation:hover>.a-Icon--Menu{stroke:#ff626a!important}.o-Header [data-module=header] .o-Header__m-SiteLogo{display:flex}.o-Header [data-module=header] .o-Header__m-SiteLogo>a{height:60px}.o-Header [data-module=header] .o-Header__m-SiteLogo .a-Icon--Logo{height:60px;width:60px}.o-Header [data-module=header] .o-Header__a-NavLink{z-index:100;position:relative}.o-Header [data-module=header] .o-Header__a-NavLink:after{content:"";position:absolute;top:50px;left:0;right:0;transform-origin:center right;transform:scaleX(0);margin:0 17.5px}.o-Header [data-module=header] .o-Header__a-NavLink:hover:after{height:5px;border-radius:5px;background-color:#ff626a;transform-origin:center left;transform:scaleX(1);transition:transform .1s ease}.o-Header [data-module=header] .o-Header__a-NavLink:not(:empty){display:flex;justify-content:center;align-items:center;height:80px;padding:0 17.5px}.o-Header [data-module=header] .o-Header__m-NavItem{display:flex;align-items:center;justify-content:flex-end}.o-Header [data-module=header] .o-Header__m-NavItem.premium-flyout .o-Header__m-DropdownMenu:after{display:block;content:"";width:100%;position:absolute;bottom:-3px;height:25px;margin:-21px;background-image:linear-gradient(90deg,#cfe7f9 0,#87ccff 127%)}.o-Header [data-module=header] .o-Header__m-NavItem.premium-flyout .o-Header__a-NavLink:hover:after{background-color:#87ccff}.o-Header [data-module=header] .o-Header__m-NavItemWrap{align-items:center;flex:0 0 auto;text-align:center;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;font-weight:600;font-size:16px;height:100%;display:flex}.o-Header [data-module=header] .o-Header__m-NavItemWrap a{text-decoration:none;color:#1c1c1c;transition:all .05s linear}.o-Header [data-module=header] .o-Header__m-NavItemLabel{position:absolute}.o-Header [data-module=header] .o-Header__m-NavItemLabel span{position:relative;top:-12px;right:-6px;font-family:FranklinGothicURW-Dem,Helvetica,Arial,sans-serif;font-size:10px;line-height:.8;color:#54a2d9}.o-Header [data-module=header] .o-Header__m-NavItemLabel span>svg{width:12px;height:12px;margin-left:-4px}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--moreLinks{position:relative}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--moreLinks .m-Navigation--IconWrap{margin:0 17.5px 0 0;font-size:0}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--moreLinks .o-Header__m-DropdownMenu{width:288px;left:-14px}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox,.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--siteLogo{height:inherit}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--siteLogo{font-size:0}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--siteLogo a{height:60px;margin:0 17.5px}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--siteLogo .a-Icon--Logo{height:60px;width:60px}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox{margin-left:auto}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchForm__m-Area{position:relative}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchForm__m-Area [data-typeahead-hints]{height:0}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--profile{position:relative;margin-left:20px}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--profile .o-Header__m-DropdownList{text-align:right}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--profile .o-Header__m-DropdownMenu{width:190px;left:-140px;padding:0 20px 20px}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--profile .logged-in,.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--profile .logged-out{display:none}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--iconLink{margin-left:20px}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--iconLink .m-Navigation--saves,.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--iconLink .m-Navigation--shopping-list{display:flex;height:100%;align-items:center}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--iconLink .m-Navigation--saves a,.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--iconLink .m-Navigation--shopping-list a{font-size:0}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--iconLink .m-Navigation--saves svg{width:17px;height:22px}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--iconLink .m-Navigation--shopping-list svg{width:23px;height:24px}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchForm__m-InputWrap{display:flex}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchForm__a-Input{display:block;width:250px;height:40px;padding:18px 70px 12px 12px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;font-size:15px;border:0;border-radius:22px;box-shadow:0 0 8px 0 #d5d5d5;background-color:#fff;transition:none}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchForm__a-Input::placeholder{font-size:14px;color:#707070}.Win32 .o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchForm__a-Input,.Win64 .o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchForm__a-Input{padding:15px 70px 12px 12px}}@media only screen and (min-device-width:738px) and (max-width:1055px){.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchForm__a-Input{padding:18px 65px 12px 12px;width:210px}}@media only screen and (min-device-width:738px){.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchBox__a-Button--Clear{display:none}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchBox__a-Button--Clear .a-Icon--clear{position:absolute;top:50%;transform:translateY(-50%);right:45px;width:11px;height:11px;stroke:none;fill:#979797;cursor:pointer}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchBox__a-Button--Search{padding:0!important;border:none;background:none}.o-Header [data-module=header] .o-Header__m-NavItemWrap.m-NavItemWrap--searchBox .m-SearchBox__a-Button--Search .a-Icon--search{position:absolute;top:50%;right:14.5px;transform:translateY(-50%) rotateY(180deg);width:23px;height:23px;cursor:pointer}}.o-Header__m-NavItem.is-Free,.o-Header__m-NavItem.is-Free.hide-nav,.o-Header__m-NavItem.is-Premium,.o-Header__m-NavItem.is-Premium.hide-nav,.o-Header__m-NavItem.is-Premium.show-nav{display:none!important;opacity:0;transition:opacity .1s ease-out}[data-module=header] .o-Header__m-NavItem.is-Free,[data-module=header] .o-Header__m-NavItem.is-Free.show-nav{display:flex!important;opacity:1;transition:opacity .1s ease-out}.premium [data-module=header] .o-Header__m-NavItem.is-Premium,.premium [data-module=header] .o-Header__m-NavItem.is-Premium.hide-nav,.premium [data-module=header] .o-Header__m-NavItem.is-Premium.show-nav{display:flex!important;opacity:1;transition:opacity .1s ease-out}.premium [data-module=header] .o-Header__m-NavItem.is-Free,.premium [data-module=header] .o-Header__m-NavItem.is-Free.show-nav{display:none!important;opacity:0;transition:opacity .1s ease-out}.l-Columns--2up{max-width:960px;margin-left:auto;margin-right:auto}.l-Columns--2up:after{content:"";display:table;clear:both}.l-Columns--2up>:nth-child(odd){float:left;clear:left;margin:0 7px 28px 0}.l-Columns--2up>:nth-child(2n+2){float:left;clear:none;margin:0 0 28px 7px}.l-List .m-MediaBlock{display:table;width:100%;margin:0 0 14px}.l-List .m-MediaBlock__a-Label{position:relative;margin:0 0 7px}.l-List .m-MediaBlock__m-MediaWrap{display:table-cell;line-height:0;padding-right:14px;position:relative}.l-List .m-MediaBlock__m-TextWrap{display:table-cell;vertical-align:middle;width:60.25%;vertical-align:top}.l-List .m-MediaBlock__a-Image{display:inline-block}.l-List .m-MediaBlock__m-MediaWrap .m-MediaBlock__a-Label{line-height:normal;display:none}.l-List .m-MediaBlock__m-TextWrap .m-MediaBlock__a-Label{display:inline-block}.o-Breadcrumb{list-style:none;margin-bottom:7px;z-index:1;font-size:12px;padding:7px 0 0}.o-Breadcrumb a,.o-Breadcrumb a:visited{color:#1c1c1c}.o-Breadcrumb a:after,.o-Breadcrumb a:visited:after{display:inline-block;font-style:normal;font-weight:400;line-height:1;text-transform:none;-webkit-font-feature-settings:"liga";-ms-font-feature-settings:"liga" 1;-o-font-feature-settings:"liga";font-feature-settings:"liga";font-family:fn-icons;content:"/";margin:0 3.5px}.o-Breadcrumb a:after:hover,.o-Breadcrumb a:visited:after:hover{text-decoration:none}.o-Breadcrumb li{display:inline-block}.o-Breadcrumb li a,.o-Breadcrumb li a:visited{color:#1c1c1c}.o-Breadcrumb li:last-child a:after,.o-Breadcrumb li:last-child a:visited:after{display:none;font-style:normal;font-weight:400;line-height:1;text-transform:none;-webkit-font-feature-settings:"liga";-ms-font-feature-settings:"liga" 1;-o-font-feature-settings:"liga";font-feature-settings:"liga";font-family:fn-icons}.o-Breadcrumb li:last-child a:after:hover,.o-Breadcrumb li:last-child a:visited:after:hover{text-decoration:none}.o-Breadcrumb--Light li:visited,.o-Breadcrumb--Light li a,.o-Breadcrumb--Light li a:visited{color:#fff!important}.a-Input{padding:7px;font-size:12px;line-height:1.35;color:#1c1c1c;outline:none;border:1px solid #ccc;border-radius:3px;height:37px;background-color:#fff;box-shadow:none;transition:border-color .15s ease-in-out}html.js-support:not(.core-js) .m-Carousel__m-Slide:not(:first-child){display:none}.rightRail .m-MediaBlock{border-top:1px dotted #333;padding-top:14px;margin-bottom:14px}.rightRail .m-MediaBlock:first-child{border-top:none;padding-top:0}.rightRail .m-MediaBlock:last-child{margin-bottom:7px}.rightRail .m-MediaBlock__a-Headline{font-size:20px;font-weight:400;line-height:1.1;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;color:#1c1c1c}.l-Columns .m-MediaBlock__a-Headline,.m-MediaBlock__a-Headline{font-size:28px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;line-height:1;font-weight:400}.rightRail .m-MediaBlock__a-AssetInfo{font-size:15px}.m-MediaBlock__a-AssetInfo{white-space:nowrap}.rightRail .m-MediaBlock__a-Label{margin:0 0 7px!important}.rightRail .m-MediaBlock__a-Description{margin:3.5px 0;font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;font-size:15px;line-height:1.35}.m-MediaBlock__m-MediaWrap a,.m-MediaBlock__m-MediaWrap a:visited{position:relative;display:block}.m-MediaBlock__a-Button{background:#00aeef;color:#fff;border:none;display:inline-block;padding:7px 14px;text-align:center;cursor:pointer;white-space:nowrap;outline:none;-moz-appearance:none;-webkit-appearance:none}.m-MediaBlock__a-Button:hover{color:#fff;text-decoration:none}.m-MediaBlock__a-Button[disabled]{color:#bebdbc;pointer-events:none}.rightRail .m-MediaBlock__m-PromoList{margin-bottom:7px}.m-MediaBlock__m-MediaWrap{position:relative}.m-MediaBlock__a-Image{display:block;width:100%;height:auto;max-width:100%;min-width:100%}.m-MediaBlock__a-Label{background:#f9e929;color:#1c1c1c;padding:6px 7px 0;font-size:14px;text-transform:uppercase;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif}.m-MediaBlock__a-Headline{margin-bottom:7px}.m-MediaBlock__a-Headline a,.m-MediaBlock__a-Headline a:visited{display:inline-block;color:#1c1c1c}.m-MediaBlock__a-Headline a:active,.m-MediaBlock__a-Headline a:hover{color:#1c1c1c;text-decoration:none}.m-MediaBlock__a-Headline a:active .m-MediaBlock__a-HeadlineText,.m-MediaBlock__a-Headline a:hover .m-MediaBlock__a-HeadlineText{text-decoration:underline}.m-MediaBlock__a-AssetInfo{font-size:18px;font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;line-height:1;color:#ababaa}.m-MediaBlock__a-AssetInfo:hover{text-decoration:none}.l-List .m-MediaBlock__a-Description,.m-MediaBlock__a-Description{margin:7px 0}.m-MediaBlock__a-Cta{color:#1c1c1c;font-weight:400}.m-MediaBlock__a-Cta:before{display:inline-block;font-style:normal;font-weight:400;line-height:.9;text-transform:none;-webkit-font-feature-settings:"liga";-ms-font-feature-settings:"liga" 1;-o-font-feature-settings:"liga";font-feature-settings:"liga";font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;content:"»\a";margin:-2px 6px 0 0;font-size:24px;color:red}.l-Columns .m-MediaBlock__m-MediaWrap{margin:0 0 10.5px;position:relative}.l-Columns .m-MediaBlock__m-MediaWrap .m-MediaBlock__a-Label{bottom:0;left:0;pointer-events:none}.l-Columns .m-MediaBlock__m-TextWrap{padding:0 3.5px 0 0}.l-Columns .m-MediaBlock__m-TextWrap .m-MediaBlock__a-Label{display:none}.rightRail .l-List .m-MediaBlock__m-MediaWrap .m-MediaBlock__a-Label{margin:0 0 7px!important}.o-SocialShare__m-ShareButton{display:table;width:100.5%;padding:5px;background:#000;cursor:pointer;border-radius:3px}.o-SocialShare__m-ShareButton:hover{background:#999;text-decoration:none}.o-Capsule{margin:0 0 28px}.rightRail .o-Capsule{margin:14px 0;padding:7px;background:#fff}.o-Capsule:after,.o-Capsule:before{content:"";display:table;clear:both}.o-Capsule__m-Header{position:relative;margin-bottom:14px;border-top:5px solid #1c1c1c}.o-Capsule__m-TextWrap{display:table;width:100%}.o-Capsule__a-Headline{margin:0;font-size:34px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;line-height:1;color:#1c1c1c;text-transform:uppercase;padding-top:7px;padding-bottom:0}.o-Capsule__a-Headline a,.o-Capsule__a-Headline a:visited{color:#1c1c1c}.o-Capsule__a-Headline a:active,.o-Capsule__a-Headline a:hover{color:#1c1c1c;text-decoration:underline}.o-Capsule__a-Headline{padding:7px 0 14px;display:table-cell}.rightRail .o-Capsule__a-Headline{padding-top:7px;padding-bottom:0;font-size:28px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;line-height:1;font-weight:400}[role=contentWell] .o-Capsule__a-Headline{font-size:34px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;line-height:1;color:#1c1c1c;text-transform:uppercase;padding-top:7px;padding-bottom:0}.o-AssetDescription{clear:both}.o-AssetDescription__a-Description{margin:0 0 21px;font-size:20px;line-height:1.35;font-family:Georgia,Times New Roman,Times,serif;font-style:italic}.o-AssetDescription__a-Description b,.o-AssetDescription__a-Description strong{font-family:inherit;font-weight:700}.o-AssetNavigation{margin-bottom:14px;position:relative;top:-14px}.o-AssetNavigation .l-Columns--2up>*{margin-bottom:0}.o-AssetNavigation__m-Body{margin:0 -14px}.o-AssetNavigation__a-Button{background:#fff;color:#1c1c1c;border:none;display:inline-block;padding:14px 10px;text-align:left;cursor:pointer;white-space:nowrap;outline:none;-moz-appearance:none;-webkit-appearance:none;text-transform:uppercase;font-size:18px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;line-height:1}.o-AssetNavigation__a-Button:before{display:inline-block;font-style:normal;font-weight:400;line-height:1;text-transform:none;-webkit-font-feature-settings:"liga";-ms-font-feature-settings:"liga" 1;-o-font-feature-settings:"liga";font-feature-settings:"liga";font-family:fn-icons;content:"";font-size:20px;color:red;top:4px;position:relative;overflow:hidden;margin-right:3.5px}.o-AssetNavigation__a-Button:before:hover{text-decoration:none}.o-AssetNavigation__a-Button:hover{color:#1c1c1c;text-decoration:underline}.o-AssetNavigation__a-Button[disabled]{color:#bebdbc;pointer-events:none}.o-AssetNavigation__a-Button:first-child{margin-right:-1px;width:50%}.o-AssetNavigation__a-Button:last-child{text-align:right;border-left:1px solid #ccc;width:50%;margin-left:0}.o-AssetNavigation__a-Button:last-child:before{display:none}.o-AssetNavigation__a-Button:last-child:after{display:inline-block;font-style:normal;font-weight:400;line-height:1;text-transform:none;-webkit-font-feature-settings:"liga";-ms-font-feature-settings:"liga" 1;-o-font-feature-settings:"liga";font-feature-settings:"liga";font-family:fn-icons;content:"";font-size:20px;color:red;top:4px;position:relative;overflow:hidden;margin-left:3.5px}.o-Attribution:after,.o-Attribution:before{content:"";display:table;clear:both}.o-Attribution__m-TextWrap{width:100%;margin-top:0}@media screen{.recipePage .o-Attribution__m-TextWrap{vertical-align:top}.recipePage .o-FullAttribution .o-Capsule{margin:0 0 28px}.rightRail .recipePage .o-FullAttribution .o-Capsule{margin:14px 0;padding:7px;background:#fff;box-shadow:1px 2px 5px 0 rgba(0,0,0,.19)}.recipePage .o-FullAttribution .o-Capsule__m-Header{border-top:none;margin-bottom:0}}.hide{display:none!important}.icon,.rsArrowIcn{font-family:fn-icons}.rsArrowDisabled{display:none!important}.container-site{margin:0 auto}.col-md-18{float:left;width:616px}.col-md-10{float:left;width:336px;margin-left:14px}.is-Fluid .col-md-18{float:left;width:66.5%}.is-Fluid .col-md-10{float:right;width:30.28%;margin-left:14px}.container-aside{padding-left:14px}.rightRail{width:100%;margin-left:0}.tpPlayer{cursor:pointer}.affix{position:fixed;top:0}.animated{animation-duration:.25s;animation-fill-mode:both}.recipePage{background:#f5f5f5}.recipePage .print-recipe{display:none!important}.recipePage #dfp_bigbox_1,.recipePage #dfp_bigbox_2,.recipePage #dfp_bigbox_3,.recipePage #dfp_bigbox_recipe_top,.recipePage #dfp_prog_bigbox,.recipePage .recipe-bigbox{display:block!important;min-height:250px;position:relative}.recipePage #dfp_bigbox_1:before,.recipePage #dfp_bigbox_2:before,.recipePage #dfp_bigbox_3:before,.recipePage #dfp_bigbox_recipe_top:before,.recipePage #dfp_prog_bigbox:before,.recipePage .recipe-bigbox:before{content:"";display:block;width:300px;height:100%;position:absolute;top:0;left:50%;transform:translate(-50%);background-color:#e0e0e0;z-index:-1}.recipePage #dfp_bigbox_1.hide-ad-placeholder:before,.recipePage #dfp_bigbox_2.hide-ad-placeholder:before,.recipePage #dfp_bigbox_3.hide-ad-placeholder:before,.recipePage #dfp_bigbox_recipe_top.hide-ad-placeholder:before,.recipePage #dfp_prog_bigbox.hide-ad-placeholder:before,.recipePage .recipe-bigbox.hide-ad-placeholder:before{background:transparent}.recipePage .container-site{background:0 0;box-shadow:none}.recipePage .container-site .o-AssetNavigation{margin:0 auto}.recipePage .container-site .o-AssetNavigation.affix{display:block}.recipePage .o-Attribution{margin-bottom:5px;z-index:1;font-size:18px}.recipePage .o-Attribution__a-Image{border:5px solid #fff;display:block;width:109px;max-width:none;margin:0;border-radius:50%}.recipePage .o-Attribution__m-MediaWrap>a{margin:-54.5px auto -22px}.recipePage .o-Attribution__m-TextWrap{text-align:center}.recipePage .o-Attribution__m-Author{display:inline-block;width:100%;margin:0 auto}.recipePage .o-Attribution__a-Source{width:100%;margin:0 auto;text-align:center}.recipePage .o-Attribution__a-Name,.recipePage .o-Attribution__a-Source{margin-top:5px}.recipePage .o-Attribution__a-Author--Prefix,.recipePage .o-Attribution__a-Author span,.recipePage .o-Attribution__a-Name--Prefix,.recipePage .o-Attribution__a-Name span,.recipePage .o-Attribution__a-Source--Prefix,.recipePage .o-Attribution__a-Source span{display:inline}.recipePage .o-AssetTitle{margin:0 0 10px;text-align:center}.recipePage .o-AssetTitle__a-Headline{margin:0}.recipePage .o-ReviewSummary{margin:0 0 10px;width:100%}.o-FooterFresh,.o-Ingredients__m-Body,.o-Method,.o-Recommendations,.o-RelatedClasses.relatedClassesList2,.o-UserComments,.private-notes-body{contain:content}.recipePage .a-Button--Watch{display:flex;flex-direction:row;align-items:center;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);margin:0;white-space:nowrap;pointer-events:none;overflow:visible;z-index:1}.recipePage .a-Button--Watch span{align-self:center}.recipePage .a-Button--Watch span.a-Button__a-Icon{fill:#fff;overflow:visible}.recipePage .a-Button--Watch span.a-Button__a-Icon svg{width:100%;height:auto}.recipePage .a-Button--Watch{background-color:rgba(0,0,0,.5);font-family:FranklinGothicURW-Dem,Helvetica,Arial,sans-serif;font-weight:700;font-size:20px;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;color:#fff;line-height:1;text-transform:uppercase;padding:11px 15px;font-size:18px;letter-spacing:-.03em;border-radius:3px}.recipePage .a-Button--Watch .a-Button__a-Icon{font-weight:700;fill:#fff;margin-left:6px;height:21.2px;width:21.2px}.recipePage .a-Button--Watch .a-Button__a-ButtonText{position:relative;top:2px;font-size:20px}.recipePage .m-MediaBlock__a-Headline{margin-bottom:5px}.recipePage .m-MediaBlock .m-ReviewSummary{margin:auto 0 0;padding:0 0 10px 10px;justify-content:flex-start}.recipePage .m-MediaBlock .m-ReviewSummary .review-summary{display:flex}.recipePage .m-MediaBlock .m-ReviewSummary .review-summary a{display:flex;text-decoration:none}.recipePage .m-MediaBlock .m-ReviewSummary .review-summary .rating-stars{padding-right:5px}.recipePage .m-MediaBlock .m-ReviewSummary .review-summary span{position:relative;bottom:-2px}.recipePage .m-MediaBlock{border:0;padding:0}.recipePage .m-MediaBlock .m-ReviewSummary .rating-stars{display:flex;flex-direction:row;justify-content:flex-start}.recipePage .m-MediaBlock .m-ReviewSummary .rating-star{height:18px;width:18px}.recipePage .m-MediaBlock .m-ReviewSummary .rating-star:after{font-family:fn-icons;font-feature-settings:"liga";content:"";font-size:18px;line-height:1;color:#e3e2e0}.recipePage .m-MediaBlock .m-ReviewSummary .rating-star-full:after{color:#e6003d}.recipePage .m-MediaBlock .m-ReviewSummary .rating-star-half:after{color:transparent;background:-webkit-linear-gradient(left,#e6003d,#e6003d 50%,#e3e2e0 0,#e3e2e0);-webkit-background-clip:text}.recipePage .m-MediaBlock .m-ReviewSummary span{font-size:12px;color:#4a4a4a;text-decoration:none}.recipePage .m-MediaBlock .m-ReviewSummary a:hover span{color:#e20d32}.recipePage .rightRail .l-List div:first-child{padding-top:0;border-top:none}.recipePage .rightRail .l-List .m-MediaBlock{margin-bottom:15px;padding:15px 0 0 20px;border-top:1px solid #e0e0e0}.recipePage .rightRail .l-List .m-MediaBlock__m-TextWrap{width:50%}.recipePage .rightRail .l-List .m-MediaBlock__a-Headline{font-size:24px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;line-height:1;color:#1c1c1c}.recipePage .rightRail .l-List .m-MediaBlock__a-Description{margin:0}.recipePage .m-RecipeMedia__m-MediaBlock{position:relative;transform:translateY(-50%);top:50%}.recipePage .m-RecipeSummary{z-index:6;position:relative}.recipePage .m-RecipeSummary.m-RecipeSummary--FixedVideo{z-index:4}.recipePage .m-RecipeSummary{background:transparent}.recipePage .o-AssetActions{width:100%;display:flex;justify-content:center;flex-direction:row;padding:20px 10px;background:transparent;margin:0}.recipePage .o-AssetActions .a-Button--Save,.recipePage .o-AssetActions .a-Button--Saved{position:relative;display:inline-block;white-space:nowrap;outline:none;user-select:none;text-align:center;background:#efefef;color:#111;padding:15px 18px 10px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;border-radius:45px;font-size:18px;line-height:1;text-transform:none;transition:background-color .2s,border-color .2s;color:#fff;background-color:#5ac0b8;background-image:linear-gradient(-180deg,hsla(0,0%,100%,.01),rgba(0,0,0,.01) 100%,rgba(0,0,0,.01) 0);background-color:#e20d32;border:2px solid #e20d32;justify-content:center;align-items:center;cursor:pointer;width:268px;display:flex;text-transform:capitalize;margin-right:15px;height:unset;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.recipePage .o-AssetActions .a-Button--Save:hover,.recipePage .o-AssetActions .a-Button--Saved:hover{text-decoration:none}.Win32 .recipePage .o-AssetActions .a-Button--Save,.Win32 .recipePage .o-AssetActions .a-Button--Saved,.Win64 .recipePage .o-AssetActions .a-Button--Save,.Win64 .recipePage .o-AssetActions .a-Button--Saved{padding:10px 20px 12px}.recipePage .o-AssetActions .a-Button--Save.is-Disabled,.recipePage .o-AssetActions .a-Button--Saved.is-Disabled{pointer-events:none;background:#e3e6e6}.recipePage .o-AssetActions .a-Button--Save.is-Hover,.recipePage .o-AssetActions .a-Button--Save:hover,.recipePage .o-AssetActions .a-Button--Saved.is-Hover,.recipePage .o-AssetActions .a-Button--Saved:hover{color:#fff;border-color:#7fcec8;background:#7fcec8;background-image:none}.recipePage .o-AssetActions .a-Button--Save--Active,.recipePage .o-AssetActions .a-Button--Saved--Active{color:#5ac0b8;background:none;pointer-events:none}.recipePage .o-AssetActions .a-Button--Save--Active.is-Hover,.recipePage .o-AssetActions .a-Button--Save--Active:hover,.recipePage .o-AssetActions .a-Button--Saved--Active.is-Hover,.recipePage .o-AssetActions .a-Button--Saved--Active:hover{color:#5ac0b8;background:none}.recipePage .o-AssetActions .a-Button--Save.is-Hover,.recipePage .o-AssetActions .a-Button--Save:hover,.recipePage .o-AssetActions .a-Button--Saved.is-Hover,.recipePage .o-AssetActions .a-Button--Saved:hover{border-color:#f22045;background:#f22045}.recipePage .o-AssetActions .a-Button--Saved__a-Divider,.recipePage .o-AssetActions .a-Button--Saved__a-TextWrap{font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;color:#fff}.recipePage .o-AssetActions .a-Button--Saved__a-Divider{padding:0 7px;display:inline}.recipePage .o-AssetActions .a-Button--Saved__a-AddToBoard{color:#fff;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;border:none;padding:0;margin:0}.recipePage .o-AssetActions .a-Button--Saved:before{top:0;content:" ";width:16px;height:16px;background-image:url(/etc/designs/svg/icon-checkmark-white.svg);background-repeat:no-repeat}.recipePage .o-AssetActions .a-Icon--Bookmark{top:-3px;fill:#fff;width:17.5px;height:17.5px}.recipePage .o-AssetActions__o-SocialShare{display:flex;justify-content:center;align-items:center}.recipePage .add-to-board input[type=checkbox]+label,.recipePage .add-to-board input[type=checkbox]:checked+label{height:32px;width:32px;display:inline-block;padding:0;cursor:pointer;border-radius:50%;background-size:60%;background-position:50%;border:2px solid #1c1c1c}.recipePage .add-to-board input[type=checkbox]:checked+label{background-color:#1c1c1c}.recipePage .add-to-board input[type=checkbox]+label{border-color:#fff}.recipePage .add-to-board input[type=checkbox]{display:none}.recipePage .add-to-board--new input[type=text]{padding:14px;border-radius:4px;border:1px solid #d2d1d1;width:100%}.recipePage .add-to-board .o-Modal__m-Dialog,.recipePage .add-to-board .o-Modal__m-Dialog.in{width:50%;min-width:400px;max-width:450px}.recipePage .add-to-board .o-Modal__a-Boards__board{display:flex;align-items:center}.recipePage .add-to-board .o-Modal__a-Boards__board-wrapper{width:138px;height:90px;display:flex;justify-content:flex-end;align-items:flex-end;background-color:#d0d0d0;margin:0 7px 7px 0;padding:7px}.recipePage .add-to-board .o-Modal__a-Boards--new{display:flex;align-items:center}.recipePage .add-to-board .o-Modal__a-Boards--new__icon{width:110px;height:90px;display:flex;justify-content:center;align-items:center;background-color:#d0d0d0;margin:0 7px 7px 0}.recipePage .add-to-board .o-Modal__a-Boards--new__icon:before{content:"";display:inline-block;border-radius:50%;height:32px;width:32px;background:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 23 23'%3E%3Cpath fill='%23fff' d='M9.6 9.6V1.9a1.9 1.9 0 1 1 3.8 0v7.7h7.7a1.9 1.9 0 1 1 0 3.8h-7.7v7.7a1.9 1.9 0 1 1-3.8 0v-7.7H1.9a1.9 1.9 0 1 1 0-3.8h7.7z'/%3E%3C/svg%3E") no-repeat;background-size:60%;background-position:50%;background-color:#1c1c1c;margin-right:0}.recipePage .add-to-board .o-Modal__a-Boards--new__title{color:#1c1c1c;top:0;padding-left:7px}.recipePage .add-to-board .o-Modal__a-Headline{font-size:34px}.recipePage .add-to-board .o-Modal__a-Boards{max-height:250px;height:50vh;overflow:auto}.recipePage .add-to-board .o-Modal__a-Boards input[type=checkbox]:checked+label{background-image:url(/etc/designs/svg/icon-checkmark-white.svg);background-repeat:no-repeat}.recipePage .add-to-board .o-Modal__a-Boards .checkbox-text{display:inline-block;width:90%;top:-3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;padding-left:7px;cursor:pointer}.recipePage .add-to-board .o-Modal__a-Boards__a-Button-Cancel{display:none}.recipePage .add-to-board .o-Modal__a-Button--Primary{position:relative;display:inline-block;white-space:nowrap;outline:none;user-select:none;cursor:pointer;text-align:center;background:#efefef;color:#111;padding:15px 18px 10px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;border-radius:45px;font-size:18px;line-height:1;border:none;text-transform:none;transition:background-color .2s,border-color .2s;color:#fff;background-color:#525657;background-image:linear-gradient(-180deg,hsla(0,0%,100%,.01),rgba(0,0,0,.01) 100%,rgba(0,0,0,.01) 0);border-radius:4px;width:35%;text-transform:uppercase}.recipePage .add-to-board .o-Modal__a-Button--Primary:hover{text-decoration:none}.Win32 .recipePage .add-to-board .o-Modal__a-Button--Primary,.Win64 .recipePage .add-to-board .o-Modal__a-Button--Primary{padding:10px 20px 12px}.recipePage .add-to-board .o-Modal__a-Button--Primary.is-Disabled{pointer-events:none;background:#e3e6e6}.recipePage .add-to-board .o-Modal__a-Button--Primary.is-Hover,.recipePage .add-to-board .o-Modal__a-Button--Primary:hover{color:#fff;border-color:#6b7071;background:#6b7071;background-image:none}.recipePage .add-to-board .o-Modal__a-Button--Disabled{pointer-events:none;background:#e3e6e6}.recipePage .add-to-board .o-Modal__a-Button--Cancel{display:none}.recipePage .add-to-board .o-Modal__a-Button--Close{top:-12px;right:-12px;width:26px;height:26px}.recipePage .add-to-board .o-Modal__a-Button--Close:after{top:55%;left:55%;font-size:16px}.recipePage .add-to-board .o-Modal__m-Footer{padding:10px 20px;text-align:center}.recipePage .o-AssetActions{border-bottom:1px solid #e0e0e0}.recipePage .o-AssetActions--saves{border-bottom:none}.Win32 .recipePage .o-AssetActions .a-Icon--Bookmark,.Win64 .recipePage .o-AssetActions .a-Icon--Bookmark{top:0}.recipePage .o-AssetNavigation{margin-bottom:0;top:0}.recipePage .o-AssetNavigation__m-Body{margin:0}.recipePage .o-AssetNavigation.affix{width:calc(66.5% - 14px);min-width:665px;max-width:835px;margin:0 -1px}.recipePage .o-AssetNavigation__a-Button{color:#666;border-color:#e0e0e0;border-bottom:none}.recipePage .o-AssetNavigation__a-Button:hover{color:#1c1c1c;text-decoration:none}.recipePage .o-AssetNavigation__a-Button:hover:after,.recipePage .o-AssetNavigation__a-Button:hover:before{color:#1c1c1c}.recipePage .o-AssetNavigation__a-Button:after,.recipePage .o-AssetNavigation__a-Button:before{color:#5ac0b8}.recipePage .o-AssetTitle{position:relative}.recipePage .o-AssetTitle__a-Headline{font-size:42px;font-family:Georgia,Times New Roman,Times,serif;line-height:1.35;font-weight:700;letter-spacing:-.5px;color:#1c1c1c}.recipePage .o-Attribution{position:relative;padding-right:0;padding-bottom:0;border-bottom:none}.recipePage .o-Attribution__m-Body{display:block}.recipePage .o-Attribution__m-MediaWrap{margin-right:0;width:auto;display:block;padding-right:0}.recipePage .o-Attribution__m-TextWrap{display:block;padding-top:20px}.recipePage .o-Attribution{z-index:5;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;color:#1c1c1c;letter-spacing:1.5px}.recipePage .o-Attribution a{color:#1c1c1c}.recipePage .o-Attribution a:hover{color:#e20d32;text-decoration:none}.recipePage .o-Attribution .o-Attribution__m-MediaWrap{position:relative;text-align:center}.recipePage .o-Attribution .o-Attribution__m-MediaWrap>a{display:inline-block;background:#fff;border-radius:50%;-webkit-font-smoothing:antialiased;box-shadow:0 0 7px transparent;transition:transform .3s,box-shadow .3s}.recipePage .o-Attribution .o-Attribution__m-MediaWrap>a:hover{box-shadow:0 0 7px rgba(0,0,0,.25);transform:scale(1.04)}.recipePage .o-Attribution__m-Author{font-size:16px}.recipePage .o-Attribution__a-Source{font-size:15px}.recipePage .o-Attribution__a-Source--Label,.recipePage .o-Attribution__a-Source--Prefix{font-size:14px}.recipePage .o-Attribution__a-Source .o-Attribution__a-Name a{color:#e20d32}.recipePage .o-Attribution__a-Source .o-Attribution__a-Name a:hover{color:#1c1c1c}.recipePage .o-Attribution__a-Author{text-transform:uppercase}.recipePage .o-Attribution__a-Author .o-Attribution__a-Author--Prefix,.recipePage .o-Attribution__a-Author .o-Attribution__a-Name,.recipePage .o-Attribution__a-Author .o-Attribution__a-Name a{font-size:16px}.recipePage .o-Attribution__m-Author{text-transform:uppercase}.recipePage .o-Attribution__a-Source{font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif}.recipePage .o-Attribution__a-Source .o-Attribution__a-Name,.recipePage .o-Attribution__a-Source .o-Attribution__a-Name a,.recipePage .o-Attribution__a-Source .o-Attribution__a-Source--Label,.recipePage .o-Attribution__a-Source .o-Attribution__a-Source--Prefix{font-size:14px}.recipePage .o-Attribution__a-Source-For{font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;text-transform:uppercase}.recipePage .o-Attribution__a-Source-For .o-Attribution__a-Source--Prefix{text-transform:uppercase}.recipePage .o-Attribution__a-Source-For .o-Attribution__a-Source--Label{font-size:16px}.recipePage .o-Attribution__a-Source-For .o-Attribution__a-Name a{color:#1c1c1c}.recipePage .o-Attribution__a-Source-From{font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;text-transform:capitalize}.recipePage .o-Attribution__a-Source-From .o-Attribution__a-Source--Prefix{font-size:14px;text-transform:capitalize}.recipePage .o-Attribution__a-Source-From .o-Attribution__a-Source--Prefix a{color:#e20d32}.recipePage .o-Attribution__a-Source-From .o-Attribution__a-Source--Prefix a:hover{color:#1c1c1c}.recipePage .o-Attribution__a-Source-From .o-Attribution__a-Source--Label{font-size:14px}.recipePage .o-Capsule__a-Headline{display:inherit;font-size:inherit;text-transform:none;padding:0}.recipePage .o-Capsule__m-Header{margin-bottom:20px;border-top:none}.recipePage .o-Capsule__a-HeadlineText{font-size:24px;font-family:Georgia,Times New Roman,Times,serif;line-height:1.35;font-weight:700;letter-spacing:-.5px;color:#1c1c1c;text-transform:none}.recipePage .o-Capsule__a-Button{position:relative;display:inline-block;white-space:nowrap;outline:none;user-select:none;cursor:pointer;text-align:center;background:#efefef;color:#111;padding:15px 18px 10px;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;border-radius:45px;font-size:18px;line-height:1;border:none;text-transform:none;transition:background-color .2s,border-color .2s;color:#fff;background-color:#525657;background-image:linear-gradient(-180deg,hsla(0,0%,100%,.01),rgba(0,0,0,.01) 100%,rgba(0,0,0,.01) 0);margin:0}.recipePage .o-Capsule__a-Button:hover{text-decoration:none}.Win32 .recipePage .o-Capsule__a-Button,.Win64 .recipePage .o-Capsule__a-Button{padding:10px 20px 12px}.recipePage .o-Capsule__a-Button.is-Disabled{pointer-events:none;background:#e3e6e6}.recipePage .o-Capsule__a-Button.is-Hover,.recipePage .o-Capsule__a-Button:hover{color:#fff;border-color:#6b7071;background:#6b7071;background-image:none}.recipePage .o-Capsule .m-MediaBlock__a-HeadlineText{font-size:20px}.recipePage .o-Capsule__a-Cta{font-size:24px;color:#e20d32;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;line-height:1;text-transform:none;font-size:18px}.recipePage .o-Capsule__a-Cta:hover{text-decoration:none;color:#1c1c1c}.recipePage .o-Capsule__a-Cta:after{display:none}.recipePage .rightRail .o-Capsule{margin:30px 0 20px;padding:0}.recipePage .rightRail .o-Capsule__m-Header{margin-bottom:25px}.recipePage .rightRail .o-Capsule__m-Body{margin-bottom:20px}.recipePage .rightRail .o-Capsule__a-Button{margin-bottom:0}.recipePage .o-RecipeInfo{position:relative;display:flex;justify-content:center;border-top:1px solid #eee;border-bottom:1px solid #eee}.recipePage .o-RecipeInfo__m-Level,.recipePage .o-RecipeInfo__m-Time,.recipePage .o-RecipeInfo__m-Yield{display:block;margin:0}.recipePage .o-RecipeInfo ul{width:100%;list-style:none;border-right:1px solid #eee}.recipePage .o-RecipeInfo ul:last-child{border:none}.recipePage .o-RecipeInfo ul:first-child:last-child{text-align:center}.recipePage .o-RecipeInfo ul li{margin-bottom:10px}.recipePage .o-RecipeInfo span{line-height:1}.recipePage .o-RecipeInfo__m-Level,.recipePage .o-RecipeInfo__m-Time{border-right:1px solid #eee}.recipePage .o-RecipeInfo__a-Description,.recipePage .o-RecipeInfo__a-Headline{display:inline}.recipePage .o-RecipeInfo__a-Headline{margin-right:5px}.recipePage .recipePrint .o-RecipeInfo__a-Description,.recipePage .recipePrint .o-RecipeInfo__a-Headline{font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;font-size:16px}.recipePage .o-RecipeInfo{border-top:1px solid #e0e0e0;border-bottom:1px solid #e0e0e0;font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;font-size:20px}.recipePage .o-RecipeInfo a:hover{text-decoration:none}.recipePage .o-RecipeInfo ul{border-color:#e0e0e0}.recipePage .o-RecipeInfo__a-Headline{margin-right:0;font-size:20px}.recipePage .o-RecipeInfo__a-Description{font-family:FranklinGothicURW-Dem,Helvetica,Arial,sans-serif;font-size:18px}.recipePage .o-RecipeInfo__a-Note{display:inline-block;color:#4a4a4a;font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;font-size:15px;white-space:normal}.recipePage .o-RecipeInfo__a-Note.o-RecipeInfo__a-Note--Total{line-height:1.35}.recipePage .o-RecipeInfo{margin-top:30px;margin-bottom:0;padding-top:0}.recipePage .o-RecipeInfo li a{color:#e20d32}.recipePage .o-RecipeInfo li a:hover{color:#1c1c1c}.recipePage .o-RecipeInfo__m-Level,.recipePage .o-RecipeInfo__m-Time,.recipePage .o-RecipeInfo__m-Yield{padding:20px 30px 5px}.recipePage .o-RecipeInfo__m-Time{border-right:1px solid #e0e0e0}.recipePage .o-RecipeInfo__a-Headline{font-size:18px;font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif}.recipePage .o-RecipeInfo__a-NutritionInfo{font-size:18px}.recipePage .o-RecipeLead,.recipePage .o-RecipeLead__m-RecipeMedia{position:relative}.recipePage .o-RecipeLead{min-height:7px}.recipePage .o-RecipeLead--HasPhotoNoVideo{height:400px}.recipePage .o-RecipeLead__m-RecipeMedia{overflow:hidden;height:400px}.recipePage .o-RecipeLead{backface-visibility:hidden}.recipePage .o-RecipeLead.o-RecipeLead--VideoButtonBound .a-Button--Watch .a-Button__a-Icon--Watch{opacity:1;fill:#fff}.recipePage .o-RecipeLead.o-RecipeLead--VideoButtonBound .a-Button--Watch:after{opacity:0}.recipePage .o-RecipeLead.o-RecipeLead--VideoButtonBound .a-Button__a-ButtonText{padding-top:.5px}.recipePage .o-RecipeLead.o-RecipeLead--VideoButtonBound .a-Loader{opacity:0}.recipePage .o-RecipeLead.o-RecipeLead--VideoButtonBound .m-MediaBlock__m-MediaWrap{cursor:pointer}.recipePage .o-RecipeLead.o-RecipeLead--NoPhotoAndNoVideo.o-RecipeLead--HasAvatar{min-height:77px}.recipePage .o-RecipeLead.o-RecipeLead--NoAvatar{min-height:7px}.recipePage .o-RecipeLead.o-RecipeLead--NoAvatar .o-Attribution__m-TextWrap{padding-top:20px}.recipePage .o-RecipeLead.o-RecipeLead--VideoButtonBound .m-VideoPlayer__a-Container{width:100%;height:auto;padding-bottom:56.25%}.recipePage .o-RecipeLead__a-Sticker{position:absolute;top:0;left:0;z-index:1;pointer-events:none}.recipePage .o-RecipeLead .o-VideoPlaylist{transition:opacity .5s}.recipePage .o-RecipeLead .o-RecipeLead__m-RecipeMedia{opacity:1}.recipePage .o-RecipeLead .m-MediaBlock__m-MediaWrap:hover .a-Button--Watch{background-color:#cc0729}.recipePage .o-RecipeLead .m-CtaWrap{display:none!important}.recipePage .o-RecipeLead .m-MediaBlock__VideoButton{width:100%;padding:0;appearance:none;border:0;outline:0;cursor:pointer}.recipePage .o-RecipeLead .a-Button--Watch{background-color:#e20d32;color:#fff;text-indent:inherit;transition:background-color .3s,opacity .75s;margin-left:0}.recipePage .o-RecipeLead .a-Button--Watch .a-Button__a-Icon--Watch{opacity:0;transition:opacity .3s;fill:#fff}.recipePage .o-RecipeLead .a-Button--Watch:after{content:"";display:inline-block;position:absolute;top:50%;right:21px;transform:translateY(-50%);width:0;height:0;border-color:transparent transparent transparent #fff;border-style:solid;border-width:5px 0 5px 8.7px}.recipePage .o-RecipeLead .o-VideoPlaylist{width:100%;opacity:0;margin:0;position:absolute;visibility:hidden;left:0;top:0;z-index:5;padding:0 0 70px;background:transparent}.recipePage .o-RecipeLead .a-Loader{border-radius:50%;width:22px;height:22px;opacity:1;position:absolute;top:11px;right:15px;left:auto;margin:0;overflow:hidden;border:3px solid hsla(0,0%,88.2%,.2);border-left-color:#fff;transform:translateZ(0);animation:loadCircle 1.5s linear infinite;transition:opacity .3s}@keyframes loadCircle{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}.recipePage .o-RecipeLead__a-Logo{object-fit:cover;width:80px;height:auto;max-height:32px;margin-left:3px}.recipePage .o-RecipeLead__a-PremiumStrip{width:100%;height:10px;background-image:linear-gradient(90deg,#cfe7f9 0,#87ccff 127%);position:relative;margin-top:5px}.recipePage .o-RecipeLead__a-PremiumStrip:after{content:"premium";font-family:Helvetica Neue,Helvetica,Arial,sans-serif;font-size:12px;text-transform:uppercase;letter-spacing:.14em;line-height:1.29;right:0;bottom:calc(100% + 5px);position:absolute;color:#89caf7}.recipePage .o-RecipeLead.o-RecipeLead--HasPlaylist .o-VideoPlaylist{padding-bottom:100px}.recipePage .o-RecipeLead.o-RecipeLead--HasPlaylist .o-VideoPlaylist__m-Playlist{width:100%;position:relative;overflow:visible}.recipePage .o-RecipeLead.o-RecipeLead--HasPlaylist .o-VideoPlaylist__m-Playlist .m-MediaBlock__a-Headline .m-MediaBlock__a-AssetInfo{display:none}.recipePage .o-RecipeLead.o-RecipeLead--HasShortPlaylist .o-VideoPlaylist__m-Carousel,.recipePage .o-RecipeLead.o-RecipeLead--HasShortPlaylist .o-VideoPlaylist__m-CarouselContainer,.recipePage .o-RecipeLead.o-RecipeLead--HasShortPlaylist .o-VideoPlaylist__m-Playlist{overflow:visible}.recipePage .o-RecipeLead.o-RecipeLead--HasShortPlaylist .o-VideoPlaylist__m-CarouselContainer{height:190px;padding-bottom:5px}.recipePage .o-RecipeLead__a-Sticker{width:30%}.recipePage .o-RecipeLead__a-Sticker img{width:100%}.recipePage .o-RecipeLead .m-MediaBlock__VideoButton{background:#e0e0e0}.recipePage .o-RecipeLead .m-VideoPlayer__a-Container{width:854px;height:480px;padding-bottom:0}.recipePage .o-RecipeLead__a-Logo{width:115px}.recipePage .o-RecipeLead__a-PremiumStrip{height:11px}.recipePage .o-RecipeLead__a-PremiumStrip:after{font-size:16px}.recipePage .o-RecipeLead .a-Button--MealPlan{position:absolute;right:20px;bottom:20px;display:flex;height:47px;padding:13px 28px 5px 29px;border:none;border-radius:100px;color:#ff626a;background-color:#fff;z-index:7;outline:0;cursor:pointer}.recipePage .o-RecipeLead .a-Button--MealPlan .a-Button-Text{font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;font-size:16px;margin:2px 0 0 7px}.recipePage .o-RecipeLead .a-Button--MealPlan .add-to-meal-plan{display:block}.recipePage .o-RecipeLead .a-Button--MealPlan .added-to-meal-plan{display:none}.recipePage .o-RecipeLead--NoPhotoAndNoVideo .a-Button--MealPlan{right:0;bottom:-50px}.recipePage .o-RecipeLead--VideoShowing .a-Button--MealPlan{bottom:0}.recipePage .o-RecipeLead--HasPlaylist.o-RecipeLead--VideoShowing .a-Button--MealPlan{bottom:20px}.recipePage .o-RelatedClasses .o-Capsule__a-HeadlineText{font-size:40px;line-height:1.2}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock{display:flex;flex-direction:column}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-MediaWrap{margin-bottom:0}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-TextWrap{background-color:#fff;position:relative}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-TextWrap .class-instructor{font-family:Franklin Gothic URW Cond Book,Helvetica,Arial,sans-serif;font-size:12px;font-weight:400;color:#000}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-TextWrap .premium-indicator{position:absolute;bottom:0;left:0;width:100%;height:10px;background:linear-gradient(90deg,#cfe7f9 0,#87ccff 127%);cursor:pointer}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-HeadlineText{font-size:16px;line-height:1;letter-spacing:-.25px}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo{display:flex;flex-direction:column;justify-content:left;position:absolute;bottom:15px;width:85%;font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;font-size:12px;color:#a5a5a5;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;line-height:1.17}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo .class-info span{display:inline-block}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo .class-info>:not(:first-child):before{display:inline-block;content:"•";margin:0 4px 0 1px}.recipePage .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo .class-info .class-rating .a-Icon--rating{width:20px;height:20px;fill:#a5a5a5;margin-bottom:-3px}.recipePage .o-RelatedClasses .m-MediaBlock__m-MediaWrap .premium-indicator{position:absolute;bottom:0;width:100%;height:10px;background:linear-gradient(90deg,#cfe7f9 0,#87ccff 127%);cursor:pointer}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Header{padding:0 0 0 20px}.recipePage .rightRail .o-RelatedClasses .o-Capsule__a-HeadlineText{font-size:30px;line-height:1.2}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .l-Columns.l-Columns--2up{display:flex;flex-direction:column}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .l-Columns.l-Columns--2up>:nth-child(2n+2){margin:0}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock{display:table;width:100%;margin-right:0;padding:15px 0 0 20px;border-top:1px solid #e0e0e0}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock:first-child{padding-top:0;border:none}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-MediaWrap{display:block;margin-right:14px;padding-right:0;overflow:hidden}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-MediaWrap a{cursor:pointer;height:0;background:#e0e0e0;padding-bottom:75%}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-MediaWrap a img{padding-bottom:75%}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-TextWrap{display:table-cell;background-color:transparent}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-TextWrap a{cursor:pointer}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-TextWrap a:hover{color:#e6003d}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-TextWrap .class-instructor{font-family:Franklin Gothic URW Cond Medium,Helvetica,Arial,sans-serif;font-size:16px;color:#000;letter-spacing:-.23px;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-HeadlineText{font-size:20px;margin-top:3px;line-height:1;letter-spacing:-.25px}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo{bottom:0;color:#6e6e6e;font-size:13px;letter-spacing:-.2px}@media only screen and (max-device-width:1055px){.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo__a-AssetInfo{font-size:12px}}@media (max-device-width:1366px){.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-TextWrap .class-instructor{font-size:16px}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-HeadlineText{font-size:18px}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo{font-size:12px}}@media (min-width:1366px){.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__m-TextWrap .class-instructor{font-size:18px}.recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo{font-size:16px}}@supports (-ms-ime-align:auto){.Win32 .recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-Headline,.Win64 .recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-Headline{margin-bottom:0}.Win32 .recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo,.Win64 .recipePage .rightRail .o-RelatedClasses .o-Capsule__m-Body .m-MediaBlock__a-AssetInfo{position:relative}}.recipePage .recipe-body .relatedClasses:not(.parbase){margin-bottom:20px;padding-bottom:5px;border-bottom:1px solid #e0e0e0}.recipePage .recipe-body .relatedClasses:not(.parbase) .classesWithRecipe{width:100%}.recipePage .recipe-body .relatedClasses:not(.parbase) .classesWithRecipe .m-MediaBlock__a-HeadlineText{line-height:1.2}.recipePage .o-ReviewSummary{float:none;max-width:none;vertical-align:bottom;display:flex;justify-content:center}.recipePage .o-ReviewSummary .review-summary{display:flex;align-items:flex-end}.recipePage .o-ReviewSummary .review-summary a{text-decoration:none;display:flex;align-items:flex-end}.recipePage .o-ReviewSummary .review-summary span{font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;font-size:16px;line-height:1.35;color:#4a4a4a;margin-left:5px}.recipePage .o-ReviewSummary .review-summary a:hover span{color:#e6003d}.recipePage .o-ReviewSummary .review-summary .rating-stars{display:flex;flex-direction:row;justify-content:flex-start}.recipePage .o-ReviewSummary .review-summary .rating-star{height:28px;width:28px}.recipePage .o-ReviewSummary .review-summary .rating-star:after{font-family:fn-icons;font-feature-settings:"liga";content:"";font-size:28px;line-height:1;color:#e3e2e0}.recipePage .o-ReviewSummary .review-summary .rating-star-full:after{color:#e6003d}.recipePage .o-ReviewSummary .review-summary .rating-star-half:after{color:transparent;background:-webkit-linear-gradient(left,#e6003d,#e6003d 50%,#e3e2e0 0,#e3e2e0);-webkit-background-clip:text}.recipePage .o-ReviewSummary .m-Rating{margin:0}.Win32 .recipePage .o-SocialShare,.Win64 .recipePage .o-SocialShare{margin-bottom:0}.recipePage .o-SocialShare__m-ShareButton{width:44px;height:44px;min-width:44px;min-height:44px;fill:#fff;background-color:#525657;border-radius:50%;padding:7px;display:flex;justify-content:center;align-items:center}.recipePage .o-SocialShare__m-ShareButton .a-Icon{width:25px;height:25px}.recipePage .o-SocialShare__m-ShareButton:hover{background:#6b7071}.recipePage .o-SocialShare__m-ShareButton--pinterest{background-color:#d0021b}.recipePage .o-SocialShare__m-ShareButton--pinterest:hover{background:#fd0826}.recipePage .o-SocialShare__m-ShareButton--facebook{background-color:#39599f}.recipePage .o-SocialShare__m-ShareButton--facebook:hover{background:#4c70bf}.recipePage .o-SocialShare__m-ShareButton--facebookMessenger{background-color:#2b87fc}.recipePage .o-SocialShare__m-ShareButton--facebookMessenger:hover{background:#5da3fd}.Win32 .recipePage .o-SocialShare__m-ShareButton--facebookMessenger,.Win64 .recipePage .o-SocialShare__m-ShareButton--facebookMessenger{margin-top:0}.recipePage .o-SocialShare__m-ShareButton--twitter{background-color:#1da1f2}.recipePage .o-SocialShare__m-ShareButton--twitter:hover{background:#4db5f5}.recipePage .o-SocialShare__m-ShareButton--print{margin-left:6px;margin-top:2px}.Win32 .recipePage .o-SocialShare__m-ShareButton--print,.Win64 .recipePage .o-SocialShare__m-ShareButton--print{margin-top:0}.recipePage .o-SocialShare__a-Title{display:inline-block;position:relative;top:1px;margin-right:15px;font-family:FranklinGothicURW-Boo,Helvetica,Arial,sans-serif;font-size:16px;color:#ababab}.recipePage .o-SocialShare .m-SocialIcons{display:flex}.recipePage .o-SocialShare .m-SocialIcons li:not(:first-of-type){margin-left:6px}.recipePage .o-VideoPromo{width:100%;display:flex;justify-content:center}.recipePage .o-VideoPromo .m-MediaBlock__m-MediaWrap a{height:0;background:#e0e0e0;padding-bottom:75%}.recipePage .o-VideoPromo .m-MediaBlock__m-MediaWrap .a-Button--Watch{background:rgba(0,0,0,.5);padding-bottom:0;margin-left:0;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%)}.recipePage .o-VideoPromo{display:block;width:calc(50% - 25px);float:right}.recipePage .o-VideoPromo .m-MediaBlock__m-MediaWrap{display:block;margin-right:14px;padding-right:0}.recipePage .recipe-body .o-VideoPromo{width:auto;float:none;margin-bottom:20px;padding:11px 20px 20px}.recipePage .recipe-body .o-VideoPromo .m-MediaBlock{max-width:400px}.recipePage .o-VideoPromo{margin:0;padding:20px;border-bottom:1px solid #e0e0e0;background-color:transparent;clear:right}.recipePage .o-VideoPromo--HideAll,.recipePage .o-VideoPromo--HideImage .m-MediaBlock__m-MediaWrap{display:none}.recipePage .o-VideoPromo .m-MediaBlock{margin:0}.recipePage .o-VideoPromo .m-MediaBlock__m-MediaWrap .a-Button--Watch{background-color:rgba(0,0,0,.5);font-family:FranklinGothicURW-Dem,Helvetica,Arial,sans-serif;font-weight:700;font-size:20px;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;color:#fff;line-height:1;text-transform:uppercase;padding:0;height:30px;width:30px;font-size:18px;border-radius:100%}.recipePage .o-VideoPromo .m-MediaBlock__m-MediaWrap .a-Button--Watch .a-Button__a-Icon{font-weight:700;fill:#fff}.recipePage .o-VideoPromo .m-MediaBlock__m-MediaWrap .a-Button--Watch .a-Button__a-ButtonText{display:none}.recipePage .o-VideoPromo .m-MediaBlock__m-MediaWrap .a-Button--Watch .a-Button__a-Icon{margin:0;height:30px;width:30px}.recipePage .o-VideoPromo .m-MediaBlock__a-Cta,.recipePage .o-VideoPromo .m-MediaBlock__a-Source--Name a{color:#e6003d}.recipePage .recipeInfo{clear:both}.recipePage .o-AssetDescription{padding:0 5vw;text-align:center}.recipePage .container-site{width:auto;min-width:994px;max-width:1280px;padding:0 15px}.recipePage .container-site .container-aside{padding-left:0}.recipePage .container-site .container-aside .rightRail{float:none}.recipePage .container-site .o-AssetNavigation.affix{width:calc(66.5% - 14px);min-width:665px;max-width:835px;margin:0 -1px}.recipePage .container-site .row{display:flex;justify-content:space-between}.recipePage .container-site .row .sticky-rr{position:sticky;top:15px;clear:both}.recipePage .container-site .col-md-18{width:66.5%}.recipePage .container-site .col-md-10{width:30.28%;min-width:300px;margin-left:0;float:right}.recipePage .recipe-lead .fnk-notification-bar{width:400px;left:42px}.rightRail .o-Capsule{margin:unset;padding:unset;background:none;box-shadow:none}.o-FooterFresh{margin:20px 0 0}.recipePage .variant--TitleAboveImage .o-Attribution,.recipePage .variant--TitleAboveImage .o-ReviewSummary{opacity:0}.recipePage .variant--TitleAboveImage.container-site--HasAvatar .o-Attribution,.recipePage .variant--TitleAboveImage.container-site--HasAvatar .o-ReviewSummary,.recipePage .variant--TitleAboveImage.container-site--NoAvatar .o-Attribution,.recipePage .variant--TitleAboveImage.container-site--NoAvatar .o-ReviewSummary{opacity:1}.recipePage .variant--TitleAboveImage.container-site--HasAvatar .o-Attribution,.recipePage .variant--TitleAboveImage.container-site--HasAvatar .o-ReviewSummary{padding-left:77px}.recipePage .variant--TitleAboveImage .o-AssetNavigation{margin-bottom:25px}.recipePage .variant--TitleAboveImage .o-AssetTitle{text-align:left}.recipePage .variant--TitleAboveImage .o-ReviewSummary{display:block}.recipePage .variant--TitleAboveImage .o-Attribution{padding-bottom:35px}.recipePage .variant--TitleAboveImage .o-Attribution a{margin:0}.recipePage .variant--TitleAboveImage .o-Attribution .o-Attribution__m-MediaWrap{position:absolute;left:0;top:-38px}.recipePage .variant--TitleAboveImage .o-Attribution__m-TextWrap{padding-top:0;text-align:left}.recipePage .variant--TitleAboveImage .o-Attribution__a-Image{width:62px}.recipePage .variant--TitleAboveImage .o-Attribution__a-Source{text-align:left}.recipePage .variant--TitleAboveImage .o-AssetDescription{margin-top:21px}.recipePage #dfp_bigbox_recipe_top{min-height:600px}
+
+</style>
+
+    <!-- end critical styles -->
+
+    <!-- non critical styles -->
+    <link id="recipe-non-critical-styles" rel="preload" type="text/css" as="style" onerror="this.rel='stylesheet'" onload="this.onload=null;this.rel='stylesheet'" href="//food.fnr.sndimg.com/etc/clientlibs/assets/v2/css/food/templates/recipeNoncritical.desktop.md5-39aca011706b86d8b5214870189fc33e.css">
+    <noscript><link rel="stylesheet" type="text/css" href="//food.fnr.sndimg.com/etc/clientlibs/assets/v2/css/food/templates/recipeNoncritical.desktop.md5-39aca011706b86d8b5214870189fc33e.css"></noscript>
+    
+    <script type="text/javascript">
+      (function fallback(){
+        var noncriticalStyles = document.getElementById("recipe-non-critical-styles");
+        if(noncriticalStyles && noncriticalStyles.rel !== 'stylesheet') {
+          if (!(noncriticalStyles.relList && noncriticalStyles.relList.supports && noncriticalStyles.relList.supports('preload'))) {
+            noncriticalStyles.rel = "stylesheet";
+          }
+        }
+      })();
+    </script>
+    <!-- end non critical styles -->
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+  
+  <!-- New Relic Browser snippet , should be before everything else -->
+
+  <script type="text/javascript">
+    (function (){
+      var percentEnabled = parseInt("25") || 5;//Default value is set to 5% if the config value is not set
+      var rand = 0;
+      var enableForAutomation = false;
+      var urlParams;
+      var observer, entries, entry, metric, cls;
+      if ("URLSearchParams" in window){//This may not be present in IE
+        urlParams = new URLSearchParams(window.location.search);
+        enableForAutomation = urlParams.get("enableForAutomation") || false;
+      }
+
+      if (percentEnabled < 100)
+        rand = Math.floor(Math.random() * 100); // assign the user into a bucket between 0 and 99
+
+      if (percentEnabled == 100 || rand < percentEnabled || enableForAutomation) {
+
+        // ADD UPDATES FOR NEW RELIC: Copy and replace all new relic code except ;NREUM.info... on
+        ;window.NREUM||(NREUM={});NREUM.init={privacy:{cookies_enabled:true}};
+        window.NREUM||(NREUM={}),__nr_require=function(t,e,n){function r(n){if(!e[n]){var o=e[n]={exports:{}};t[n][0].call(o.exports,function(e){var o=t[n][1][e];return r(o||e)},o,o.exports)}return e[n].exports}if("function"==typeof __nr_require)return __nr_require;for(var o=0;o<n.length;o++)r(n[o]);return r}({1:[function(t,e,n){function r(t){try{c.console&&console.log(t)}catch(e){}}var o,i=t("ee"),a=t(27),c={};try{o=localStorage.getItem("__nr_flags").split(","),console&&"function"==typeof console.log&&(c.console=!0,o.indexOf("dev")!==-1&&(c.dev=!0),o.indexOf("nr_dev")!==-1&&(c.nrDev=!0))}catch(s){}c.nrDev&&i.on("internal-error",function(t){r(t.stack)}),c.dev&&i.on("fn-err",function(t,e,n){r(n.stack)}),c.dev&&(r("NR AGENT IN DEVELOPMENT MODE"),r("flags: "+a(c,function(t,e){return t}).join(", ")))},{}],2:[function(t,e,n){function r(t,e,n,r,c){try{l?l-=1:o(c||new UncaughtException(t,e,n),!0)}catch(f){try{i("ierr",[f,s.now(),!0])}catch(d){}}return"function"==typeof u&&u.apply(this,a(arguments))}function UncaughtException(t,e,n){this.message=t||"Uncaught error with no additional information",this.sourceURL=e,this.line=n}function o(t,e){var n=e?null:s.now();i("err",[t,n])}var i=t("handle"),a=t(28),c=t("ee"),s=t("loader"),f=t("gos"),u=window.onerror,d=!1,p="nr@seenError",l=0;s.features.err=!0,t(1),window.onerror=r;try{throw new Error}catch(h){"stack"in h&&(t(13),t(12),"addEventListener"in window&&t(6),s.xhrWrappable&&t(14),d=!0)}c.on("fn-start",function(t,e,n){d&&(l+=1)}),c.on("fn-err",function(t,e,n){d&&!n[p]&&(f(n,p,function(){return!0}),this.thrown=!0,o(n))}),c.on("fn-end",function(){d&&!this.thrown&&l>0&&(l-=1)}),c.on("internal-error",function(t){i("ierr",[t,s.now(),!0])})},{}],3:[function(t,e,n){t("loader").features.ins=!0},{}],4:[function(t,e,n){function r(){_++,T=g.hash,this[u]=y.now()}function o(){_--,g.hash!==T&&i(0,!0);var t=y.now();this[h]=~~this[h]+t-this[u],this[d]=t}function i(t,e){E.emit("newURL",[""+g,e])}function a(t,e){t.on(e,function(){this[e]=y.now()})}var c="-start",s="-end",f="-body",u="fn"+c,d="fn"+s,p="cb"+c,l="cb"+s,h="jsTime",m="fetch",v="addEventListener",w=window,g=w.location,y=t("loader");if(w[v]&&y.xhrWrappable){var x=t(10),b=t(11),E=t(8),R=t(6),O=t(13),N=t(7),M=t(14),P=t(9),S=t("ee"),C=S.get("tracer");t(16),y.features.spa=!0;var T,_=0;S.on(u,r),S.on(p,r),S.on(d,o),S.on(l,o),S.buffer([u,d,"xhr-done","xhr-resolved"]),R.buffer([u]),O.buffer(["setTimeout"+s,"clearTimeout"+c,u]),M.buffer([u,"new-xhr","send-xhr"+c]),N.buffer([m+c,m+"-done",m+f+c,m+f+s]),E.buffer(["newURL"]),x.buffer([u]),b.buffer(["propagate",p,l,"executor-err","resolve"+c]),C.buffer([u,"no-"+u]),P.buffer(["new-jsonp","cb-start","jsonp-error","jsonp-end"]),a(M,"send-xhr"+c),a(S,"xhr-resolved"),a(S,"xhr-done"),a(N,m+c),a(N,m+"-done"),a(P,"new-jsonp"),a(P,"jsonp-end"),a(P,"cb-start"),E.on("pushState-end",i),E.on("replaceState-end",i),w[v]("hashchange",i,!0),w[v]("load",i,!0),w[v]("popstate",function(){i(0,_>1)},!0)}},{}],5:[function(t,e,n){function r(t){}if(window.performance&&window.performance.timing&&window.performance.getEntriesByType){var o=t("ee"),i=t("handle"),a=t(13),c=t(12),s="learResourceTimings",f="addEventListener",u="resourcetimingbufferfull",d="bstResource",p="resource",l="-start",h="-end",m="fn"+l,v="fn"+h,w="bstTimer",g="pushState",y=t("loader");y.features.stn=!0,t(8),"addEventListener"in window&&t(6);var x=NREUM.o.EV;o.on(m,function(t,e){var n=t[0];n instanceof x&&(this.bstStart=y.now())}),o.on(v,function(t,e){var n=t[0];n instanceof x&&i("bst",[n,e,this.bstStart,y.now()])}),a.on(m,function(t,e,n){this.bstStart=y.now(),this.bstType=n}),a.on(v,function(t,e){i(w,[e,this.bstStart,y.now(),this.bstType])}),c.on(m,function(){this.bstStart=y.now()}),c.on(v,function(t,e){i(w,[e,this.bstStart,y.now(),"requestAnimationFrame"])}),o.on(g+l,function(t){this.time=y.now(),this.startPath=location.pathname+location.hash}),o.on(g+h,function(t){i("bstHist",[location.pathname+location.hash,this.startPath,this.time])}),f in window.performance&&(window.performance["c"+s]?window.performance[f](u,function(t){i(d,[window.performance.getEntriesByType(p)]),window.performance["c"+s]()},!1):window.performance[f]("webkit"+u,function(t){i(d,[window.performance.getEntriesByType(p)]),window.performance["webkitC"+s]()},!1)),document[f]("scroll",r,{passive:!0}),document[f]("keypress",r,!1),document[f]("click",r,!1)}},{}],6:[function(t,e,n){function r(t){for(var e=t;e&&!e.hasOwnProperty(u);)e=Object.getPrototypeOf(e);e&&o(e)}function o(t){c.inPlace(t,[u,d],"-",i)}function i(t,e){return t[1]}var a=t("ee").get("events"),c=t("wrap-function")(a,!0),s=t("gos"),f=XMLHttpRequest,u="addEventListener",d="removeEventListener";e.exports=a,"getPrototypeOf"in Object?(r(document),r(window),r(f.prototype)):f.prototype.hasOwnProperty(u)&&(o(window),o(f.prototype)),a.on(u+"-start",function(t,e){var n=t[1],r=s(n,"nr@wrapped",function(){function t(){if("function"==typeof n.handleEvent)return n.handleEvent.apply(n,arguments)}var e={object:t,"function":n}[typeof n];return e?c(e,"fn-",null,e.name||"anonymous"):n});this.wrapped=t[1]=r}),a.on(d+"-start",function(t){t[1]=this.wrapped||t[1]})},{}],7:[function(t,e,n){function r(t,e,n){var r=t[e];"function"==typeof r&&(t[e]=function(){var t=i(arguments),e={};o.emit(n+"before-start",[t],e);var a;e[m]&&e[m].dt&&(a=e[m].dt);var c=r.apply(this,t);return o.emit(n+"start",[t,a],c),c.then(function(t){return o.emit(n+"end",[null,t],c),t},function(t){throw o.emit(n+"end",[t],c),t})})}var o=t("ee").get("fetch"),i=t(28),a=t(27);e.exports=o;var c=window,s="fetch-",f=s+"body-",u=["arrayBuffer","blob","json","text","formData"],d=c.Request,p=c.Response,l=c.fetch,h="prototype",m="nr@context";d&&p&&l&&(a(u,function(t,e){r(d[h],e,f),r(p[h],e,f)}),r(c,"fetch",s),o.on(s+"end",function(t,e){var n=this;if(e){var r=e.headers.get("content-length");null!==r&&(n.rxSize=r),o.emit(s+"done",[null,e],n)}else o.emit(s+"done",[t],n)}))},{}],8:[function(t,e,n){var r=t("ee").get("history"),o=t("wrap-function")(r);e.exports=r;var i=window.history&&window.history.constructor&&window.history.constructor.prototype,a=window.history;i&&i.pushState&&i.replaceState&&(a=i),o.inPlace(a,["pushState","replaceState"],"-")},{}],9:[function(t,e,n){function r(t){function e(){s.emit("jsonp-end",[],p),t.removeEventListener("load",e,!1),t.removeEventListener("error",n,!1)}function n(){s.emit("jsonp-error",[],p),s.emit("jsonp-end",[],p),t.removeEventListener("load",e,!1),t.removeEventListener("error",n,!1)}var r=t&&"string"==typeof t.nodeName&&"script"===t.nodeName.toLowerCase();if(r){var o="function"==typeof t.addEventListener;if(o){var a=i(t.src);if(a){var u=c(a),d="function"==typeof u.parent[u.key];if(d){var p={};f.inPlace(u.parent,[u.key],"cb-",p),t.addEventListener("load",e,!1),t.addEventListener("error",n,!1),s.emit("new-jsonp",[t.src],p)}}}}}function o(){return"addEventListener"in window}function i(t){var e=t.match(u);return e?e[1]:null}function a(t,e){var n=t.match(p),r=n[1],o=n[3];return o?a(o,e[r]):e[r]}function c(t){var e=t.match(d);return e&&e.length>=3?{key:e[2],parent:a(e[1],window)}:{key:t,parent:window}}var s=t("ee").get("jsonp"),f=t("wrap-function")(s);if(e.exports=s,o()){var u=/[?&](?:callback|cb)=([^&#]+)/,d=/(.*)\.([^.]+)/,p=/^(\w+)(\.|$)(.*)$/,l=["appendChild","insertBefore","replaceChild"];Node&&Node.prototype&&Node.prototype.appendChild?f.inPlace(Node.prototype,l,"dom-"):(f.inPlace(HTMLElement.prototype,l,"dom-"),f.inPlace(HTMLHeadElement.prototype,l,"dom-"),f.inPlace(HTMLBodyElement.prototype,l,"dom-")),s.on("dom-start",function(t){r(t[0])})}},{}],10:[function(t,e,n){var r=t("ee").get("mutation"),o=t("wrap-function")(r),i=NREUM.o.MO;e.exports=r,i&&(window.MutationObserver=function(t){return this instanceof i?new i(o(t,"fn-")):i.apply(this,arguments)},MutationObserver.prototype=i.prototype)},{}],11:[function(t,e,n){function r(t){var e=a.context(),n=c(t,"executor-",e),r=new f(n);return a.context(r).getCtx=function(){return e},a.emit("new-promise",[r,e],e),r}function o(t,e){return e}var i=t("wrap-function"),a=t("ee").get("promise"),c=i(a),s=t(27),f=NREUM.o.PR;e.exports=a,f&&(window.Promise=r,["all","race"].forEach(function(t){var e=f[t];f[t]=function(n){function r(t){return function(){a.emit("propagate",[null,!o],i),o=o||!t}}var o=!1;s(n,function(e,n){Promise.resolve(n).then(r("all"===t),r(!1))});var i=e.apply(f,arguments),c=f.resolve(i);return c}}),["resolve","reject"].forEach(function(t){var e=f[t];f[t]=function(t){var n=e.apply(f,arguments);return t!==n&&a.emit("propagate",[t,!0],n),n}}),f.prototype["catch"]=function(t){return this.then(null,t)},f.prototype=Object.create(f.prototype,{constructor:{value:r}}),s(Object.getOwnPropertyNames(f),function(t,e){try{r[e]=f[e]}catch(n){}}),a.on("executor-start",function(t){t[0]=c(t[0],"resolve-",this),t[1]=c(t[1],"resolve-",this)}),a.on("executor-err",function(t,e,n){t[1](n)}),c.inPlace(f.prototype,["then"],"then-",o),a.on("then-start",function(t,e){this.promise=e,t[0]=c(t[0],"cb-",this),t[1]=c(t[1],"cb-",this)}),a.on("then-end",function(t,e,n){this.nextPromise=n;var r=this.promise;a.emit("propagate",[r,!0],n)}),a.on("cb-end",function(t,e,n){a.emit("propagate",[n,!0],this.nextPromise)}),a.on("propagate",function(t,e,n){this.getCtx&&!e||(this.getCtx=function(){if(t instanceof Promise)var e=a.context(t);return e&&e.getCtx?e.getCtx():this})}),r.toString=function(){return""+f})},{}],12:[function(t,e,n){var r=t("ee").get("raf"),o=t("wrap-function")(r),i="equestAnimationFrame";e.exports=r,o.inPlace(window,["r"+i,"mozR"+i,"webkitR"+i,"msR"+i],"raf-"),r.on("raf-start",function(t){t[0]=o(t[0],"fn-")})},{}],13:[function(t,e,n){function r(t,e,n){t[0]=a(t[0],"fn-",null,n)}function o(t,e,n){this.method=n,this.timerDuration=isNaN(t[1])?0:+t[1],t[0]=a(t[0],"fn-",this,n)}var i=t("ee").get("timer"),a=t("wrap-function")(i),c="setTimeout",s="setInterval",f="clearTimeout",u="-start",d="-";e.exports=i,a.inPlace(window,[c,"setImmediate"],c+d),a.inPlace(window,[s],s+d),a.inPlace(window,[f,"clearImmediate"],f+d),i.on(s+u,r),i.on(c+u,o)},{}],14:[function(t,e,n){function r(t,e){d.inPlace(e,["onreadystatechange"],"fn-",c)}function o(){var t=this,e=u.context(t);t.readyState>3&&!e.resolved&&(e.resolved=!0,u.emit("xhr-resolved",[],t)),d.inPlace(t,g,"fn-",c)}function i(t){y.push(t),h&&(b?b.then(a):v?v(a):(E=-E,R.data=E))}function a(){for(var t=0;t<y.length;t++)r([],y[t]);y.length&&(y=[])}function c(t,e){return e}function s(t,e){for(var n in t)e[n]=t[n];return e}t(6);var f=t("ee"),u=f.get("xhr"),d=t("wrap-function")(u),p=NREUM.o,l=p.XHR,h=p.MO,m=p.PR,v=p.SI,w="readystatechange",g=["onload","onerror","onabort","onloadstart","onloadend","onprogress","ontimeout"],y=[];e.exports=u;var x=window.XMLHttpRequest=function(t){var e=new l(t);try{u.emit("new-xhr",[e],e),e.addEventListener(w,o,!1)}catch(n){try{u.emit("internal-error",[n])}catch(r){}}return e};if(s(l,x),x.prototype=l.prototype,d.inPlace(x.prototype,["open","send"],"-xhr-",c),u.on("send-xhr-start",function(t,e){r(t,e),i(e)}),u.on("open-xhr-start",r),h){var b=m&&m.resolve();if(!v&&!m){var E=1,R=document.createTextNode(E);new h(a).observe(R,{characterData:!0})}}else f.on("fn-end",function(t){t[0]&&t[0].type===w||a()})},{}],15:[function(t,e,n){function r(t){if(!c(t))return null;var e=window.NREUM;if(!e.loader_config)return null;var n=(e.loader_config.accountID||"").toString()||null,r=(e.loader_config.agentID||"").toString()||null,f=(e.loader_config.trustKey||"").toString()||null;if(!n||!r)return null;var h=l.generateSpanId(),m=l.generateTraceId(),v=Date.now(),w={spanId:h,traceId:m,timestamp:v};return(t.sameOrigin||s(t)&&p())&&(w.traceContextParentHeader=o(h,m),w.traceContextStateHeader=i(h,v,n,r,f)),(t.sameOrigin&&!u()||!t.sameOrigin&&s(t)&&d())&&(w.newrelicHeader=a(h,m,v,n,r,f)),w}function o(t,e){return"00-"+e+"-"+t+"-01"}function i(t,e,n,r,o){var i=0,a="",c=1,s="",f="";return o+"@nr="+i+"-"+c+"-"+n+"-"+r+"-"+t+"-"+a+"-"+s+"-"+f+"-"+e}function a(t,e,n,r,o,i){var a="btoa"in window&&"function"==typeof window.btoa;if(!a)return null;var c={v:[0,1],d:{ty:"Browser",ac:r,ap:o,id:t,tr:e,ti:n}};return i&&r!==i&&(c.d.tk=i),btoa(JSON.stringify(c))}function c(t){return f()&&s(t)}function s(t){var e=!1,n={};if("init"in NREUM&&"distributed_tracing"in NREUM.init&&(n=NREUM.init.distributed_tracing),t.sameOrigin)e=!0;else if(n.allowed_origins instanceof Array)for(var r=0;r<n.allowed_origins.length;r++){var o=h(n.allowed_origins[r]);if(t.hostname===o.hostname&&t.protocol===o.protocol&&t.port===o.port){e=!0;break}}return e}function f(){return"init"in NREUM&&"distributed_tracing"in NREUM.init&&!!NREUM.init.distributed_tracing.enabled}function u(){return"init"in NREUM&&"distributed_tracing"in NREUM.init&&!!NREUM.init.distributed_tracing.exclude_newrelic_header}function d(){return"init"in NREUM&&"distributed_tracing"in NREUM.init&&NREUM.init.distributed_tracing.cors_use_newrelic_header!==!1}function p(){return"init"in NREUM&&"distributed_tracing"in NREUM.init&&!!NREUM.init.distributed_tracing.cors_use_tracecontext_headers}var l=t(24),h=t(17);e.exports={generateTracePayload:r,shouldGenerateTrace:c}},{}],16:[function(t,e,n){function r(t){var e=this.params,n=this.metrics;if(!this.ended){this.ended=!0;for(var r=0;r<p;r++)t.removeEventListener(d[r],this.listener,!1);e.aborted||(n.duration=a.now()-this.startTime,this.loadCaptureCalled||4!==t.readyState?null==e.status&&(e.status=0):i(this,t),n.cbTime=this.cbTime,u.emit("xhr-done",[t],t),c("xhr",[e,n,this.startTime]))}}function o(t,e){var n=s(e),r=t.params;r.host=n.hostname+":"+n.port,r.pathname=n.pathname,t.parsedOrigin=s(e),t.sameOrigin=t.parsedOrigin.sameOrigin}function i(t,e){t.params.status=e.status;var n=v(e,t.lastSize);if(n&&(t.metrics.rxSize=n),t.sameOrigin){var r=e.getResponseHeader("X-NewRelic-App-Data");r&&(t.params.cat=r.split(", ").pop())}t.loadCaptureCalled=!0}var a=t("loader");if(a.xhrWrappable){var c=t("handle"),s=t(17),f=t(15).generateTracePayload,u=t("ee"),d=["load","error","abort","timeout"],p=d.length,l=t("id"),h=t(21),m=t(20),v=t(18),w=window.XMLHttpRequest;a.features.xhr=!0,t(14),t(7),u.on("new-xhr",function(t){var e=this;e.totalCbs=0,e.called=0,e.cbTime=0,e.end=r,e.ended=!1,e.xhrGuids={},e.lastSize=null,e.loadCaptureCalled=!1,t.addEventListener("load",function(n){i(e,t)},!1),h&&(h>34||h<10)||window.opera||t.addEventListener("progress",function(t){e.lastSize=t.loaded},!1)}),u.on("open-xhr-start",function(t){this.params={method:t[0]},o(this,t[1]),this.metrics={}}),u.on("open-xhr-end",function(t,e){"loader_config"in NREUM&&"xpid"in NREUM.loader_config&&this.sameOrigin&&e.setRequestHeader("X-NewRelic-ID",NREUM.loader_config.xpid);var n=f(this.parsedOrigin);if(n){var r=!1;n.newrelicHeader&&(e.setRequestHeader("newrelic",n.newrelicHeader),r=!0),n.traceContextParentHeader&&(e.setRequestHeader("traceparent",n.traceContextParentHeader),n.traceContextStateHeader&&e.setRequestHeader("tracestate",n.traceContextStateHeader),r=!0),r&&(this.dt=n)}}),u.on("send-xhr-start",function(t,e){var n=this.metrics,r=t[0],o=this;if(n&&r){var i=m(r);i&&(n.txSize=i)}this.startTime=a.now(),this.listener=function(t){try{"abort"!==t.type||o.loadCaptureCalled||(o.params.aborted=!0),("load"!==t.type||o.called===o.totalCbs&&(o.onloadCalled||"function"!=typeof e.onload))&&o.end(e)}catch(n){try{u.emit("internal-error",[n])}catch(r){}}};for(var c=0;c<p;c++)e.addEventListener(d[c],this.listener,!1)}),u.on("xhr-cb-time",function(t,e,n){this.cbTime+=t,e?this.onloadCalled=!0:this.called+=1,this.called!==this.totalCbs||!this.onloadCalled&&"function"==typeof n.onload||this.end(n)}),u.on("xhr-load-added",function(t,e){var n=""+l(t)+!!e;this.xhrGuids&&!this.xhrGuids[n]&&(this.xhrGuids[n]=!0,this.totalCbs+=1)}),u.on("xhr-load-removed",function(t,e){var n=""+l(t)+!!e;this.xhrGuids&&this.xhrGuids[n]&&(delete this.xhrGuids[n],this.totalCbs-=1)}),u.on("addEventListener-end",function(t,e){e instanceof w&&"load"===t[0]&&u.emit("xhr-load-added",[t[1],t[2]],e)}),u.on("removeEventListener-end",function(t,e){e instanceof w&&"load"===t[0]&&u.emit("xhr-load-removed",[t[1],t[2]],e)}),u.on("fn-start",function(t,e,n){e instanceof w&&("onload"===n&&(this.onload=!0),("load"===(t[0]&&t[0].type)||this.onload)&&(this.xhrCbStart=a.now()))}),u.on("fn-end",function(t,e){this.xhrCbStart&&u.emit("xhr-cb-time",[a.now()-this.xhrCbStart,this.onload,e],e)}),u.on("fetch-before-start",function(t){function e(t,e){var n=!1;return e.newrelicHeader&&(t.set("newrelic",e.newrelicHeader),n=!0),e.traceContextParentHeader&&(t.set("traceparent",e.traceContextParentHeader),e.traceContextStateHeader&&t.set("tracestate",e.traceContextStateHeader),n=!0),n}var n,r=t[1]||{};"string"==typeof t[0]?n=t[0]:t[0]&&t[0].url&&(n=t[0].url),n&&(this.parsedOrigin=s(n),this.sameOrigin=this.parsedOrigin.sameOrigin);var o=f(this.parsedOrigin);if(o&&(o.newrelicHeader||o.traceContextParentHeader))if("string"==typeof t[0]){var i={};for(var a in r)i[a]=r[a];i.headers=new Headers(r.headers||{}),e(i.headers,o)&&(this.dt=o),t.length>1?t[1]=i:t.push(i)}else t[0]&&t[0].headers&&e(t[0].headers,o)&&(this.dt=o)})}},{}],17:[function(t,e,n){var r={};e.exports=function(t){if(t in r)return r[t];var e=document.createElement("a"),n=window.location,o={};e.href=t,o.port=e.port;var i=e.href.split("://");!o.port&&i[1]&&(o.port=i[1].split("/")[0].split("@").pop().split(":")[1]),o.port&&"0"!==o.port||(o.port="https"===i[0]?"443":"80"),o.hostname=e.hostname||n.hostname,o.pathname=e.pathname,o.protocol=i[0],"/"!==o.pathname.charAt(0)&&(o.pathname="/"+o.pathname);var a=!e.protocol||":"===e.protocol||e.protocol===n.protocol,c=e.hostname===document.domain&&e.port===n.port;return o.sameOrigin=a&&(!e.hostname||c),"/"===o.pathname&&(r[t]=o),o}},{}],18:[function(t,e,n){function r(t,e){var n=t.responseType;return"json"===n&&null!==e?e:"arraybuffer"===n||"blob"===n||"json"===n?o(t.response):"text"===n||""===n||void 0===n?o(t.responseText):void 0}var o=t(20);e.exports=r},{}],19:[function(t,e,n){function r(){}function o(t,e,n){return function(){return i(t,[f.now()].concat(c(arguments)),e?null:this,n),e?void 0:this}}var i=t("handle"),a=t(27),c=t(28),s=t("ee").get("tracer"),f=t("loader"),u=NREUM;"undefined"==typeof window.newrelic&&(newrelic=u);var d=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],p="api-",l=p+"ixn-";a(d,function(t,e){u[e]=o(p+e,!0,"api")}),u.addPageAction=o(p+"addPageAction",!0),u.setCurrentRouteName=o(p+"routeName",!0),e.exports=newrelic,u.interaction=function(){return(new r).get()};var h=r.prototype={createTracer:function(t,e){var n={},r=this,o="function"==typeof e;return i(l+"tracer",[f.now(),t,n],r),function(){if(s.emit((o?"":"no-")+"fn-start",[f.now(),r,o],n),o)try{return e.apply(this,arguments)}catch(t){throw s.emit("fn-err",[arguments,this,t],n),t}finally{s.emit("fn-end",[f.now()],n)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(t,e){h[e]=o(l+e)}),newrelic.noticeError=function(t,e){"string"==typeof t&&(t=new Error(t)),i("err",[t,f.now(),!1,e])}},{}],20:[function(t,e,n){e.exports=function(t){if("string"==typeof t&&t.length)return t.length;if("object"==typeof t){if("undefined"!=typeof ArrayBuffer&&t instanceof ArrayBuffer&&t.byteLength)return t.byteLength;if("undefined"!=typeof Blob&&t instanceof Blob&&t.size)return t.size;if(!("undefined"!=typeof FormData&&t instanceof FormData))try{return JSON.stringify(t).length}catch(e){return}}}},{}],21:[function(t,e,n){var r=0,o=navigator.userAgent.match(/Firefox[\/\s](\d+\.\d+)/);o&&(r=+o[1]),e.exports=r},{}],22:[function(t,e,n){function r(){return c.exists&&performance.now?Math.round(performance.now()):(i=Math.max((new Date).getTime(),i))-a}function o(){return i}var i=(new Date).getTime(),a=i,c=t(29);e.exports=r,e.exports.offset=a,e.exports.getLastTimestamp=o},{}],23:[function(t,e,n){function r(t,e){var n=t.getEntries();n.forEach(function(t){"first-paint"===t.name?d("timing",["fp",Math.floor(t.startTime)]):"first-contentful-paint"===t.name&&d("timing",["fcp",Math.floor(t.startTime)])})}function o(t,e){var n=t.getEntries();n.length>0&&d("lcp",[n[n.length-1]])}function i(t){t.getEntries().forEach(function(t){t.hadRecentInput||d("cls",[t])})}function a(t){if(t instanceof h&&!v){var e=Math.round(t.timeStamp),n={type:t.type};e<=p.now()?n.fid=p.now()-e:e>p.offset&&e<=Date.now()?(e-=p.offset,n.fid=p.now()-e):e=p.now(),v=!0,d("timing",["fi",e,n])}}function c(t){d("pageHide",[p.now(),t])}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var s,f,u,d=t("handle"),p=t("loader"),l=t(26),h=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){s=new PerformanceObserver(r);try{s.observe({entryTypes:["paint"]})}catch(m){}f=new PerformanceObserver(o);try{f.observe({entryTypes:["largest-contentful-paint"]})}catch(m){}u=new PerformanceObserver(i);try{u.observe({type:"layout-shift",buffered:!0})}catch(m){}}if("addEventListener"in document){var v=!1,w=["click","keydown","mousedown","pointerdown","touchstart"];w.forEach(function(t){document.addEventListener(t,a,!1)})}l(c)}},{}],24:[function(t,e,n){function r(){function t(){return e?15&e[n++]:16*Math.random()|0}var e=null,n=0,r=window.crypto||window.msCrypto;r&&r.getRandomValues&&(e=r.getRandomValues(new Uint8Array(31)));for(var o,i="xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx",a="",c=0;c<i.length;c++)o=i[c],"x"===o?a+=t().toString(16):"y"===o?(o=3&t()|8,a+=o.toString(16)):a+=o;return a}function o(){return a(16)}function i(){return a(32)}function a(t){function e(){return n?15&n[r++]:16*Math.random()|0}var n=null,r=0,o=window.crypto||window.msCrypto;o&&o.getRandomValues&&Uint8Array&&(n=o.getRandomValues(new Uint8Array(31)));for(var i=[],a=0;a<t;a++)i.push(e().toString(16));return i.join("")}e.exports={generateUuid:r,generateSpanId:o,generateTraceId:i}},{}],25:[function(t,e,n){function r(t,e){if(!o)return!1;if(t!==o)return!1;if(!e)return!0;if(!i)return!1;for(var n=i.split("."),r=e.split("."),a=0;a<r.length;a++)if(r[a]!==n[a])return!1;return!0}var o=null,i=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var c=navigator.userAgent,s=c.match(a);s&&c.indexOf("Chrome")===-1&&c.indexOf("Chromium")===-1&&(o="Safari",i=s[1])}e.exports={agent:o,version:i,match:r}},{}],26:[function(t,e,n){function r(t){function e(){t(a&&document[a]?document[a]:document[o]?"hidden":"visible")}"addEventListener"in document&&i&&document.addEventListener(i,e,!1)}e.exports=r;var o,i,a;"undefined"!=typeof document.hidden?(o="hidden",i="visibilitychange",a="visibilityState"):"undefined"!=typeof document.msHidden?(o="msHidden",i="msvisibilitychange"):"undefined"!=typeof document.webkitHidden&&(o="webkitHidden",i="webkitvisibilitychange",a="webkitVisibilityState")},{}],27:[function(t,e,n){function r(t,e){var n=[],r="",i=0;for(r in t)o.call(t,r)&&(n[i]=e(r,t[r]),i+=1);return n}var o=Object.prototype.hasOwnProperty;e.exports=r},{}],28:[function(t,e,n){function r(t,e,n){e||(e=0),"undefined"==typeof n&&(n=t?t.length:0);for(var r=-1,o=n-e||0,i=Array(o<0?0:o);++r<o;)i[r]=t[e+r];return i}e.exports=r},{}],29:[function(t,e,n){e.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(t,e,n){function r(){}function o(t){function e(t){return t&&t instanceof r?t:t?s(t,c,i):i()}function n(n,r,o,i){if(!p.aborted||i){t&&t(n,r,o);for(var a=e(o),c=m(n),s=c.length,f=0;f<s;f++)c[f].apply(a,r);var d=u[y[n]];return d&&d.push([x,n,r,a]),a}}function l(t,e){g[t]=m(t).concat(e)}function h(t,e){var n=g[t];if(n)for(var r=0;r<n.length;r++)n[r]===e&&n.splice(r,1)}function m(t){return g[t]||[]}function v(t){return d[t]=d[t]||o(n)}function w(t,e){f(t,function(t,n){e=e||"feature",y[n]=e,e in u||(u[e]=[])})}var g={},y={},x={on:l,addEventListener:l,removeEventListener:h,emit:n,get:v,listeners:m,context:e,buffer:w,abort:a,aborted:!1};return x}function i(){return new r}function a(){(u.api||u.feature)&&(p.aborted=!0,u=p.backlog={})}var c="nr@context",s=t("gos"),f=t(27),u={},d={},p=e.exports=o();p.backlog=u},{}],gos:[function(t,e,n){function r(t,e,n){if(o.call(t,e))return t[e];var r=n();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(t,e,{value:r,writable:!0,enumerable:!1}),r}catch(i){}return t[e]=r,r}var o=Object.prototype.hasOwnProperty;e.exports=r},{}],handle:[function(t,e,n){function r(t,e,n,r){o.buffer([t],r),o.emit(t,e,n)}var o=t("ee").get("handle");e.exports=r,r.ee=o},{}],id:[function(t,e,n){function r(t){var e=typeof t;return!t||"object"!==e&&"function"!==e?-1:t===window?0:a(t,i,function(){return o++})}var o=1,i="nr@id",a=t("gos");e.exports=r},{}],loader:[function(t,e,n){function r(){if(!b++){var t=x.info=NREUM.info,e=p.getElementsByTagName("script")[0];if(setTimeout(f.abort,3e4),!(t&&t.licenseKey&&t.applicationID&&e))return f.abort();s(g,function(e,n){t[e]||(t[e]=n)});var n=a();c("mark",["onload",n+x.offset],null,"api"),c("timing",["load",n]);var r=p.createElement("script");r.src="https://"+t.agent,e.parentNode.insertBefore(r,e)}}function o(){"complete"===p.readyState&&i()}function i(){c("mark",["domContent",a()+x.offset],null,"api")}var a=t(22),c=t("handle"),s=t(27),f=t("ee"),u=t(25),d=window,p=d.document,l="addEventListener",h="attachEvent",m=d.XMLHttpRequest,v=m&&m.prototype;NREUM.o={ST:setTimeout,SI:d.setImmediate,CT:clearTimeout,XHR:m,REQ:d.Request,EV:d.Event,PR:d.Promise,MO:d.MutationObserver};var w=""+location,g={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-spa-1184.min.js"},y=m&&v&&v[l]&&!/CriOS/.test(navigator.userAgent),x=e.exports={offset:a.getLastTimestamp(),now:a,origin:w,features:{},xhrWrappable:y,userAgent:u};t(19),t(23),p[l]?(p[l]("DOMContentLoaded",i,!1),d[l]("load",r,!1)):(p[h]("onreadystatechange",o),d[h]("onload",r)),c("mark",["firstbyte",a.getLastTimestamp()],null,"api");var b=0},{}],"wrap-function":[function(t,e,n){function r(t){return!(t&&t instanceof Function&&t.apply&&!t[a])}var o=t("ee"),i=t(28),a="nr@original",c=Object.prototype.hasOwnProperty,s=!1;e.exports=function(t,e){function n(t,e,n,o){function nrWrapper(){var r,a,c,s;try{a=this,r=i(arguments),c="function"==typeof n?n(r,a):n||{}}catch(f){p([f,"",[r,a,o],c])}u(e+"start",[r,a,o],c);try{return s=t.apply(a,r)}catch(d){throw u(e+"err",[r,a,d],c),d}finally{u(e+"end",[r,a,s],c)}}return r(t)?t:(e||(e=""),nrWrapper[a]=t,d(t,nrWrapper),nrWrapper)}function f(t,e,o,i){o||(o="");var a,c,s,f="-"===o.charAt(0);for(s=0;s<e.length;s++)c=e[s],a=t[c],r(a)||(t[c]=n(a,f?c+o:o,i,c))}function u(n,r,o){if(!s||e){var i=s;s=!0;try{t.emit(n,r,o,e)}catch(a){p([a,n,r,o])}s=i}}function d(t,e){if(Object.defineProperty&&Object.keys)try{var n=Object.keys(t);return n.forEach(function(n){Object.defineProperty(e,n,{get:function(){return t[n]},set:function(e){return t[n]=e,e}})}),e}catch(r){p([r])}for(var o in t)c.call(t,o)&&(e[o]=t[o]);return e}function p(e){try{t.emit("internal-error",e)}catch(n){}}return t||(t=o),n.inPlace=f,n.flag=a,n}},{}]},{},["loader",2,16,5,3,4]);
+        ;NREUM.loader_config={accountID:"605604",trustKey:"2006878",agentID:"18919466",licenseKey:"7ce026ff1f",applicationID:"18918664"}
+        ;NREUM.info={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",licenseKey:"7ce026ff1f",applicationID:"18918664",sa:1}
+        // End of new relic script
+
+        // Custom CLS metric.  Source: https://web.dev/cls/
+        try { // Use try for 'layout-shift'
+          cls = 0;
+          metric = 'layout-shift';
+          observer = new PerformanceObserver(function (list) {
+            entries = list.getEntries();
+            for (var i=0; i < entries.length; i++){
+              entry = entries[i];
+              if (!entry.hadRecentInput) {
+                cls += entry.value;
+              }
+            }
+            newrelic.setCustomAttribute(metric, cls); //send to NR after adding up the CLS values
+          });
+          observer.observe({type: 'layout-shift', buffered: true});
+        } catch (e) {
+          // Do nothing, if it is not supported
+          console.log('NR Custom Metric', 'Unable to observe CLS/Layout Shift on this browser.');
+          console.log('NR Custom Metric', 'Error:', e);
+        }
+
+      }
+    })();
+
+  </script>
+
+
+
+    
+
+
+
+  
+  
+
+
+
+
+  <link rel="preconnect" href="https://assets.adobedtm.com" crossorigin>
+  <link rel="preconnect" href="https://code.adsales.snidigital.com" crossorigin>
+  <link rel="preconnect" href="https://s.go-mpulse.net">
+  <link rel="preconnect" href="https://cdn.whisk.com">
+  <link rel="preconnect" href="https://food.cld.sndimg.com">
+  <link rel="preconnect" href="https://www.googletagmanager.com">
+  <link rel="preconnect" href="https://cdns.gigya.com">
+  <link rel="preconnect" href="https://ssa.foodnetwork.com">
+  <link rel="preconnect" href="https://www.lightboxcdn.com">
+
+    
+    <link rel="apple-touch-icon" sizes="57x57" href="/etc/clientlibs/assets/images/food/apple-touch-icon-57x57.png"> <link rel="apple-touch-icon" sizes="114x114" href="/etc/clientlibs/assets/images/food/apple-touch-icon-114x114.png"> <link rel="apple-touch-icon" sizes="72x72" href="/etc/clientlibs/assets/images/food/apple-touch-icon-72x72.png"> <link rel="apple-touch-icon" sizes="144x144" href="/etc/clientlibs/assets/images/food/apple-touch-icon-144x144.png"> <link rel="apple-touch-icon" sizes="60x60" href="/etc/clientlibs/assets/images/food/apple-touch-icon-60x60.png"> <link rel="apple-touch-icon" sizes="120x120" href="/etc/clientlibs/assets/images/food/apple-touch-icon-120x120.png"> <link rel="apple-touch-icon" sizes="76x76" href="/etc/clientlibs/assets/images/food/apple-touch-icon-76x76.png"> <link rel="apple-touch-icon" sizes="152x152" href="/etc/clientlibs/assets/images/food/apple-touch-icon-152x152.png"> <link rel="apple-touch-icon" sizes="180x180" href="/etc/clientlibs/assets/images/food/apple-touch-icon-180x180.png"> <link rel="icon" type="image/png" href="/etc/clientlibs/assets/images/food/favicon-192x192.png" sizes="192x192"> <link rel="icon" type="image/png" href="/etc/clientlibs/assets/images/food/favicon-160x160.png" sizes="160x160"> <link rel="icon" type="image/png" href="/etc/clientlibs/assets/images/food/favicon-96x96.png" sizes="96x96"> <link rel="icon" type="image/png" href="/etc/clientlibs/assets/images/food/favicon-16x16.png" sizes="16x16"> <link rel="icon" type="image/png" href="/etc/clientlibs/assets/images/food/favicon-32x32.png" sizes="32x32"> <meta name="msapplication-TileColor" content="#0fadc4"> <meta name="msapplication-TileImage" content="/etc/clientlibs/assets/images/food/mstile-144x144.png">
+
+    
+      
+      
+        <meta name="viewport" content="width=1024">
+      
+    
+
+    <meta name="keywords" content="">
+    <meta name="author"  content="">
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+   <link rel="canonical" href="https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140"/>
+   
+ 
+ 
+
+
+
+
+    
+    
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+    
+        
+        
+        
+        
+        
+    
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<title>Spaghetti alla Carbonara Recipe | Tyler Florence | Food Network</title>
+
+
+
+  
+    <meta name="description" content="For a quick dinner, whip up Tyler Florence&#039;s authentic Spaghetti alla Carbonara recipe, a rich tangle of pasta, pancetta and egg, from Food Network.">
+  
+  
+
+
+
+
+  <meta property="og:title" content="Spaghetti alla Carbonara">
+
+
+
+
+  
+  
+  
+    
+
+
+
+  
+  
+
+
+
+
+  
+  
+    
+  
+
+
+    <meta property="og:description" content="Get Spaghetti alla Carbonara Recipe from Food Network">
+  
+
+
+
+
+
+
+
+
+
+    
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<meta property="og:url" content="https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140"/>
+
+<meta property="og:image" content="https://food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.616.462.suffix/1431766590243.jpeg"/>
+
+<meta property="twitter:card" content="summary"/>
+<meta property="og:site_name" content="Food Network"/>
+
+      
+
+
+    
+
+
+
+    
+
+    
+
+
+
+
+  
+  
+
+
+
+  
+  
+  
+
+  
+  <script>
+    document.getElementsByTagName('html')[0].className += ' js-support ' + navigator.platform;
+    var SNI = window.SNI || {};
+    SNI.JS_RESOURCE_PATH="//food.fnr.sndimg.com/etc/clientlibs/assets/v2/js/"
+  </script>
+
+  
+
+  <script>
+(function () { 
+  if ( typeof window.CustomEvent === "function" ) return false;
+  function CustomEvent ( event, params ) {
+    params = params || { bubbles: false, cancelable: false, detail: undefined };
+    var evt = document.createEvent( 'CustomEvent' );
+    evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+    return evt;
+   }
+  CustomEvent.prototype = window.Event.prototype;
+  window.CustomEvent = CustomEvent;
+})();
+var SNILoadEvents = {
+  listen: function(names) {
+    var evtObj = SNILoadEvents.events = {};
+    for (var i=0; i < names.length; i++) {
+      var name = 'SNILoadEvent_' + names[i];
+      if (window.CustomEvent) {
+        evtObj[names[i]] = new CustomEvent(name);
+      } else {
+        evtObj[names[i]] = document.createEvent('CustomEvent');
+        evtObj[names[i]].initCustomEvent(name, true, true);
+      }
+    }
+  },
+  trigger: function(names) {
+    var names = (typeof names === 'string') ? [ names ] : names;
+    for (var i=0; i < names.length; i++) {
+      try {
+        window.dispatchEvent(window.SNILoadEvents.events[names[i]]);
+        window.removeEventListener('SNILoadEvent_' + names[i], window.SNILoadEvents.events[names[i]].function);
+        window.SNILoadEvents.events[names[i]] = { firedAlready: true };
+      } catch(e) {
+        if (window.console) {
+          console.warn('SNILoadEvents event "' + names[i] + '" already triggered.');
+        }
+      }
+    }
+  },
+  mdmLoaded: function(fn) {
+    SNILoadEvents.on('mdm', function(e) {
+      if (window.MetaDataManager !== 'undefined') {
+        fn();
+      } else {
+        if (window.console) {
+          console.error('MetaDataManager is not defined!');
+        }
+      }
+    });
+  },
+  on: function(name, fn) {
+    if (window.SNILoadEvents.events[name].firedAlready) {
+      fn();
+    } else {
+      window.SNILoadEvents.events[name].function = fn;
+      window.addEventListener('SNILoadEvent_' + name, fn);
+    }
+  }
+};
+
+SNILoadEvents.listen([
+  'sni-all',
+  'core',
+  'mdm',
+  'ads',
+  'analytics'
+]);
+
+(function() {
+  var jqMethods = 'css|hide|addClass|removeClass|find|remove|html|height|offset|animate|closest|appendTo|insertAfter|load|attr|append|on'.split('|');
+  function makePlugin(parent, name, operand) {
+    return function() {
+      var params = arguments;
+      SNILoadEvents.on('core', function() {
+        var $el = window.$.apply(window.$.fn, operand);
+        $el[name].apply($el, params);
+      });
+      return parent;
+    };
+  }
+  window.updateJqMethods = function (name) {
+    jqMethods.push(name);
+  };
+  window.jQuery = window.$ = function() {
+    var operand = arguments;
+    if (typeof arguments[0] === 'function') {
+      SNILoadEvents.on('core', function() {
+        window.$.apply(window.$.fn, operand);
+      });
+    }
+    var jqMethodsObj = {};
+    for (var i=0; i < jqMethods.length; i++) {
+      jqMethodsObj[jqMethods[i]] = makePlugin(jqMethodsObj, jqMethods[i], operand);
+    }
+    return jqMethodsObj;
+  };
+})();
+</script>
+
+
+  
+  
+
+
+
+  
+  
+
+
+
+
+  <script src="//assets.adobedtm.com/launch-ENe37f8b8d568443619b43fb72877cfc3d.min.js" async></script>
+
+
+
+  <script>
+    (function() {
+      
+      /*   */
+      sessionStorage.setItem('countryCode', "ID");
+      /*   */
+    })();
+  </script>
+
+  
+
+    
+
+
+
+  
+  
+
+
+
+    
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+<script type="text/javascript">
+SNILoadEvents.mdmLoaded(function() {
+  var mdManager = window.mdManager = new MetaDataManager(),
+    origPubDate = '2015-07-22T10:03:44.111-04:00'.replace(/T.*$/, ''),
+    lastReplicationDate = '2018-11-12T10:51:24.122-05:00'.replace(/T.*$/, '');
+    mdManager.addParameter("Url", "\/recipes\/tyler\u002Dflorence\/spaghetti\u002Dalla\u002Dcarbonara\u002Drecipe\u002D1914140");
+    mdManager.addParameter("Title", "spaghetti alla carbonara");
+    mdManager.addParameter("Site", "food");
+    mdManager.addParameter("CategoryDspName", "recipes");
+    mdManager.addParameter("SctnDspName", "tyler-florence");
+    mdManager.addParameter("SubSection", "s");
+    mdManager.addParameter("Classification", "s,tyler-florence,recipes,food");
+    mdManager.addParameter("DetailID", "97189181-a964-4cbe-8cdc-bb499cf487fb");
+    mdManager.addParameter("PageNumber", "1");
+    mdManager.addParameter("behavioralInteraction", "1-1-1");
+    mdManager.addParameter("Type", "recipe");
+    mdManager.addParameter("UniqueID", "food|recipepage|97189181-a964-4cbe-8cdc-bb499cf487fb|1");
+    mdManager.addParameter("AdKey1", "tv");
+    mdManager.addParameter("AdKey2", "");
+    mdManager.addParameter("ContentTag1", "");
+    mdManager.addParameter("ContentTag2", "");
+
+    mdManager.addParameter("Sponsorship", "RCD_SPAGHETTI");
+
+    mdManager.addParameter("Show_Abbr", "");
+    mdManager.addParameter("Source", "");
+    mdManager.addParameter("Delivery_Channel", "web");
+    mdManager.addParameter("EditorialTracking", "");
+    mdManager.addParameter("Difficulty", "intermediate");
+    mdManager.addParameter("Preptime", "");
+    mdManager.addParameter("Cuisine", "italian");
+    mdManager.addParameter("Technique", "");
+    mdManager.addParameter("Dish", "carbonara");
+    mdManager.addParameter("Taste", "");
+    mdManager.addParameter("Nutrition", "");
+    mdManager.addParameter("Occasions", "");
+    mdManager.addParameter("MainIngredient", "");
+    mdManager.addParameter("MealPart", "main-dish");
+    mdManager.addParameter("MealType", "");
+    mdManager.addParameter("Region", "");
+    mdManager.addParameter("Country", "");
+    mdManager.addParameter("State", "");
+    mdManager.addParameter("City", "");
+
+    mdManager.addParameter("TargetedTerms", "spaghetti;egg;flat-leaf parsley;garnish;DO;sauce;drain;cheese;Parmigiano-Reggiano;parsley;pot;olive;pancetta;pasta;beat;olive oil;season;carbonara;saute;pan;boil;crisp;virgin olive oil;eggs;garlic;salt;dry;al;cloves;black pepper;garlic cloves;extra-virgin olive oil;bacon;Parmesan;al dente;skillet;cup");
+    mdManager.addParameter("OrigPubDate", origPubDate + '|' + lastReplicationDate);
+});
+
+</script>
+
+
+<link rel="amphtml" href="https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140.amp"/>
+    <link rel="amppackage" href="https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140.amppkg"/>
+    <meta name="branch:deeplink:$deeplink_path" content="itk/v4/recipes/97189181-a964-4cbe-8cdc-bb499cf487fb" />
+
+    
+    
+    <meta name="tp:initialize" content="false">
+    <meta name="tp:PreferredRuntimes" content="Flash,HTML5" />
+    
+
+
+<script>
+  var SNI = window.SNI || {};
+  SNI.Config = SNI.Config || {};
+
+  SNI.Config.brand = "food";
+  SNI.Config.useGigyaLogin = true;
+  if ("null" !== "null") {
+    SNI.Config.socialCommentsCmbUri = "null";
+  }
+  if ("null" !== "null") {
+    SNI.Config.userRegisterCmbUri = "null";
+  }
+  if (typeof SNILoadEvents !== 'undefined') {
+    SNILoadEvents.on('core', function() {
+      SNI.Config.VPC.setUri('//www.player.video.snidigital.com/vpc/1/14/');
+    });
+  }
+  SNI.Config.Video = {
+    fallbackSiteSectionId: '1152909',
+    networkId: '191701'
+  };
+</script>
+
+    
+
+    
+    <script>
+        var cqMobile = false,
+            cqBasePage = '//www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140',
+            cqWCMDisabled = true,
+            cqIncludeVideo = true;
+    </script>
+
+  
+
+
+
+  
+  
+
+
+  
+  
+
+  
+    <meta property="fb:app_id" content="582148248497951"/>
+  
+
+
+  
+  <script>    
+    (function (b, r, a, n, c, h, _, s, d, k) { if (!b[n] || !b[n]._q) { for (; s < _.length;)c(h, _[s++]); d = r.createElement(a); d.async = 1; d.src = "https://cdn.branch.io/branch-latest.min.js"; k = r.getElementsByTagName(a)[0]; k.parentNode.insertBefore(d, k); b[n] = h } })(window, document, "script", "branch", function (b, r) { b[r] = function () { b._q.push([r, arguments]) } }, { _q: [], _v: 1 }, "addListener applyCode autoAppIndex banner closeBanner closeJourney creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setBranchViewData setIdentity track validateCode trackCommerceEvent logEvent disableTracking".split(" "), 0);
+    
+    // init Branch
+    branch.init('key_live_pdHECYu12dCh1KDTapMI7jfoqyiT0D57', function (err, data) {
+      console.log('Branch initialized', data, err);
+    });
+    // enable auto-opening app on iOS
+    branch.setBranchViewData({
+      '$uri_redirect_mode': 1
+    });
+  </script>
+
+
+   
+
+
+
+   
+
+
+  
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+<script>
+var isShoppingListEnabled = true;
+</script>
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch"}]);</script>
+                              <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="RWSLQ-RA5BZ-XHZBZ-4H2G2-ME7FC",function(){function e(){if(!o){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,i.parentNode.appendChild(e),o=!0}}function t(e){o=!0;var n,t,a,r,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(i.parentNode,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",r=(a.frameElement||a).style,r.width=0,r.height=0,r.border=0,r.display="none",i.parentNode.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void(0);",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=12,window.BOOMR.url=n+"RWSLQ-RA5BZ-XHZBZ-4H2G2-ME7FC";var i=document.currentScript||document.getElementsByTagName("script")[0],o=!1,r=document.createElement("link");if(r.relList&&"function"==typeof r.relList.supports&&r.relList.supports("preload")&&"as"in r)window.BOOMR.snippetMethod="p",r.href=window.BOOMR.url,r.rel="preload",r.as="script",r.addEventListener("load",e),r.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!o)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),i.parentNode.appendChild(r);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="",a="pwtmtkvyglcewyjsph4q-f-3a0329f60-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"32","ak.cp":"535731","ak.ai":parseInt("325785",10),"ak.ol":"0","ak.cr":7,"ak.ipv":4,"ak.proto":"h2","ak.rid":"2ca81bcb","ak.r":42184,"ak.a2":n,"ak.m":"","ak.n":"essl","ak.bpcip":"125.166.201.0","ak.cport":65513,"ak.gh":"184.25.236.52","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.csrc":"-","ak.acc":"","ak.t":"1630697977","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==VLv9LQ/GIPgRBdGGz8ulm22Y2AELuimiE5NWOSxYUOvzcTuOV6SMiOw6HpkkYbrHUTCKQxXuBh1bw3duNrVnSurgtYgOb5E5iOhi6+PQkH2in7YBhkoes+K46zY4YFbcWg9XGnIa1FMzuZCyYsJwLAoTnGtKgRgIigceVOhz4fZpt1zIgSTnwCVRTWOgprRiHzlkwgkfee3OBetySi2PIXPkyj9O80IStS8ejYRGrA6CMZLdIK4+nxdmGpRvDqjgF5SE25okS1xVSXLdDStb6tcVJmw08I5FJV9b8XMJgHC3skQLIkvyklMVxmuAJ7cmGxgWOgxT1rM1Ms4Pg1Jhv1OYQ6IXS/Oz9qLc/7pkbPJrjrn8pJNCdksMafQfY40ItqNj71fXNiPstwVooqPyYRGN48a+gPjuwtlmtTLZlqM=","ak.pv":"222","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.bpcip","ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+
+
+
+
+  
+  
+
+
+
+  
+  
+  
+  
+  
+    
+  
+
+
+<body class="recipePage" data-shorten-url="//www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140" data-module="page" data-page-path="/content/food-com/en/recipes/tyler-florence/s/sp/spa/spag/spaghetti-alla-carbonara-recipe">
+  
+
+  <section id="site" class="flush-top">
+    <div class="header"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/header"></span>
+
+
+
+  
+  
+
+
+<!--
+The design nodes specified the header path.
+Generally you can find this specified at /etc/designs/<SITE>/basePage/header/@header
+-->
+
+  
+     <!-- SDI include (path: /content/food-com/navigationConfigs/header/_jcr_content/header.beta.cache.html, resourceType: foodcom/components/navigation/header) -->
+
+
+<div id="leaderboard-wrap">
+    <div id="leaderboard">
+        <div id="dfp_leaderboard"></div>
+    </div>
+</div>
+
+<header class="o-Header ">
+    <section class="o-Header__m-Area o-Header__m-Area--Top">
+        
+        <div class="o-Header__m-Area m-Area__m-Container">
+
+</div>
+    </section>
+
+    <section class="o-Header__m-Area o-Header__m-Area--Main" data-module="header" data-header-main>
+        
+        <script type="text/x-config">
+            {
+                "entitlementsApi": "https://api.digitalstudios.discovery.com/subscriptions/v1/entitlements/web",
+                "highlightOnHover": true,
+                "darkThemeHeader": false,
+                "hoverIntentGlobal":
+                        {
+                        "highlight": true,
+                        "timeout": 100
+                        }
+            }
+        </script>
+        <div class="o-Header__m-Area m-Area__m-Container">
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--moreLinks" data-animate-menu="animate"><div class="o-Header__m-NavItem" data-type="menu-action" data-dropdown="true">
+  
+  <div class="o-Header__m-Navigation m-Navigation--IconWrap">
+    
+      <svg class="o-Header__a-Icon a-Icon--Menu" data-type="button-header-nav">
+        <symbol id="icon-hamburger-menu" viewBox="0 0 21 17">
+    <g fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-width="1.5">
+        <path d="M0 7.8L19.2 7.8M0 .6L19.2.6M0 15L19.2 15" transform="translate(1 1)"/>
+    </g>
+</symbol>
+
+        <use xlink:href="#icon-hamburger-menu"></use>
+      </svg>
+    
+  </div>
+  
+  <div data-type="dropdown-menu" class="o-Header__m-DropdownMenu o-Header__m-DropdownMenu--MoreLinks">
+
+    <ul class="o-Header__m-DropdownList" data-animate-item>
+      <li class="o-Header__m-DropdownListItem">
+        <a href="https://watch.foodnetwork.com/?utm_source=marketingsite&utm_medium=trendingline_watchfullseasons_text">Watch Full Seasons</a>
+      </li>
+    
+      <li class="o-Header__m-DropdownListItem">
+        <a href="//www.foodnetwork.com/shows/tv-schedule">TV Schedule</a>
+      </li>
+    
+      <li class="o-Header__m-DropdownListItem">
+        <a href="//www.foodnetwork.com/videos">Videos</a>
+      </li>
+    
+      <li class="o-Header__m-DropdownListItem">
+        <a href="//www.foodnetwork.com/how-to/packages/shopping">Shop</a>
+      </li>
+    
+      <li class="o-Header__m-DropdownListItem">
+        <a href="//www.foodnetwork.com/features/articles/sweepstakes-and-contests">Sweepstakes</a>
+      </li>
+    
+      <li class="o-Header__m-DropdownListItem">
+        <a href="//www.foodnetwork.com/magazine">Magazine</a>
+      </li>
+    
+      <li class="o-Header__m-DropdownListItem">
+        <a href="//www.foodnetwork.com/fn-dish">Blog</a>
+      </li>
+    
+      <li class="o-Header__m-DropdownListItem">
+        <a href="//www.foodnetwork.com/shows/a-z">Shows A-Z</a>
+      </li>
+    
+      <li class="o-Header__m-DropdownListItem">
+        <a href="//www.foodnetwork.com/profiles/talent">Chefs A-Z</a>
+      </li>
+    
+      <li class="o-Header__m-DropdownListItem">
+        <a href="//www.foodnetwork.com/restaurants">Restaurants</a>
+      </li>
+    </ul>
+
+    <ul class="m-SocialLinks" data-animate-item>
+      <li class="m-SocialLinks__a-Button--facebook">
+        <a class="m-SocialLinks__a-Icon--facebook" href="https://www.facebook.com/FoodNetwork" target="_blank" aria-label="facebook">
+          
+  
+    
+  <svg class="m-SocialLinks__a-Icon--Facebook m-SocialLinks__a-Icon a-Icon--Facebook a-Icon">
+    
+    <symbol id="icon-facebook" viewBox="0 0 12 27">
+    <path d="M8.26953125,8.72265625 L12.4042969,8.72265625 L11.9511719,13.3671875 L8.26953125,13.3671875 L8.26953125,26.6777344 L2.77539062,26.6777344 L2.77539062,13.3671875 L0,13.3671875 L0,8.72265625 L2.77539062,8.72265625 L2.77539062,6.00390625 C2.77539062,4.04035477 3.22851109,2.54883322 4.13476562,1.52929688 C5.07878076,0.509760527 6.60806234,0 8.72265625,0 L12.4042969,0 L12.4042969,4.58789062 L10.0820312,4.58789062 C9.66666459,4.58789062 9.32682424,4.62565066 9.0625,4.70117188 C8.83593637,4.77669309 8.66601619,4.90885322 8.55273438,5.09765625 C8.43945256,5.28645928 8.36393248,5.47525947 8.32617188,5.6640625 C8.28841127,5.85286553 8.26953125,6.1171858 8.26953125,6.45703125 L8.26953125,8.72265625 Z"/>
+</symbol>
+
+    <use xlink:href="#icon-facebook"></use>
+  </svg>
+
+  
+
+        </a>
+      </li>
+    
+      <li class="m-SocialLinks__a-Button--twitter">
+        <a class="m-SocialLinks__a-Icon--twitter" href="https://twitter.com/FoodNetwork" target="_blank" aria-label="twitter">
+          
+  
+    
+  <svg class="m-SocialLinks__a-Icon--Twitter m-SocialLinks__a-Icon a-Icon--Twitter a-Icon">
+    
+    <symbol id="icon-twitter" viewBox="0 0 25 21">
+    <path d="M25.4882812,2.43554688 C24.7708297,3.49284383 23.9023488,4.39908477 22.8828125,5.15429688 L22.8828125,5.83398438 C22.8828125,7.23112678 22.6751323,8.62824822 22.2597656,10.0253906 C21.844399,11.422533 21.2213583,12.7630144 20.390625,14.046875 C19.5598917,15.3307356 18.5592506,16.4635368 17.3886719,17.4453125 C16.2558537,18.4270882 14.8776123,19.2200491 13.2539062,19.8242188 C11.5924396,20.3906278 9.83659779,20.6738281 7.98632813,20.6738281 C5.0787615,20.6738281 2.41667875,19.8997473 0,18.3515625 C0.377606055,18.3893231 0.792966484,18.4082031 1.24609375,18.4082031 C3.6627725,18.4082031 5.81509473,17.6718824 7.703125,16.1992188 C6.57030684,16.1614581 5.5696658,15.8027378 4.70117188,15.1230469 C3.79491734,14.443356 3.1718767,13.5937551 2.83203125,12.5742188 C3.2096373,12.6119794 3.54947766,12.6308594 3.8515625,12.6308594 C4.30468977,12.6308594 4.75781023,12.5742193 5.2109375,12.4609375 C4.00259812,12.1966133 3.00195709,11.5924526 2.20898438,10.6484375 C1.41601166,9.70442236 1.01953125,8.59050121 1.01953125,7.30664062 L1.01953125,7.25 C1.73698275,7.66536666 2.52994357,7.89192689 3.3984375,7.9296875 C2.680986,7.43879963 2.11458541,6.81575898 1.69921875,6.06054688 C1.24609148,5.30533477 1.01953125,4.47461391 1.01953125,3.56835938 C1.01953125,2.62434424 1.2649715,1.75586334 1.75585938,0.962890625 C3.07748057,2.54883605 4.66340221,3.83267738 6.51367187,4.81445312 C8.40170215,5.75846826 10.4029842,6.28710881 12.5175781,6.40039062 C12.4420569,5.98502396 12.4042969,5.58854355 12.4042969,5.2109375 C12.4042969,3.77603449 12.9140574,2.54883322 13.9335938,1.52929688 C14.9531301,0.509760527 16.1803314,0 17.6152344,0 C19.1256586,0 20.4094999,0.547520566 21.4667969,1.64257813 C22.6373756,1.41601449 23.7324168,1.00065406 24.7519531,0.396484375 C24.3743471,1.60482375 23.6191463,2.54882473 22.4863281,3.22851562 C23.4681039,3.15299441 24.4687449,2.88867414 25.4882812,2.43554688 Z"/>
+</symbol>
+
+    <use xlink:href="#icon-twitter"></use>
+  </svg>
+
+  
+
+        </a>
+      </li>
+    
+      <li class="m-SocialLinks__a-Button--instagram">
+        <a class="m-SocialLinks__a-Icon--instagram" href="https://instagram.com/FoodNetwork" target="_blank" aria-label="instagram">
+          
+  
+    
+  <svg class="m-SocialLinks__a-Icon--Instagram m-SocialLinks__a-Icon a-Icon--Instagram a-Icon">
+    
+    <symbol id="icon-instagram" viewBox="0 0 25 25">
+    <path d="M16.5957031,12.4609375 C16.5957031,11.2903587 16.1897827,10.2991577 15.3779297,9.48730469 C14.5660767,8.67545167 13.5748756,8.26953125 12.4042969,8.26953125 C11.2714787,8.26953125 10.2991577,8.67545167 9.48730469,9.48730469 C8.67545167,10.2991577 8.26953125,11.2903587 8.26953125,12.4609375 C8.26953125,13.5937557 8.67545167,14.5660767 9.48730469,15.3779297 C10.2991577,16.1897827 11.2714787,16.5957031 12.4042969,16.5957031 C13.5748756,16.5957031 14.5660767,16.1897827 15.3779297,15.3779297 C16.1897827,14.5660767 16.5957031,13.5937557 16.5957031,12.4609375 Z M18.8046875,12.4609375 C18.8046875,14.1979254 18.1816469,15.6894469 16.9355469,16.9355469 C15.6894469,18.1816469 14.1790453,18.8046875 12.4042969,18.8046875 C10.667309,18.8046875 9.17578748,18.1816469 7.9296875,16.9355469 C6.68358752,15.6894469 6.06054687,14.1979254 6.06054687,12.4609375 C6.06054687,10.686189 6.68358752,9.17578748 7.9296875,7.9296875 C9.17578748,6.68358752 10.667309,6.06054687 12.4042969,6.06054687 C14.1790453,6.06054687 15.6894469,6.68358752 16.9355469,7.9296875 C18.1816469,9.17578748 18.8046875,10.686189 18.8046875,12.4609375 Z M20.5605469,5.77734375 C20.5605469,6.19271041 20.4095067,6.55143078 20.1074219,6.85351562 C19.805337,7.15560047 19.4654967,7.30664062 19.0878906,7.30664062 C18.672524,7.30664062 18.3138036,7.15560047 18.0117188,6.85351562 C17.7096339,6.55143078 17.5585938,6.19271041 17.5585938,5.77734375 C17.5585938,5.3997377 17.7096339,5.05989734 18.0117188,4.7578125 C18.3138036,4.45572766 18.672524,4.3046875 19.0878906,4.3046875 C19.4654967,4.3046875 19.805337,4.45572766 20.1074219,4.7578125 C20.4095067,5.05989734 20.5605469,5.3997377 20.5605469,5.77734375 Z M16.1425781,2.265625 L8.69433594,2.265625 C7.12727081,2.265625 5.92838957,2.41666516 5.09765625,2.71875 C4.83333201,2.83203182 4.58789176,2.96419195 4.36132812,3.11523438 C4.13476449,3.2662768 3.90820426,3.45507699 3.68164062,3.68164062 C3.45507699,3.90820426 3.2662768,4.13476449 3.11523438,4.36132812 C2.96419195,4.58789176 2.83203182,4.83333201 2.71875,5.09765625 C2.41666516,5.92838957 2.25618499,7.13671082 2.23730469,8.72265625 C2.21842438,10.3086017 2.20898438,11.554683 2.20898438,12.4609375 C2.20898438,13.367192 2.21842438,14.6038333 2.23730469,16.1708984 C2.25618499,17.7379636 2.41666516,18.9368448 2.71875,19.7675781 C2.83203182,20.0319024 2.96419195,20.2773426 3.11523438,20.5039062 C3.2662768,20.7304699 3.45507699,20.9570301 3.68164062,21.1835938 C3.90820426,21.4101574 4.12532448,21.5989576 4.33300781,21.75 C4.54069114,21.9010424 4.79557141,22.0332026 5.09765625,22.1464844 C5.92838957,22.4485692 7.12727081,22.6090494 8.69433594,22.6279297 C10.2614011,22.64681 11.4980423,22.65625 12.4042969,22.65625 C13.3105514,22.65625 14.5566327,22.64681 16.1425781,22.6279297 C17.7285236,22.6090494 18.9368448,22.4485692 19.7675781,22.1464844 C20.0319024,22.0332026 20.2773426,21.9010424 20.5039062,21.75 C20.7304699,21.5989576 20.9570301,21.4101574 21.1835938,21.1835938 C21.4101574,20.9570301 21.5989576,20.7304699 21.75,20.5039062 C21.9010424,20.2773426 22.0332026,20.0319024 22.1464844,19.7675781 C22.4485692,18.9368448 22.5996094,17.7379636 22.5996094,16.1708984 L22.5996094,8.72265625 C22.5996094,7.13671082 22.4485692,5.92838957 22.1464844,5.09765625 C22.0332026,4.83333201 21.9010424,4.58789176 21.75,4.36132812 C21.5989576,4.13476449 21.4101574,3.90820426 21.1835938,3.68164062 C20.9570301,3.45507699 20.7304699,3.2662768 20.5039062,3.11523438 C20.2773426,2.96419195 20.0319024,2.83203182 19.7675781,2.71875 C18.9368448,2.41666516 17.7285236,2.265625 16.1425781,2.265625 Z M24.8652344,9.88378906 L24.8652344,14.9814453 C24.8652344,15.8310589 24.8274743,16.6900998 24.7519531,17.5585938 C24.7141925,18.5781301 24.5537124,19.5221311 24.2705078,20.390625 C23.9873033,21.2591189 23.4869828,22.0520797 22.7695312,22.7695312 C22.0520797,23.4869828 21.2496789,23.9873033 20.3623047,24.2705078 C19.4749305,24.5537124 18.5403695,24.7330725 17.5585938,24.8085938 C16.6900998,24.8463544 15.8310589,24.8652344 14.9814453,24.8652344 L9.88378906,24.8652344 C9.03417544,24.8652344 8.17513455,24.8463544 7.30664062,24.8085938 C6.28710428,24.7330725 5.3431033,24.5537124 4.47460938,24.2705078 C3.60611545,23.9873033 2.81315463,23.4869828 2.09570312,22.7695312 C1.37825162,22.0520797 0.877931104,21.2591189 0.594726562,20.390625 C0.311522021,19.5221311 0.132161836,18.5781301 0.056640625,17.5585938 C0.0188800195,16.6900998 0,15.8310589 0,14.9814453 L0,9.88378906 C0,9.03417544 0.0188800195,8.17513455 0.056640625,7.30664062 C0.132161836,6.32486488 0.311522021,5.39030392 0.594726562,4.50292969 C0.877931104,3.61555546 1.37825162,2.81315463 2.09570312,2.09570312 C2.81315463,1.37825162 3.60611545,0.877931104 4.47460938,0.594726562 C5.3431033,0.311522021 6.28710428,0.151041855 7.30664062,0.11328125 C8.17513455,0.0377600391 9.03417544,0 9.88378906,0 L14.9814453,0 C15.8310589,0 16.6900998,0.0377600391 17.5585938,0.11328125 C18.5403695,0.151041855 19.4749305,0.311522021 20.3623047,0.594726562 C21.2496789,0.877931104 22.0520797,1.37825162 22.7695312,2.09570312 C23.4869828,2.81315463 23.9873033,3.61555546 24.2705078,4.50292969 C24.5537124,5.39030392 24.7141925,6.32486488 24.7519531,7.30664062 C24.8274743,8.17513455 24.8652344,9.03417544 24.8652344,9.88378906 Z"/>
+</symbol>
+
+    <use xlink:href="#icon-instagram"></use>
+  </svg>
+
+  
+
+        </a>
+      </li>
+    
+      <li class="m-SocialLinks__a-Button--youtube">
+        <a class="m-SocialLinks__a-Icon--youtube" href="https://www.youtube.com/FoodNetwork" target="_blank" aria-label="youtube">
+          
+  
+    
+  <svg class="m-SocialLinks__a-Icon--Youtube m-SocialLinks__a-Icon a-Icon--Youtube a-Icon">
+    
+    <symbol id="icon-youtube" viewBox="0 0 27 19">
+    <path d="M13.5351563,0 C6.76168488,0 2.81250563,0.398433516 1.6875,1.1953125 C0.562494375,1.99219148 0,4.78122609 0,9.5625 C0,14.3672115 0.562494375,17.1679648 1.6875,17.9648438 C2.81250563,18.7617227 6.76168488,19.1601562 13.5351563,19.1601562 C20.28519,19.1601562 24.2226506,18.7617227 25.3476562,17.9648438 C26.4726619,17.1679648 27.0351562,14.3672115 27.0351562,9.5625 C27.0351562,4.78122609 26.4726619,1.99219148 25.3476562,1.1953125 C24.2226506,0.398433516 20.28519,0 13.5351563,0 Z M13.921875,12.375 C13.2890593,12.7500019 12.5039109,13.2246065 11.5664062,13.7988281 L10.1601562,14.6601562 L10.1601562,4.5 L18.5976562,9.5625 L16.8398438,10.6171875 C15.6679629,11.320316 14.6953164,11.9062477 13.921875,12.375 Z"/>
+</symbol>
+
+    <use xlink:href="#icon-youtube"></use>
+  </svg>
+
+  
+
+        </a>
+      </li>
+    
+      <li class="m-SocialLinks__a-Button--pinterest">
+        <a class="m-SocialLinks__a-Icon--pinterest" href="https://www.pinterest.com/FoodNetwork" target="_blank" aria-label="pinterest">
+          
+  
+    
+  <svg class="m-SocialLinks__a-Icon--Pinterest m-SocialLinks__a-Icon a-Icon--Pinterest a-Icon">
+    
+    <symbol id="icon-pinterest" viewBox="0 0 23 29">
+    <path d="M9.30200913,19.1876287 C8.88664247,21.1889408 8.38632195,23.0769427 7.80103257,24.8516912 C7.21574318,26.6264396 6.22454216,28.0235611 4.82739976,29.0430974 C4.4120331,26.022249 4.55363324,23.3035262 5.25220444,20.8868474 C5.95077565,18.4701687 6.54549626,16.0535262 7.03638413,13.6368474 C6.20565081,12.239705 6.17733078,10.5405033 6.95142319,8.53919117 C7.72551561,6.53787908 8.99991692,5.89595841 10.7746654,6.61340992 C11.8319623,7.02877658 12.2662028,7.81229739 12.0773998,8.96399586 C11.8885967,10.1156943 11.5959564,11.3240156 11.1994701,12.5889959 C10.8029837,13.8539761 10.5669835,15.0150973 10.4914623,16.0723943 C10.415941,17.1296912 11.0578617,17.8093719 12.4172435,18.1114568 C13.8521465,18.375781 15.0510278,17.9981806 16.0139232,16.9786443 C16.9768186,15.9591079 17.6659393,14.6941466 18.081306,13.1837224 C18.4966727,11.6732982 18.6193928,10.1156966 18.4494701,8.51087086 C18.2795473,6.90604512 17.7603468,5.65052382 16.8918529,4.74426929 C15.6079923,3.46040871 14.1259108,2.77128799 12.4455638,2.67688648 C10.7652169,2.58248497 9.20761526,2.92232532 7.77271226,3.69641773 C6.33780925,4.47051014 5.16724804,5.5844313 4.26099351,7.03821461 C3.35473898,8.49199792 3.05265866,10.1439996 3.35474351,11.9942693 C3.50578593,12.8627632 3.84562628,13.570764 4.37427476,14.1182927 C4.90292323,14.6658215 4.80852314,15.5626224 4.09107163,16.8087224 C2.4673656,16.4311164 1.36288445,15.6475956 0.777595069,14.4581365 C0.192305684,13.2686774 -0.0625745792,11.8243559 0.0129466317,10.1251287 C0.126228448,7.33084386 1.19294955,5.02748148 3.21314194,3.21497242 C5.23333434,1.40246336 7.43285661,0.364062282 9.81177476,0.0997380433 C12.8703838,-0.240107406 15.6363067,0.288533141 18.1096263,1.68567554 C20.582946,3.08281795 22.0272675,5.21626015 22.4426341,8.08606617 C22.6691978,9.7097722 22.6125577,11.3240139 22.2727123,12.9288396 C21.9328668,14.5336653 21.3664662,15.9591068 20.5734935,17.2052068 C19.7805208,18.4513068 18.7515597,19.4330678 17.4865794,20.1505193 C16.2215992,20.8679708 14.7772777,21.1700511 13.1535716,21.0567693 C12.2850777,20.9812481 11.595957,20.7546878 11.0861888,20.3770818 C10.5764206,19.9994757 9.98170003,19.6029953 9.30200913,19.1876287 Z"/>
+</symbol>
+
+    <use xlink:href="#icon-pinterest"></use>
+  </svg>
+
+  
+
+        </a>
+      </li>
+    
+      <li class="m-SocialLinks__a-Button--snapchat">
+        <a class="m-SocialLinks__a-Icon--snapchat" href="//www.foodnetwork.com/site/snapchat-discover.html" target="_blank" aria-label="snapchat">
+          
+  
+    
+  <svg class="m-SocialLinks__a-Icon--Snapchat m-SocialLinks__a-Icon a-Icon--Snapchat a-Icon">
+    
+    <symbol id="icon-snapchat" viewBox="0 0 27 25">
+    <path d="M6.03947405,8.24911607 L6.10978655,8.24911607 C6.13322416,8.57724271 6.15080211,8.8936458 6.16252092,9.19833482 C6.17423973,9.50302384 6.20353631,9.8077083 6.25041155,10.1123973 C6.25041155,10.253023 6.22697428,10.3526314 6.18009905,10.4112254 C6.13322381,10.4698195 6.05119338,10.4991161 5.9340053,10.4991161 C5.69962912,10.4756785 5.47111578,10.4405226 5.24845842,10.3936473 C5.02580106,10.3467721 4.82072498,10.2881789 4.63322405,10.2178661 C4.39884787,10.1475532 4.17033453,10.1182566 3.94767717,10.1299754 C3.72501981,10.1416943 3.5082251,10.2061467 3.29728655,10.3233348 C2.94572229,10.5108358 2.75236485,10.7627864 2.71720842,11.0791942 C2.682052,11.395602 2.81681627,11.6709899 3.1215053,11.9053661 C3.33244385,12.0459918 3.54923856,12.1690374 3.77189592,12.2745067 C3.99455328,12.379976 4.22306662,12.4795844 4.4574428,12.5733348 C4.62150612,12.6436477 4.79142629,12.7081002 4.96720842,12.7666942 C5.14299055,12.8252882 5.31291073,12.9014594 5.47697405,12.9952098 C5.75822545,13.1358355 5.93986426,13.311615 6.02189592,13.5225536 C6.10392758,13.7334921 6.074631,13.991302 5.9340053,14.2959911 C5.3949401,15.4678719 4.69768145,16.4756744 3.84220842,17.3194286 C2.98673539,18.1631828 1.87932459,18.7256772 0.519942796,19.0069286 C0.285566624,19.0538038 0.127365081,19.1709901 0.0453334209,19.3584911 C-0.0366982393,19.545992 -0.00740165725,19.7452088 0.133224046,19.9561473 C0.226974515,20.0733354 0.344160843,20.1905217 0.484786546,20.3077098 C0.625412249,20.4248979 0.766035843,20.5069283 0.906661546,20.5538036 C1.2582258,20.6944293 1.60978479,20.8116156 1.96134905,20.9053661 L3.01603655,21.1866161 C3.34416319,21.2569289 3.53752063,21.3213814 3.59611467,21.3799754 C3.65470871,21.4385695 3.71916119,21.6202083 3.78947405,21.9248973 C3.90666213,22.4874001 4.04728573,22.8213812 4.21134905,22.9268504 C4.37541237,23.0323197 4.75040862,23.0264604 5.33634905,22.9092723 C6.0863528,22.7686466 6.81290803,22.7510687 7.51603655,22.8565379 C8.21916506,22.9620072 8.88712713,23.272551 9.5199428,23.7881786 C9.73088135,23.9522419 9.95353537,24.1104434 10.1879115,24.2627879 C10.4222877,24.4151325 10.6566604,24.5498967 10.8910365,24.6670848 C11.7582284,25.1123995 12.6254072,25.3350536 13.492599,25.3350536 C14.3597909,25.3350536 15.2152511,25.1123995 16.0590053,24.6670848 C16.3871319,24.5030215 16.6976757,24.3213827 16.9906459,24.1221629 C17.2836161,23.9229432 17.5824413,23.7178671 17.8871303,23.5069286 C18.2855698,23.2022395 18.7191592,22.9971635 19.1879115,22.8916942 C19.6566639,22.7862249 20.1371278,22.7569283 20.6293178,22.8038036 C20.8871316,22.8272412 21.1449415,22.8565378 21.4027553,22.8916942 C21.6605691,22.9268506 21.9066604,22.9561472 22.1410365,22.9795848 C22.422288,23.0264601 22.627364,23.0030228 22.7562709,22.9092723 C22.8851778,22.8155219 22.9847862,22.6397424 23.055099,22.3819286 C23.0785367,22.2647405 23.1078332,22.1416948 23.1429897,22.0127879 C23.1781461,21.8838811 23.2074427,21.7491168 23.2308803,21.6084911 C23.2543179,21.491303 23.2953331,21.4034132 23.3539272,21.3448192 C23.4125212,21.2862252 23.500411,21.2452099 23.617599,21.2217723 C24.0394762,21.1280219 24.4613469,21.0225542 24.883224,20.9053661 C25.3051012,20.788178 25.7269719,20.659273 26.148849,20.5186473 C26.2660371,20.4717721 26.3773641,20.4014603 26.4828334,20.3077098 C26.5883027,20.2139594 26.6879111,20.1202103 26.7816615,20.0264598 C26.9222872,19.8389589 26.9633025,19.6221642 26.9047084,19.3760692 C26.8461144,19.1299742 26.6761942,18.9952099 26.3949428,18.9717723 C26.3246299,18.9717723 26.2484588,18.9600537 26.1664272,18.9366161 C26.0843955,18.9131785 26.0082244,18.9014598 25.9379115,18.9014598 C24.7191555,18.5264579 23.711353,17.9288077 22.914474,17.1084911 C22.1175951,16.2881745 21.4730703,15.3155279 20.9808803,14.1905223 C20.8871298,13.9327085 20.8695519,13.7100545 20.9281459,13.5225536 C20.98674,13.3350526 21.1332229,13.1827104 21.367599,13.0655223 C21.5551,12.9717719 21.7425981,12.8897414 21.930099,12.8194286 C22.1176,12.7491157 22.3050981,12.6670853 22.492599,12.5733348 C22.7269752,12.4561467 22.9672072,12.3448197 23.2133022,12.2393504 C23.4593972,12.1338812 23.6879105,11.9991169 23.898849,11.8350536 C24.1566628,11.624115 24.2679898,11.3721644 24.2328334,11.0791942 C24.197677,10.786224 24.0394755,10.545992 23.758224,10.3584911 C23.5238479,10.2178654 23.2777566,10.1299756 23.0199428,10.0948192 C22.762129,10.0596628 22.5043191,10.100678 22.2465053,10.2178661 C22.0590044,10.2881789 21.8715062,10.3467721 21.6840053,10.3936473 C21.4965044,10.4405226 21.3090062,10.4756785 21.1215053,10.4991161 C20.9808796,10.5225537 20.8754119,10.4991164 20.805099,10.4288036 C20.7347862,10.3584907 20.6996303,10.2295858 20.6996303,10.0420848 C20.7465055,9.50301962 20.7816614,8.9581032 20.805099,8.4073192 C20.8285367,7.85653519 20.8402553,7.29990013 20.8402553,6.73739732 C20.8402553,5.68270455 20.6293199,4.72177666 20.2074428,3.85458482 C19.7855657,2.98739298 19.1644781,2.23740048 18.3441615,1.60458482 C17.1254055,0.69051775 15.8480745,0.16903859 14.5121303,0.0401316951 C13.1761861,-0.0887751995 11.8168247,0.0928636091 10.4340053,0.58505357 C9.35587491,0.960055445 8.47111813,1.53426845 7.77970842,2.30770982 C7.08829871,3.08115119 6.60197545,4.01864181 6.32072405,5.12020982 C6.20353596,5.61239978 6.13908348,6.12801962 6.12736467,6.66708482 C6.11564586,7.20615002 6.08634928,7.73348849 6.03947405,8.24911607 Z"/>
+</symbol>
+
+    <use xlink:href="#icon-snapchat"></use>
+  </svg>
+
+  
+
+        </a>
+      </li>
+    </ul>
+
+  </div>
+</div>
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--siteLogo" data-animate-menu="none"><div class="o-Header__m-SiteLogo">
+  <a href="//www.foodnetwork.com" title="home" aria-label="home page">
+    
+    
+
+    
+    
+  
+    
+  <svg class="o-Header__a-Icon--Logo o-Header__a-Icon a-Icon--Logo a-Icon">
+    
+    <symbol id="icon-brand-logo" viewBox="0 0 187 187">
+    <style>.st0{fill:#fff}.st1{fill:#e6003d}</style>
+    <path class="st0" d="M93.6 0C42-.1 0 41.8 0 93.4c0 49.9 40 93 93.4 93.6 51.6.1 93.6-41.8 93.6-93.4C187 39.6 142.8.9 93.6 0z"/>
+    <path class="st1" d="M113.7 79.3c-.3-.4-.6-.7-.9-.9-.3-.3-.7-.5-1.1-.7-.4-.2-.9-.3-1.3-.4-.5-.1-1-.1-1.6-.1-.6 0-1.1 0-1.6.1s-1 .2-1.4.4c-.4.2-.9.4-1.3.7-.4.3-.8.6-1.2 1-.7.7-1.3 1.4-1.9 2.3-.5.9-1 1.8-1.4 2.8-.4 1-.7 2.2-1 3.3-.3 1.2-.5 2.4-.8 3.8-.3 1.3-.5 2.6-.7 3.8-.2 1.2-.3 2.3-.3 3.4s0 2 .2 2.9c.2.9.5 1.6.9 2.3.3.4.6.7.9 1 .3.3.7.5 1.1.7.4.2.9.3 1.3.4.5.1 1 .1 1.6.1.6 0 1.1-.1 1.6-.2s1-.3 1.5-.4c.5-.2.9-.4 1.3-.7a10.6 10.6 0 0 0 3-3.3c.5-.9 1-1.9 1.3-2.9l.6-1.8c.1-.5.3-1 .4-1.6.3-1.2.5-2.4.8-3.7l.3-1.8c.1-.7.2-1.3.3-1.9.2-1.2.3-2.3.3-3.3s0-2-.2-2.8c0-1.1-.3-1.8-.7-2.5zM72.2 79.3c-.3-.4-.6-.7-.9-.9-.3-.3-.7-.5-1.1-.7-.4-.2-.9-.3-1.3-.4-.5-.1-1-.1-1.6-.1-.6 0-1.1 0-1.6.1s-1 .2-1.4.4c-.5.2-.9.4-1.3.7l-1.2.9c-.7.7-1.3 1.4-1.9 2.3-.5.9-1 1.8-1.4 2.8-.4 1-.7 2.2-1 3.3-.3 1.2-.6 2.4-.8 3.8-.3 1.3-.5 2.6-.7 3.8-.2 1.2-.3 2.3-.3 3.4s0 2 .2 2.9c.2.9.5 1.6.9 2.3.3.4.6.7.9 1a4.95 4.95 0 0 0 2.4 1.1c.5.1 1 .1 1.6.1.6 0 1.1-.1 1.6-.2s1-.3 1.5-.4c.5-.2.9-.4 1.3-.7a10.6 10.6 0 0 0 3-3.3c.5-.9 1-1.8 1.3-2.9l.6-1.8c.1-.5.3-1 .4-1.6.3-1.2.5-2.4.8-3.7l.3-1.8.3-2c.2-1.2.3-2.3.3-3.3s0-2-.2-2.8c0-.9-.3-1.6-.7-2.3zM154 78.3c-.3-.3-.7-.5-1.1-.7-.4-.2-.9-.3-1.3-.4-.5-.1-1-.1-1.6-.1-.6 0-1.1 0-1.6.1s-1 .2-1.4.4c-.5.2-.9.4-1.3.7-.4.3-.8.6-1.2 1-.7.7-1.4 1.4-1.9 2.3-.5.9-1 1.8-1.4 2.9-.4 1-.7 2.2-1 3.4-.3 1.2-.6 2.5-.8 3.8-.3 1.3-.5 2.6-.7 3.8-.2 1.2-.3 2.4-.3 3.4 0 1.1 0 2 .2 2.9.2.9.5 1.7.9 2.3.3.4.6.7.9 1 .3.3.7.5 1.1.7.4.2.9.3 1.3.4.5.1 1 .1 1.6.1.6 0 1.1-.1 1.6-.2s1-.3 1.5-.4c.5-.2.9-.4 1.4-.7.4-.3.8-.6 1.2-1 .7-.7 1.3-1.5 1.9-2.3.5-.9 1-1.9 1.3-2.9l.6-1.8c.2-.7.4-1.4.6-2.2.2-1.1.5-2.2.7-3.3.1-.6.2-1.2.3-1.7l.3-2c.2-1.2.3-2.3.3-3.3s0-2-.2-2.8c-.2-.9-.5-1.6-.9-2.3-.4-.5-.7-.9-1-1.1z"/>
+    <path class="st1" d="M179.4 56.3c-.5.1-1 .2-1.5.4s-.9.4-1.4.7c-.4.3-.9.6-1.3 1-.8.7-1.4 1.5-2 2.4-.6.9-1 1.9-1.4 3-.4 1.1-.7 2.3-1.1 3.5-.3 1.2-.6 2.6-.8 4-.2.8-1.5 8.8-2.6 15.2l-1.5 8.4s0 .2-.1.5c0 .2-.1.3-.1.5-.1.7-.2 1.3-.3 1.9 0 .3-.1.5-.1.7V99.3a6.79 6.79 0 0 0 .8 3.8c.2.3.5.6.7.8l.9.6c.3.2.7.3 1.1.4h.2l-3 9.5h-.9c-1.1 0-2.1-.2-3.1-.4-.9-.2-1.8-.5-2.6-.9-.1-.1-.3-.2-.4-.3-.5-.3-1.1-.6-1.6-.9-.7-.5-1.4-1.1-1.9-1.8-.8-1.1-1.4-2.3-1.8-3.6-.5.8-1.1 1.7-1.7 2.5-.3.3-.6.7-.9 1l-.2.2c-.2.1-.3.3-.5.4-.2.1-.3.3-.5.4a14.3 14.3 0 0 1-7.2 3.2c-1 .1-2.1.2-3.3.1-1.1 0-2.1-.2-3.1-.4s-1.9-.5-2.8-.9c-.9-.4-1.6-.9-2.3-1.4-.7-.5-1.3-1.1-1.8-1.8-.9-1.2-1.4-2.6-1.8-4.1-.3-1.5-.4-3.1-.4-4.8.1-1.7.3-3.4.5-5.2.3-1.7.6-3.5 1-5.2.3-1.7.7-3.4 1.2-5.1.4-1.7.9-3.4 1.6-5.1.6-1.6 1.4-3.2 2.3-4.6.9-1.4 2-2.7 3.3-3.7.7-.6 1.5-1.1 2.4-1.6.9-.4 1.8-.8 2.8-1.1 1-.3 2-.5 3-.6 1-.1 2.1-.2 3.1-.1 1.1.1 2.1.2 3 .4.9.2 1.8.5 2.6.9s1.5.9 2.2 1.5c.6.5 1.1 1.2 1.6 1.9l.3-1.9c.3-1.6.7-3.3 1.1-5.1.4-1.8.8-3.5 1.3-5.1.5-1.6 1-3.1 1.5-4.5.2-.5.4-.9.6-1.4.1-.1.1-.3.3-.6 0 0 0-.1.1-.1.1-.2.2-.3.3-.5.2-.4.5-.8.7-1.2.5-.7 1-1.4 1.6-2 1.9-2 4.6-4.2 8.5-4.9A92.9 92.9 0 0 0 93.6 0C42-.1 0 41.8 0 93.4c0 15 3.5 29.2 9.8 41.8a9.6 9.6 0 0 0 4.6-4.1l.1-.1.1-.1c.5-.9 1-1.8 1.4-2.8.4-1 .7-2.1 1-3.3 0-.2 7.1-38.8 7.6-41.1h-6.2l3-10.3h4.9l.5-2.7c.1-.4.1-.7.2-1.1l.2-.9c.3-1.6.6-3.5.9-4.8.3-1.1.5-2 .8-2.8a22 22 0 0 1 1.3-3.4c.7-1.6 1.5-3 2.5-4.3 1-1.4 2.1-2.6 3.4-3.7.9-.8 2-1.6 3.1-2.3 1.2-.7 2.4-1.4 3.7-1.9 1.4-.6 2.9-1 4.4-1.3 1.6-.3 3.3-.5 5-.5h.2c1.7 0 3.3.2 4.7.5.6.1 1.1.3 1.6.4h.1l-3.4 10.9-.1-.1c-.1 0-.1-.1-.2-.1-.5-.2-1.1-.4-1.7-.6-.6-.1-1.3-.2-2-.2h-.1c-.7 0-1.5.1-2.2.2-.6.1-1.2.3-1.9.6h-.1-.1c-.5.2-.9.4-1.4.7-.4.3-.9.6-1.3.9-.7.6-1.4 1.3-1.9 2.2-.5.8-1 1.7-1.3 2.8-.3.9-.7 2-.9 3.3 0 .1-.2 1.1-.3 1.9-.1.7-.2 1.3-.3 1.4l-.7 4.9h7.4l-3.1 10.3h-6.1l-5.6 31.1-1.4 7.6c-.3 1.8-.6 3.3-1.1 4.8-.5 2-1.1 3.7-1.8 5.2-.7 1.6-1.6 3.1-2.6 4.4-1 1.4-2.2 2.6-3.5 3.8-1 .9-2 1.7-3.1 2.3-.9.6-1.9 1.1-3 1.6A93.3 93.3 0 0 0 93.4 187c51.6.1 93.6-41.8 93.6-93.4.1-13.2-2.7-25.8-7.6-37.3zM84.1 85.9c-.1 1.6-.4 3.4-.7 5.4-.3 2-.7 3.8-1.1 5.5-.4 1.7-.9 3.2-1.6 4.6-.6 1.4-1.3 2.7-2.2 3.9-.9 1.2-1.9 2.3-3 3.4-.8.7-1.7 1.4-2.8 2.1a23.43 23.43 0 0 1-7.4 3.1c-1.5.3-3 .5-4.7.5-1.7 0-3.2-.1-4.5-.4-1.3-.3-2.6-.7-3.6-1.2-1.1-.5-2-1.1-2.8-1.7-.8-.7-1.5-1.4-2-2.1-.8-1.1-1.4-2.2-1.9-3.4-.4-1.2-.7-2.5-.8-3.9-.1-1.4-.1-3 .1-4.6.2-1.7.4-3.5.8-5.6.4-2 .8-3.9 1.3-5.5.5-1.7 1-3.2 1.7-4.6.6-1.4 1.4-2.7 2.3-3.8.9-1.2 1.9-2.3 3.1-3.3.8-.7 1.7-1.4 2.8-2 1-.6 2.1-1.2 3.4-1.7a21.9 21.9 0 0 1 8.6-1.6c1.6 0 3.1.2 4.4.5 1.3.3 2.5.7 3.5 1.2s1.9 1.1 2.7 1.7c.8.6 1.4 1.3 2 2 .8 1 1.4 2.1 1.9 3.3.4 1.2.7 2.4.8 3.8-.2 1.3-.2 2.8-.3 4.4zm41.5 0c-.1 1.6-.4 3.4-.7 5.4-.3 2-.7 3.8-1.1 5.5-.4 1.7-1 3.2-1.6 4.6-.6 1.4-1.3 2.7-2.2 3.9-.9 1.2-1.9 2.3-3 3.4-.8.7-1.7 1.4-2.8 2.1a23.43 23.43 0 0 1-7.4 3.1c-1.5.3-3 .5-4.7.5-1.7 0-3.2-.1-4.5-.4-1.4-.3-2.6-.7-3.6-1.2-1.1-.5-2-1.1-2.8-1.7-.8-.7-1.5-1.4-2-2.1-.8-1.1-1.4-2.2-1.9-3.4-.4-1.2-.7-2.5-.8-3.9-.1-1.4-.1-3 .1-4.7.2-1.7.4-3.5.8-5.6.4-2 .8-3.9 1.3-5.5.5-1.7 1-3.2 1.7-4.6.7-1.4 1.4-2.7 2.3-3.8.9-1.2 1.9-2.3 3.1-3.3.8-.7 1.7-1.4 2.8-2 1-.6 2.1-1.2 3.4-1.7 1.2-.5 2.5-.9 4-1.1 1.4-.3 2.9-.4 4.6-.4 1.6 0 3.1.2 4.4.5 1.3.3 2.5.7 3.5 1.2s1.9 1.1 2.7 1.7c.8.6 1.4 1.3 2 2 .8 1 1.4 2.1 1.9 3.3.4 1.2.7 2.4.8 3.8-.2 1.3-.2 2.8-.3 4.4z"/>
+    <g>
+        <path class="st0" d="M59.5 137.9v-6.7c0-1.5-.9-2-1.8-2s-1.8.5-1.8 2v6.7h-2.8v-11h2.7v1c.7-.8 1.7-1.1 2.8-1.1 1.1 0 2 .4 2.6 1 .9.9 1.1 1.9 1.1 3.1v7h-2.8zM69.9 133.2c0 1.4.9 2.5 2.4 2.5 1.2 0 1.8-.3 2.5-1l1.7 1.6a5.27 5.27 0 0 1-4.2 1.7c-2.6 0-5.1-1.2-5.1-5.6 0-3.6 1.9-5.6 4.8-5.6 3.1 0 4.8 2.2 4.8 5.3v1.2h-6.9zm3.9-3c-.3-.7-.9-1.1-1.8-1.1s-1.5.5-1.8 1.1c-.2.4-.2.7-.3 1.2h4.2c0-.5-.1-.8-.3-1.2zM85.3 137.9c-2.2 0-3.2-1.6-3.2-3.2v-5.5h-1.2v-2.1h1.2v-3.3h2.8v3.3h1.9v2.1h-1.9v5.3c0 .6.3 1 1 1h1v2.3h-1.6zM103.6 137.9h-2.3L99 131l-2.3 6.9h-2.3l-3.4-11h3l1.8 6.8 2.2-6.8h2l2.3 6.8 1.8-6.8h2.9l-3.4 11zM119 136.7c-.7.7-1.8 1.4-3.4 1.4-1.6 0-2.7-.6-3.4-1.4-1-1-1.2-2.3-1.2-4.3s.3-3.2 1.2-4.3c.7-.7 1.8-1.4 3.4-1.4 1.6 0 2.7.6 3.4 1.4 1 1 1.2 2.3 1.2 4.3s-.2 3.2-1.2 4.3zm-2.1-7c-.3-.3-.7-.5-1.3-.5-.6 0-1 .2-1.3.5-.6.6-.6 1.5-.6 2.7 0 1.1.1 2.1.6 2.7.3.3.7.5 1.3.5.5 0 1-.2 1.3-.5.6-.6.6-1.5.6-2.7 0-1.2-.1-2.1-.6-2.7zM130.9 129.9c-.4-.4-.8-.7-1.5-.7-.8 0-1.8.6-1.8 2v6.6h-2.7v-11h2.7v1.1c.5-.6 1.6-1.2 2.8-1.2 1.1 0 1.8.3 2.6 1l-2.1 2.2zM143.9 137.9l-2.7-4.6-1.2 1.3v3.3h-2.8v-15.1h2.8v8.5l3.7-4.5h3.3l-3.9 4.4 4.2 6.6h-3.4z"/>
+    </g>
+</symbol>
+
+    <use xlink:href="#icon-brand-logo"></use>
+  </svg>
+
+  
+
+  </a>
+
+</div>
+</div>
+
+  
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--flyOutNavItem" data-animate-menu="animate">
+  <div class="o-Header__m-NavItem  " data-type="menu-action" data-dropdown="true">
+      
+        
+          <a class="o-Header__a-NavLink" href="//www.foodnetwork.com/recipes">Recipes</a>
+          
+        
+        
+      
+      
+      <div data-type="dropdown-menu" class="o-Header__m-DropdownMenu  o-Header__m-DropdownMenu--FlyOut " data-module="flyout-menu">
+        <script type="text/x-config">{"horizontalScroll":{"deferInit":true}}</script>
+        <div class="m-DropdownMenu__m-Body" data-horizontal-scroll>
+          
+          
+          
+          <div class="m-DropdownMenu__m-TextPromo " data-animate-item>
+            
+            
+            <ul>
+              <li><a href="//www.foodnetwork.com/holidays-and-parties/packages/labor-day" target="_self">Labor Day</a>
+              </li>
+            
+              <li><a href="//www.foodnetwork.com/recipes/photos/30-minute-dinner-recipes" target="_self">Quick Dinners</a>
+              </li>
+            
+              <li><a href="//www.foodnetwork.com/grilling" target="_self">Summer Grilling</a>
+              </li>
+            
+              <li><a href="//www.foodnetwork.com/recipes/packages/recipes-for-kids/back-to-school" target="_self">Back to School</a>
+              </li>
+            
+              <li><a href="//www.foodnetwork.com/healthy" target="_self">Healthy</a>
+              </li>
+            </ul>
+            <div>
+              
+  <a class="m-DropdownMenu__a-Cta" href="//www.foodnetwork.com/recipes">See All Recipes</a>
+
+            </div>
+          </div>
+          
+          <div class="m-DropdownMenu__m-MediaGroup">
+            <div class="m-DropdownMenu__m-Container">
+              
+              
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 1, "cardType": "Recipe of the Day"}'>
+                  <span class="m-MediaPromo__a-Label">Recipe of the Day</span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Recipe " data-animate-item>
+                              <a href="//www.foodnetwork.com/recipes/smoked-red-pepper-dip-with-grilled-crudite-9825517" title="Smoked Red Pepper Dip with Grilled Crudite" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2021/01/25/QK407_Smoked-Red-Pepper-Dip-with-Grilled-Crudite_s4x3.jpg.rend.hgtvcom.196.196.suffix/1611594820159.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2021/01/25/QK407_Smoked-Red-Pepper-Dip-with-Grilled-Crudite_s4x3.jpg.rend.hgtvcom.196.196.suffix/1611594820159.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Smoked Red Pepper Dip with Grilled Crudite</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                        </div>
+                </div>
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 2, "cardType": "Trending Recipes"}'>
+                  <span class="m-MediaPromo__a-Label">Trending Recipes</span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Recipe " data-animate-item>
+                              <a href="//www.foodnetwork.com/recipes/bobby-flay/watermelon-strawberry-sangria-2437173" title="Watermelon-Strawberry Sangria" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2015/4/2/0/QF0402H_Watermelon-Strawberry-Sangria_s4x3.jpg.rend.hgtvcom.196.196.suffix/1427992233528.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2015/4/2/0/QF0402H_Watermelon-Strawberry-Sangria_s4x3.jpg.rend.hgtvcom.196.196.suffix/1427992233528.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Watermelon-Strawberry Sangria</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Recipe " data-animate-item>
+                              <a href="//www.foodnetwork.com/recipes/potato-chip-crusted-chicken-strips-with-honey-mustard-dipping-sauce-8068669" title="Potato Chip-Crusted Chicken Strips" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2020/01/21/QK206_potato-chip-chicken-tenders_s4x3.jpg.rend.hgtvcom.196.196.suffix/1599176992922.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2020/01/21/QK206_potato-chip-chicken-tenders_s4x3.jpg.rend.hgtvcom.196.196.suffix/1599176992922.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Potato Chip-Crusted Chicken Strips</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Recipe " data-animate-item>
+                              <a href="//www.foodnetwork.com/recipes/michael-symon/fettuccine-with-smoked-tomato-sauce-8875780" title="Fettuccine with Smoked Tomato Sauce" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2020/07/31/ANIE110_fettucine-with-smoked-tomato-sauce_s4x3.jpg.rend.hgtvcom.196.196.suffix/1596207926481.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2020/07/31/ANIE110_fettucine-with-smoked-tomato-sauce_s4x3.jpg.rend.hgtvcom.196.196.suffix/1596207926481.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Fettuccine with Smoked Tomato Sauce</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Recipe " data-animate-item>
+                              <a href="//www.foodnetwork.com/recipes/food-network-kitchen/bus-stop-blueberry-muffins-11398315" title="Bus Stop Blueberry Muffins" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2021/08/3/0/FN_BUS_STOP_BLUEBERRY_MUFFINS_H_f_s4x3.jpg.rend.hgtvcom.196.196.suffix/1628021693628.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2021/08/3/0/FN_BUS_STOP_BLUEBERRY_MUFFINS_H_f_s4x3.jpg.rend.hgtvcom.196.196.suffix/1628021693628.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Bus Stop Blueberry Muffins</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                        </div>
+                </div>
+              
+            </div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+  
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--flyOutNavItem" data-animate-menu="animate">
+  <div class="o-Header__m-NavItem  " data-type="menu-action" data-dropdown="true">
+      
+        
+          <a class="o-Header__a-NavLink" href="//www.foodnetwork.com/shows">Shows</a>
+          
+        
+        
+      
+      
+      <div data-type="dropdown-menu" class="o-Header__m-DropdownMenu  o-Header__m-DropdownMenu--FlyOut " data-module="flyout-menu">
+        <script type="text/x-config">{"horizontalScroll":{"deferInit":true}}</script>
+        <div class="m-DropdownMenu__m-Body" data-horizontal-scroll>
+          
+          
+          
+          
+          
+    
+
+    <div class="m-DropdownMenu__m-SchedulePromo m-SchedulePromo" data-module="on-tv-full-width"> 
+      <script type="text/x-config">
+      {
+        "onTonightTimeGMT":"1:0",
+        "isWhatsHotOn":false,
+        "removeHiddenElements": false,
+        "parentClass":"m-SchedulePromo",
+        "display": {
+          "upNext": false,
+          "watchLive": false
+        }
+      }
+      </script>
+      <span class="m-SchedulePromo__a-Label">TV Schedule</span>
+      
+  <a class="m-SchedulePromo__a-Cta" href="//www.foodnetwork.com/shows/tv-schedule">See TV Schedule</a>
+
+        <div class="m-SchedulePromo__m-TextWrap m-TextWrap">
+          
+          <ul>
+            
+              
+              <li data-time="2021-09-03T12:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">8am | 7c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T12:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">8:30am | 7:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T13:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">9am | 8c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T13:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">9:30am | 8:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T14:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">10am | 9c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T14:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">10:30am | 9:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T15:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">11am | 10c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T15:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">11:30am | 10:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T16:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">12pm | 11c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T16:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">12:30pm | 11:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T17:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">1pm | 12c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T17:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">1:30pm | 12:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T18:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">2pm | 1c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T18:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">2:30pm | 1:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T19:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">3pm | 2c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T19:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">3:30pm | 2:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T20:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">4pm | 3c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T20:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">4:30pm | 3:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T21:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">5pm | 4c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T22:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">6pm | 5c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T22:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">6:30pm | 5:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T23:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">7pm | 6c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-03T23:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">7:30pm | 6:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T00:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">8pm | 7c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T00:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">8:30pm | 7:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T01:00:00.000Z" style="display: none;">
+                <h6 class="m-SchedulePromo__a-SubHeadline">
+                    On Tonight
+                </h6>
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">9pm | 8c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T01:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">9:30pm | 8:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T02:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">10pm | 9c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T02:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">10:30pm | 9:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T03:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">11pm | 10c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T03:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">11:30pm | 10:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T04:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">12am | 11c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T04:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">12:30am | 11:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T05:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">1am | 12c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T05:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">1:30am | 12:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T06:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">2am | 1c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T06:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">2:30am | 1:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T07:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">3am | 2c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T07:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">3:30am | 2:30c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T08:00:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">4am | 3c</div>
+
+              </li>
+            
+              
+              <li data-time="2021-09-04T08:30:00.000Z" style="display: none;">
+                
+                
+  <h4 class="m-SchedulePromo__a-Headline">
+    <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives">
+      <span class="m-SchedulePromo__a-HeadlineText">Diners, Drive-Ins and Dives</span>
+      
+    </a>
+  </h4>
+
+                
+  <div class="m-SchedulePromo__a-Description">4:30am | 3:30c</div>
+
+              </li>
+            
+          </ul>
+          <div>
+            
+  <a class="m-DropdownMenu__a-Cta" href="//www.foodnetwork.com/shows">See All Shows</a>
+
+          </div>
+        </div>
+      
+    </div>
+
+
+          <div class="m-DropdownMenu__m-MediaGroup">
+            <div class="m-DropdownMenu__m-Container">
+              
+              
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 1, "cardType": "Popular Shows"}'>
+                  <span class="m-MediaPromo__a-Label">Popular Shows</span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Show " data-animate-item>
+                              <a href="//www.foodnetwork.com/shows/halloween-baking-championship" title="Halloween Baking Championship" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/h/halloween-baking-championship/fnk-app-show-chip-composite-v2-halloween-baking-championship.jpg.rend.hgtvcom.126.196.suffix/1570457500707.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/h/halloween-baking-championship/fnk-app-show-chip-composite-v2-halloween-baking-championship.jpg.rend.hgtvcom.126.196.suffix/1570457500707.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Halloween Baking Championship</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Show " data-animate-item>
+                              <a href="//www.foodnetwork.com/shows/buddy-vs-duff" title="Buddy vs. Duff" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/b/buddy-vs-duff/fnk-app-show-chip-composite-buddy-vs-duff.jpg.rend.hgtvcom.126.196.suffix/1580237096079.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/b/buddy-vs-duff/fnk-app-show-chip-composite-buddy-vs-duff.jpg.rend.hgtvcom.126.196.suffix/1580237096079.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Buddy vs. Duff</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Show " data-animate-item>
+                              <a href="//www.foodnetwork.com/shows/diners-drive-ins-and-dives" title="Diners, Drive-Ins and Dives" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/d/diners-drive-ins-and-dives/fnk-app-show-chip-composite-diners-drive-ins-dives.jpg.rend.hgtvcom.126.196.suffix/1566856919197.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/d/diners-drive-ins-and-dives/fnk-app-show-chip-composite-diners-drive-ins-dives.jpg.rend.hgtvcom.126.196.suffix/1566856919197.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Diners, Drive-Ins and Dives</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                        </div>
+                </div>
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 2, "cardType": "In the Kitchen"}'>
+                  <span class="m-MediaPromo__a-Label">In the Kitchen</span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Show " data-animate-item>
+                              <a href="//www.foodnetwork.com/shows/the-pioneer-woman" title="The Pioneer Woman" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/t/the-pioneer-woman/fnk-app-show-chip-composite-pioneer-woman.jpg.rend.hgtvcom.126.196.suffix/1566937458517.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/t/the-pioneer-woman/fnk-app-show-chip-composite-pioneer-woman.jpg.rend.hgtvcom.126.196.suffix/1566937458517.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">The Pioneer Woman</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Show " data-animate-item>
+                              <a href="//www.foodnetwork.com/shows/the-kitchen" title="The Kitchen" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/t/the-kitchen/fnk-app-show-chip-composite-the-kitchen.jpg.rend.hgtvcom.126.196.suffix/1566937754934.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/t/the-kitchen/fnk-app-show-chip-composite-the-kitchen.jpg.rend.hgtvcom.126.196.suffix/1566937754934.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">The Kitchen</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Show " data-animate-item>
+                              <a href="//www.foodnetwork.com/shows/girl-meets-farm" title="Girl Meets Farm" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/g/girl-meets-farm/fnk-app-show-chip-composite-girl-meets-farm.jpg.rend.hgtvcom.126.196.suffix/1566857958556.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/shows/g/girl-meets-farm/fnk-app-show-chip-composite-girl-meets-farm.jpg.rend.hgtvcom.126.196.suffix/1566857958556.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Girl Meets Farm</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                        </div>
+                </div>
+              
+            </div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+  
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--flyOutNavItem" data-animate-menu="animate">
+  <div class="o-Header__m-NavItem  " data-type="menu-action" data-dropdown="true">
+      
+        
+          <a class="o-Header__a-NavLink" href="//www.foodnetwork.com/profiles">Chefs</a>
+          
+        
+        
+      
+      
+      <div data-type="dropdown-menu" class="o-Header__m-DropdownMenu  o-Header__m-DropdownMenu--FlyOut " data-module="flyout-menu">
+        <script type="text/x-config">{"horizontalScroll":{"deferInit":true}}</script>
+        <div class="m-DropdownMenu__m-Body" data-horizontal-scroll>
+          
+          
+          
+          
+          
+          <div class="m-DropdownMenu__m-MediaGroup">
+            <div class="m-DropdownMenu__m-Container">
+              
+              
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 1, "cardType": "Chefs &amp; Hosts"}'>
+                  <span class="m-MediaPromo__a-Label">Chefs &amp; Hosts</span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Profile " data-animate-item>
+                              <a href="//www.foodnetwork.com/profiles/talent/kardea-brown" title="Kardea Brown" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/plus/profiles/kardea-brown/FN-TalentAvatar_Kardea-Brown_s1x1.jpg.rend.hgtvcom.196.196.suffix/1583778811266.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/plus/profiles/kardea-brown/FN-TalentAvatar_Kardea-Brown_s1x1.jpg.rend.hgtvcom.196.196.suffix/1583778811266.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Kardea Brown</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Profile " data-animate-item>
+                              <a href="//www.foodnetwork.com/profiles/talent/ree-drummond" title="Ree Drummond" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/ree-drummond/FN-TalentAvatar-Ree-Drummond-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174321860.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/ree-drummond/FN-TalentAvatar-Ree-Drummond-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174321860.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Ree Drummond</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Profile " data-animate-item>
+                              <a href="//www.foodnetwork.com/profiles/talent/ina-garten" title="Ina Garten" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/ina-garten/FN-TalentAvatar-Ina-Garten-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174352136.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/ina-garten/FN-TalentAvatar-Ina-Garten-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174352136.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Ina Garten</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Profile " data-animate-item>
+                              <a href="//www.foodnetwork.com/profiles/talent/sunny-anderson" title="Sunny Anderson" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/sunny-anderson/FN-TalentAvatar-Sunny-Anderson-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174628523.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/sunny-anderson/FN-TalentAvatar-Sunny-Anderson-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174628523.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Sunny Anderson</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Profile " data-animate-item>
+                              <a href="//www.foodnetwork.com/profiles/talent/bobby-flay" title="Bobby Flay" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/bobby-flay/FN-TalentAvatar-Bobby-Flay-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174427795.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/bobby-flay/FN-TalentAvatar-Bobby-Flay-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174427795.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Bobby Flay</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Profile " data-animate-item>
+                              <a href="//www.foodnetwork.com/profiles/talent/valerie-bertinelli" title="Valerie Bertinelli" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/valerie-bertinelli/FN-TalentAvatar-Valerie-Bertinelli-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174273944.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/valerie-bertinelli/FN-TalentAvatar-Valerie-Bertinelli-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174273944.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Valerie Bertinelli</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Profile " data-animate-item>
+                              <a href="//www.foodnetwork.com/profiles/talent/guy-fieri" title="Guy Fieri" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/guy-fieri/FN-TalentAvatar-Guy-Fieri-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174403377.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/guy-fieri/FN-TalentAvatar-Guy-Fieri-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174403377.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Guy Fieri</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Profile " data-animate-item>
+                              <a href="//www.foodnetwork.com/profiles/talent/giada-de-laurentiis" title="Giada De Laurentiis" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/giada-de-laurentiis/FN-TalentAvatar-giada-delaurentiis-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174374472.jpeg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/giada-de-laurentiis/FN-TalentAvatar-giada-delaurentiis-colorblock.jpg.rend.hgtvcom.196.196.suffix/1531174374472.jpeg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Giada De Laurentiis</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Profile " data-animate-item>
+                              <a href="//www.foodnetwork.com/profiles/talent/molly-yeh" title="Molly Yeh" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/plus/unsized/avatars/FN-TalentAvatar-Molly-Yeh.jpg"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/plus/unsized/avatars/FN-TalentAvatar-Molly-Yeh.jpg"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Molly Yeh</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                        </div>
+                </div>
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 2, "cardType": ""}'>
+                  <span class="m-MediaPromo__a-Label"></span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                        </div>
+                </div>
+              
+            </div>
+            <div class="m-DropdownMenu__a-Cta a-Cta" data-animate-item>
+              
+  <a class="m-DropdownMenu__a-Cta" href="//www.foodnetwork.com/profiles">See All Chefs</a>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--flyOutNavItem" data-animate-menu="animate">
+  <div class="o-Header__m-NavItem is-Free premium-flyout" data-type="menu-action" data-dropdown="true">
+      
+        
+          <a class="o-Header__a-NavLink" href="https://kitchen.foodnetwork.com/#/get-cooking">Food Network Kitchen</a>
+          <div class="o-Header__m-NavItemLabel">
+            <span>Premium
+              
+                <svg class="o-Header__a-Icon">
+                  <symbol id="icon-fn-sparkle" viewBox="0 0 11.29 13.67">
+    <defs>
+        <style>.cls-1{fill:#fff;}.cls-1,.cls-3{fill-rule:evenodd;}.cls-2{opacity:0.8;}.cls-3{fill:#89caf7;}.cls-4{mask:url(#mask);}.cls-5{opacity:0.9;}.cls-6{mask:url(#mask-2-2);}</style>
+        <mask height="8.68" id="mask" maskUnits="userSpaceOnUse" width="6.33" x="4.95" y="4.99">
+            <g transform="translate(0.73 0.73)">
+                <g id="mask-2">
+                    <path class="cls-1" d="M4.86,8.6c1.4,0,2.53,1.56,2.53,3.5h0c0-1.94,1.13-3.5,2.53-3.5h0C8.52,8.6,7.39,7,7.39,5.1h0C7.39,7,6.26,8.6,4.86,8.6Z" id="path-1"/>
+                </g>
+            </g>
+        </mask>
+        <mask height="10.85" id="mask-2-2" maskUnits="userSpaceOnUse" width="7.91" x="0" y="0">
+            <g transform="translate(0.73 0.73)">
+                <g id="mask-4">
+                    <path class="cls-1" d="M.07,4.69c1.74,0,3.16,2,3.16,4.38h0c0-2.42,1.41-4.38,3.16-4.38h0C4.64,4.69,3.23,2.74,3.23.32h0c0,2.42-1.42,4.37-3.16,4.37Z" id="path-3"/>
+                </g>
+            </g>
+        </mask>
+    </defs>
+    <g id="sparkle">
+        <g id="Group-46-Copy">
+            <g class="cls-2" id="Group-176-Copy-6">
+                <g id="Clip-175">
+                    <path class="cls-3" d="M4.86,8.6c1.4,0,2.53,1.56,2.53,3.5h0c0-1.94,1.13-3.5,2.53-3.5h0C8.52,8.6,7.39,7,7.39,5.1h0C7.39,7,6.26,8.6,4.86,8.6Z" data-name="path-1" id="path-1-2" transform="translate(0.73 0.73)"/>
+                </g>
+            </g>
+            <g data-name="Clip-175" id="Clip-175-2">
+                <path class="cls-3" d="M.07,4.69c1.74,0,3.16,2,3.16,4.38h0c0-2.42,1.41-4.38,3.16-4.38h0C4.64,4.69,3.23,2.74,3.23.32h0c0,2.42-1.42,4.37-3.16,4.37Z" data-name="path-3" id="path-3-2" transform="translate(0.73 0.73)"/>
+            </g>
+        </g>
+    </g>
+</symbol>
+
+                  <use xlink:href="#icon-fn-sparkle"></use>
+                </svg>
+              
+            </span>
+          </div>
+        
+        
+      
+      
+      <div data-type="dropdown-menu" class="o-Header__m-DropdownMenu  o-Header__m-DropdownMenu--FlyOut has-BrandPromo" data-module="flyout-menu">
+        <script type="text/x-config">{"horizontalScroll":{"deferInit":true}}</script>
+        <div class="m-DropdownMenu__m-Body" data-horizontal-scroll>
+          
+          
+            <div class="m-DropdownMenu__m-BrandPromo">
+              <div class="m-DropdownMenu__m-Container">
+                
+                <div class="m-BrandPromo__a-Logo">
+                  
+                    <svg class="o-Header__a-Icon">
+                      <symbol id="icon-fnk-logo" viewBox="0 0 310 86">
+    <style type="text/css">
+	.str0{filter:url(#Adobe_OpacityMaskFilter);}
+	.str1{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.str2{mask:url(#fnk-logo-b_1_);fill-rule:evenodd;clip-rule:evenodd;fill:#231F20;}
+	.str3{fill-rule:evenodd;clip-rule:evenodd;fill:#231F20;}
+	.str4{filter:url(#Adobe_OpacityMaskFilter_1_);}
+	.str5{mask:url(#fnk-logo-d_1_);fill-rule:evenodd;clip-rule:evenodd;fill:#231F20;}
+	.str6{fill-rule:evenodd;clip-rule:evenodd;fill:#E6003D;}
+	.str7{filter:url(#Adobe_OpacityMaskFilter_2_);}
+	.str8{mask:url(#fnk-logo-f_1_);fill-rule:evenodd;clip-rule:evenodd;fill:#E6003D;}
+	.str9{filter:url(#Adobe_OpacityMaskFilter_3_);}
+	.str10{mask:url(#fnk-logo-h_1_);fill-rule:evenodd;clip-rule:evenodd;fill:#231F20;}
+</style>
+    <defs>
+	<filter filterUnits="userSpaceOnUse" height="45.9" id="Adobe_OpacityMaskFilter" width="44.2" x="105.6" y="39">
+		<feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+	</filter>
+</defs>
+    <mask height="45.9" id="fnk-logo-b_1_" maskUnits="userSpaceOnUse" width="44.2" x="105.6" y="39">
+	<g class="str0">
+		<polygon class="str1" id="fnk-logo-a_1_" points="105.6,39 149.8,39 149.8,84.9 105.6,84.9   "/>
+	</g>
+</mask>
+    <path class="str2" d="M129.4,84.9c-13.7,0-23.8-9.1-23.8-22.8c0-13.2,8.8-23.2,22.7-23.2c9.2,0,19.4,4.3,21.4,16.5l-11.2,3.6  c-0.8-5.4-5.4-8.3-10.1-8.3c-5.1,0-10.1,3.4-10.1,10.6c0,7,3.6,11.6,11.1,11.6c3.8,0,8.4-2,10.1-4.6l10.4,4.6  C146,80.9,138,84.9,129.4,84.9"/>
+    <path class="str3" d="M183.7,39.4c9.4,0,15.5,6.5,15.5,16.6v27.3h-12.5V58.2c0-4.6-3.3-7-7.2-7c-4.8,0-10.4,3.5-11.7,10.5v21.6h-12.4  V26.1h12.4l-0.1,20.3C171.8,41.7,177.9,39.4,183.7,39.4"/>
+    <defs>
+	<filter filterUnits="userSpaceOnUse" height="45.9" id="Adobe_OpacityMaskFilter_1_" width="45.1" x="203.6" y="39">
+		<feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+	</filter>
+</defs>
+    <mask height="45.9" id="fnk-logo-d_1_" maskUnits="userSpaceOnUse" width="45.1" x="203.6" y="39">
+	<g class="str4">
+		<polygon class="str1" id="fnk-logo-c_1_" points="203.6,39 248.7,39 248.7,84.9 203.6,84.9   "/>
+	</g>
+</mask>
+    <path class="str5" d="M216.3,56.6h20.6c-1.2-4.1-4.4-6.4-10.6-6.4C221.8,50.2,218,52.7,216.3,56.6 M238,68.7l8.8,5.5  C243,82,234,84.9,226.5,84.9c-13.7,0-22.9-9.1-22.9-22.8c0-14.2,9-23.2,22.7-23.2c12.4,0,22.4,8.6,22.4,20.7c0,3.3-1.1,5.8-1.1,5.8  H216c1.5,4.9,5.5,8.3,10.5,8.3C229,73.8,235.4,73.7,238,68.7"/>
+    <path class="str3" d="M281.8,39.4c9.4,0,15.5,6.5,15.5,16.6v27.3h-12.5V57.7c0-4.6-3.2-6.8-7-6.8c-4.8,0-10.6,3.6-11.9,10.7v21.6  h-12.4V40.3H265l0.9,6.2C270,41.6,276,39.4,281.8,39.4 M62.9,50.4c-2.1,0-4.2-0.3-6.2-0.8v33.6h12.4V49.7  C67.1,50.2,65,50.4,62.9,50.4 M104,52.4V41.8H92.8V26.1h-4.1c-0.5,9.5-6.2,17.6-14.3,21.6v4.6h6v13c0,12.4,4.7,18.4,14.7,18.4  c2,0,5.6-0.2,7.5-0.5V71.1c-0.9,0.2-3.7,0.3-5.1,0.3c-3.6,0-4.7-1.5-4.7-6.6V52.4H104z"/>
+    <path class="str6" d="M67.6,21.5c-0.1-0.1-0.1-0.2-0.2-0.2c-0.1-0.1-0.2-0.1-0.3-0.2c-0.1,0-0.2-0.1-0.3-0.1c-0.1,0-0.2,0-0.4,0  c-0.1,0-0.3,0-0.4,0c-0.1,0-0.2,0.1-0.3,0.1c-0.1,0-0.2,0.1-0.3,0.2c-0.1,0.1-0.2,0.1-0.3,0.2c-0.2,0.2-0.3,0.3-0.5,0.5  c-0.1,0.2-0.2,0.4-0.3,0.7c-0.1,0.2-0.2,0.5-0.2,0.8c-0.1,0.3-0.1,0.6-0.2,0.9c-0.1,0.3-0.1,0.6-0.2,0.9c0,0.3-0.1,0.6-0.1,0.8  c0,0.3,0,0.5,0.1,0.7c0,0.2,0.1,0.4,0.2,0.6c0.1,0.1,0.1,0.2,0.2,0.2c0.1,0.1,0.2,0.1,0.3,0.2c0.1,0,0.2,0.1,0.3,0.1  c0.1,0,0.2,0,0.4,0c0.1,0,0.3,0,0.4,0c0.1,0,0.2-0.1,0.4-0.1c0.1,0,0.2-0.1,0.3-0.2c0.1-0.1,0.2-0.1,0.3-0.2  c0.2-0.2,0.3-0.4,0.4-0.6c0.1-0.2,0.2-0.4,0.3-0.7c0-0.1,0.1-0.3,0.1-0.4c0-0.1,0.1-0.3,0.1-0.4c0.1-0.3,0.1-0.6,0.2-0.9  c0-0.1,0.1-0.3,0.1-0.4c0-0.2,0.1-0.3,0.1-0.5c0-0.3,0.1-0.6,0.1-0.8c0-0.2,0-0.5-0.1-0.7C67.8,21.9,67.7,21.7,67.6,21.5 M57.6,21.5  c-0.1-0.1-0.1-0.2-0.2-0.2c-0.1-0.1-0.2-0.1-0.3-0.2c-0.1,0-0.2-0.1-0.3-0.1c-0.1,0-0.2,0-0.4,0c-0.1,0-0.3,0-0.4,0  c-0.1,0-0.2,0.1-0.3,0.1c-0.1,0-0.2,0.1-0.3,0.2c-0.1,0.1-0.2,0.1-0.3,0.2c-0.2,0.2-0.3,0.3-0.5,0.5c-0.1,0.2-0.2,0.4-0.3,0.7  c-0.1,0.2-0.2,0.5-0.2,0.8c-0.1,0.3-0.1,0.6-0.2,0.9c-0.1,0.3-0.1,0.6-0.2,0.9c0,0.3-0.1,0.6-0.1,0.8c0,0.3,0,0.5,0,0.7  c0,0.2,0.1,0.4,0.2,0.6c0.1,0.1,0.1,0.2,0.2,0.2c0.1,0.1,0.2,0.1,0.3,0.2c0.1,0,0.2,0.1,0.3,0.1c0.1,0,0.2,0,0.4,0  c0.1,0,0.3,0,0.4,0c0.1,0,0.2-0.1,0.4-0.1c0.1,0,0.2-0.1,0.3-0.2c0.1-0.1,0.2-0.1,0.3-0.2c0.2-0.2,0.3-0.3,0.4-0.6  c0.1-0.2,0.2-0.4,0.3-0.7c0.1-0.1,0.1-0.3,0.1-0.4c0-0.1,0.1-0.2,0.1-0.4c0.1-0.3,0.1-0.6,0.2-0.9c0-0.1,0.1-0.3,0.1-0.4  c0-0.2,0.1-0.3,0.1-0.5c0-0.3,0.1-0.6,0.1-0.8c0-0.2,0-0.5-0.1-0.7C57.8,21.9,57.7,21.7,57.6,21.5 M77.6,21.5  c-0.1-0.1-0.1-0.2-0.2-0.2c-0.1-0.1-0.2-0.1-0.3-0.2C77,21,76.9,21,76.8,21c-0.1,0-0.2,0-0.4,0c-0.1,0-0.3,0-0.4,0  c-0.1,0-0.2,0.1-0.3,0.1c-0.1,0-0.2,0.1-0.3,0.2c-0.1,0.1-0.2,0.1-0.3,0.2c-0.2,0.2-0.3,0.3-0.5,0.6c-0.1,0.2-0.2,0.4-0.3,0.7  c-0.1,0.3-0.2,0.5-0.2,0.8c-0.1,0.3-0.1,0.6-0.2,0.9c-0.1,0.3-0.1,0.6-0.2,0.9c0,0.3-0.1,0.6-0.1,0.8c0,0.3,0,0.5,0.1,0.7  c0,0.2,0.1,0.4,0.2,0.6c0.1,0.1,0.1,0.2,0.2,0.2c0.1,0.1,0.2,0.1,0.3,0.2c0.1,0,0.2,0.1,0.3,0.1c0.1,0,0.2,0,0.4,0  c0.1,0,0.3,0,0.4,0c0.1,0,0.2-0.1,0.4-0.1c0.1,0,0.2-0.1,0.3-0.2c0.1-0.1,0.2-0.2,0.3-0.2c0.2-0.2,0.3-0.4,0.5-0.6  c0.1-0.2,0.2-0.5,0.3-0.7c0.1-0.1,0.1-0.3,0.1-0.4c0.1-0.2,0.1-0.3,0.1-0.5c0.1-0.3,0.1-0.5,0.2-0.8c0-0.1,0-0.3,0.1-0.4  c0-0.2,0.1-0.3,0.1-0.5c0-0.3,0.1-0.6,0.1-0.8c0-0.3,0-0.5-0.1-0.7C77.8,21.8,77.7,21.7,77.6,21.5"/>
+    <defs>
+	<filter filterUnits="userSpaceOnUse" height="45.3" id="Adobe_OpacityMaskFilter_2_" width="45.3" x="40.1" y="2.3">
+		<feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+	</filter>
+</defs>
+    <mask height="45.3" id="fnk-logo-f_1_" maskUnits="userSpaceOnUse" width="45.3" x="40.1" y="2.3">
+	<g class="str7">
+		<polygon class="str1" id="fnk-logo-e_1_" points="40.1,2.3 85.4,2.3 85.4,47.6 40.1,47.6   "/>
+	</g>
+</mask>
+    <path class="str8" d="M70.5,23.1c0,0.4-0.1,0.8-0.2,1.3c-0.1,0.5-0.2,0.9-0.3,1.3c-0.1,0.4-0.2,0.8-0.4,1.1c-0.1,0.3-0.3,0.6-0.5,0.9  c-0.2,0.3-0.5,0.6-0.7,0.8c-0.2,0.2-0.4,0.4-0.7,0.5c-0.2,0.2-0.5,0.3-0.8,0.4c-0.3,0.1-0.6,0.2-1,0.3c-0.4,0.1-0.7,0.1-1.1,0.1  c-0.4,0-0.8,0-1.1-0.1c-0.3-0.1-0.6-0.2-0.9-0.3c-0.3-0.1-0.5-0.3-0.7-0.4c-0.2-0.2-0.4-0.3-0.5-0.5c-0.2-0.3-0.3-0.5-0.5-0.8  c-0.1-0.3-0.2-0.6-0.2-0.9c0-0.3,0-0.7,0-1.1c0-0.4,0.1-0.9,0.2-1.4c0.1-0.5,0.2-0.9,0.3-1.3c0.1-0.4,0.2-0.8,0.4-1.1  c0.2-0.3,0.3-0.6,0.6-0.9c0.2-0.3,0.5-0.5,0.8-0.8c0.2-0.2,0.4-0.3,0.7-0.5c0.2-0.2,0.5-0.3,0.8-0.4c0.3-0.1,0.6-0.2,1-0.3  C66,19,66.4,19,66.8,19c0.4,0,0.7,0,1.1,0.1c0.3,0.1,0.6,0.2,0.9,0.3c0.3,0.1,0.5,0.3,0.7,0.4c0.2,0.2,0.3,0.3,0.5,0.5  c0.2,0.2,0.3,0.5,0.4,0.8c0.1,0.3,0.2,0.6,0.2,0.9C70.5,22.4,70.5,22.7,70.5,23.1L70.5,23.1z M60.5,23.1c0,0.4-0.1,0.8-0.2,1.3  c-0.1,0.5-0.2,0.9-0.3,1.3c-0.1,0.4-0.2,0.8-0.4,1.1c-0.1,0.3-0.3,0.6-0.5,0.9c-0.2,0.3-0.5,0.6-0.7,0.8c-0.2,0.2-0.4,0.4-0.7,0.5  c-0.2,0.2-0.5,0.3-0.8,0.4c-0.3,0.1-0.6,0.2-1,0.3c-0.4,0.1-0.7,0.1-1.1,0.1c-0.4,0-0.8,0-1.1-0.1c-0.3-0.1-0.6-0.2-0.9-0.3  c-0.3-0.1-0.5-0.3-0.7-0.4c-0.2-0.2-0.4-0.3-0.5-0.5c-0.2-0.3-0.3-0.5-0.5-0.8c-0.1-0.3-0.2-0.6-0.2-0.9c0-0.3,0-0.7,0-1.1  c0-0.4,0.1-0.9,0.2-1.4c0.1-0.5,0.2-0.9,0.3-1.3c0.1-0.4,0.2-0.8,0.4-1.1c0.2-0.3,0.3-0.6,0.6-0.9c0.2-0.3,0.5-0.5,0.8-0.8  c0.2-0.2,0.4-0.3,0.7-0.5c0.2-0.2,0.5-0.3,0.8-0.4c0.3-0.1,0.6-0.2,1-0.3C56,19,56.4,19,56.8,19c0.4,0,0.7,0,1.1,0.1  c0.3,0.1,0.6,0.2,0.9,0.3c0.3,0.1,0.5,0.3,0.7,0.4c0.2,0.2,0.3,0.3,0.5,0.5c0.2,0.2,0.3,0.5,0.4,0.8c0.1,0.3,0.2,0.6,0.2,0.9  C60.5,22.4,60.5,22.7,60.5,23.1L60.5,23.1z M83.5,16c-0.1,0-0.2,0.1-0.4,0.1c-0.1,0-0.2,0.1-0.3,0.2c-0.1,0.1-0.2,0.2-0.3,0.2  c-0.2,0.2-0.3,0.4-0.5,0.6c-0.1,0.2-0.2,0.5-0.3,0.7c-0.1,0.3-0.2,0.5-0.3,0.9c-0.1,0.3-0.1,0.6-0.2,1c0,0.2-0.4,2.1-0.6,3.7  c0,0-0.4,2-0.4,2s0,0.1,0,0.1c0,0,0,0.1,0,0.1c0,0.2,0,0.3-0.1,0.5c0,0.1,0,0.1,0,0.2c0,0.1,0,0.2,0,0.2c0,0,0,0,0,0  c0,0.2,0,0.3,0,0.4c0,0.2,0.1,0.3,0.2,0.5c0.1,0.1,0.1,0.1,0.2,0.2c0.1,0.1,0.1,0.1,0.2,0.1c0.1,0,0.2,0.1,0.3,0.1c0,0,0,0,0,0  L80.3,30c-0.1,0-0.1,0-0.2,0c-0.3,0-0.5,0-0.7-0.1c-0.2-0.1-0.4-0.1-0.6-0.2c0,0-0.1,0-0.1-0.1c-0.1-0.1-0.3-0.1-0.4-0.2  c-0.2-0.1-0.3-0.3-0.5-0.4c-0.2-0.3-0.3-0.6-0.4-0.9c-0.1,0.2-0.3,0.4-0.4,0.6c-0.1,0.1-0.2,0.2-0.2,0.2l0,0c0,0,0,0,0,0  c0,0-0.1,0.1-0.1,0.1c0,0,0,0,0,0c0,0-0.1,0.1-0.1,0.1c-0.1,0.1-0.2,0.2-0.4,0.3c-0.2,0.1-0.4,0.3-0.7,0.3c-0.2,0.1-0.5,0.1-0.7,0.2  c-0.2,0-0.5,0-0.8,0c-0.3,0-0.5,0-0.7-0.1c-0.2-0.1-0.5-0.1-0.7-0.2c-0.2-0.1-0.4-0.2-0.6-0.3c-0.2-0.1-0.3-0.3-0.4-0.4  c-0.2-0.3-0.3-0.6-0.4-1C71,27.6,71,27.2,71,26.8c0-0.4,0.1-0.8,0.1-1.3c0.1-0.4,0.2-0.8,0.2-1.3c0.1-0.4,0.2-0.8,0.3-1.2  c0.1-0.4,0.2-0.8,0.4-1.2c0.2-0.4,0.3-0.8,0.6-1.1c0.2-0.3,0.5-0.6,0.8-0.9c0.2-0.1,0.4-0.3,0.6-0.4c0.2-0.1,0.4-0.2,0.7-0.3  c0.2-0.1,0.5-0.1,0.7-0.2c0.2,0,0.5,0,0.8,0c0.3,0,0.5,0,0.7,0.1c0.2,0.1,0.4,0.1,0.6,0.2c0.2,0.1,0.4,0.2,0.5,0.4  c0.1,0.1,0.3,0.3,0.4,0.5c0-0.2,0-0.3,0.1-0.5c0.1-0.4,0.2-0.8,0.3-1.2c0.1-0.4,0.2-0.8,0.3-1.2c0.1-0.4,0.2-0.8,0.4-1.1  c0-0.1,0.1-0.2,0.2-0.3c0,0,0-0.1,0.1-0.1c0,0,0,0,0,0c0,0,0-0.1,0.1-0.1c0.1-0.1,0.1-0.2,0.2-0.3c0.1-0.2,0.2-0.3,0.4-0.5  c0.4-0.5,1.1-1,2.1-1.2C78.4,6.8,71.1,2.3,62.8,2.3c-12.5,0-22.6,10.1-22.7,22.6c0,3.6,0.9,7.1,2.4,10.1c0.5-0.2,0.8-0.5,1.1-1l0,0  c0,0,0,0,0,0c0.1-0.2,0.2-0.4,0.3-0.7c0.1-0.2,0.2-0.5,0.2-0.8c0-0.1,1.7-9.4,1.8-10l-1.5,0l0.7-2.5l1.2,0l0.1-0.6  c0-0.1,0-0.2,0-0.3l0-0.2c0.1-0.4,0.1-0.9,0.2-1.2c0.1-0.3,0.1-0.5,0.2-0.7c0.1-0.3,0.2-0.6,0.3-0.8c0.2-0.4,0.4-0.7,0.6-1  c0.2-0.3,0.5-0.6,0.8-0.9c0.2-0.2,0.5-0.4,0.7-0.6c0.3-0.2,0.6-0.3,0.9-0.5c0.3-0.1,0.7-0.3,1.1-0.3c0.4-0.1,0.8-0.1,1.2-0.1l0.1,0  c0.4,0,0.8,0,1.1,0.1c0.1,0,0.3,0.1,0.4,0.1l0,0l-0.8,2.6l0,0c0,0,0,0-0.1,0c-0.1-0.1-0.3-0.1-0.4-0.1c-0.2,0-0.3,0-0.5,0h0  c-0.2,0-0.4,0-0.5,0.1c-0.2,0-0.3,0.1-0.5,0.1l0,0c0,0,0,0,0,0c-0.1,0-0.2,0.1-0.3,0.2c-0.1,0.1-0.2,0.1-0.3,0.2  c-0.2,0.2-0.3,0.3-0.5,0.5c-0.1,0.2-0.2,0.4-0.3,0.7c-0.1,0.2-0.2,0.5-0.2,0.8c0,0,0,0.3-0.1,0.5c0,0.2-0.1,0.3-0.1,0.3l-0.2,1.2  l1.8,0l-0.7,2.5l-1.5,0l-1.4,7.5l-0.3,1.8c-0.1,0.4-0.2,0.8-0.3,1.2c-0.1,0.5-0.3,0.9-0.4,1.3c-0.2,0.4-0.4,0.7-0.6,1.1  c-0.2,0.3-0.5,0.6-0.8,0.9c-0.2,0.2-0.5,0.4-0.8,0.6c-0.2,0.1-0.5,0.3-0.7,0.4c4,6.2,11,10.3,18.9,10.3c12.5,0,22.6-10.1,22.7-22.6  C85.4,21.8,84.7,18.7,83.5,16L83.5,16z"/>
+    <path class="str6" d="M67.5,25.4c0,0.1-0.1,0.3-0.1,0.4c0.1-0.2,0.1-0.3,0.1-0.5c0.1-0.3,0.1-0.5,0.2-0.8c0-0.1,0-0.3,0.1-0.4  c0,0.1,0,0.3-0.1,0.4C67.6,24.8,67.6,25.1,67.5,25.4"/>
+    <path class="str1" d="M67.9,22.7c0,0.2,0,0.5-0.1,0.8c0,0.2,0,0.3-0.1,0.5c0,0.1,0,0.3-0.1,0.4c0,0.3-0.1,0.5-0.2,0.8  c0,0.2-0.1,0.4-0.1,0.5c0,0.1-0.1,0.3-0.1,0.4c-0.1,0.3-0.2,0.5-0.3,0.7c-0.1,0.2-0.3,0.4-0.4,0.6c-0.1,0.1-0.2,0.2-0.3,0.2  c-0.1,0.1-0.2,0.1-0.3,0.2c-0.1,0-0.2,0.1-0.4,0.1c-0.1,0-0.3,0-0.4,0c-0.1,0-0.3,0-0.4,0c-0.1,0-0.2-0.1-0.3-0.1  c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.2-0.1-0.2-0.2c-0.1-0.2-0.2-0.3-0.2-0.6c0-0.2-0.1-0.4-0.1-0.7c0-0.3,0-0.5,0.1-0.8  c0-0.3,0.1-0.6,0.2-0.9c0.1-0.3,0.1-0.6,0.2-0.9c0.1-0.3,0.1-0.6,0.2-0.8c0.1-0.3,0.2-0.5,0.3-0.7c0.1-0.2,0.3-0.4,0.5-0.5  c0.1-0.1,0.2-0.2,0.3-0.2c0.1-0.1,0.2-0.1,0.3-0.2c0.1,0,0.2-0.1,0.3-0.1c0.1,0,0.3,0,0.4,0c0.1,0,0.3,0,0.4,0  c0.1,0,0.2,0.1,0.3,0.1c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.2,0.1,0.2,0.2c0.1,0.2,0.2,0.3,0.2,0.5C67.9,22.3,67.9,22.5,67.9,22.7   M70.3,21.1c-0.1-0.3-0.3-0.5-0.4-0.8c-0.1-0.2-0.3-0.3-0.5-0.5c-0.2-0.2-0.4-0.3-0.7-0.4s-0.5-0.2-0.9-0.3C67.5,19,67.2,19,66.8,19  c-0.4,0-0.8,0-1.1,0.1c-0.3,0.1-0.7,0.2-1,0.3c-0.3,0.1-0.6,0.3-0.8,0.4c-0.2,0.2-0.5,0.3-0.7,0.5c-0.3,0.3-0.5,0.5-0.8,0.8  c-0.2,0.3-0.4,0.6-0.6,0.9c-0.2,0.3-0.3,0.7-0.4,1.1c-0.1,0.4-0.2,0.8-0.3,1.3c-0.1,0.5-0.2,0.9-0.2,1.4c0,0.4,0,0.8,0,1.1  c0,0.3,0.1,0.7,0.2,0.9c0.1,0.3,0.3,0.6,0.5,0.8c0.1,0.2,0.3,0.3,0.5,0.5c0.2,0.2,0.4,0.3,0.7,0.4c0.3,0.1,0.5,0.2,0.9,0.3  c0.3,0.1,0.7,0.1,1.1,0.1c0.4,0,0.8,0,1.1-0.1c0.3-0.1,0.7-0.2,1-0.3c0.3-0.1,0.6-0.3,0.8-0.4c0.2-0.2,0.5-0.3,0.7-0.5  c0.3-0.3,0.5-0.5,0.7-0.8c0.2-0.3,0.4-0.6,0.5-0.9c0.1-0.3,0.3-0.7,0.4-1.1c0.1-0.4,0.2-0.8,0.3-1.3c0.1-0.5,0.1-0.9,0.2-1.3  c0-0.4,0-0.8,0-1.1C70.5,21.7,70.4,21.4,70.3,21.1 M45.2,36.3c0.3-0.3,0.6-0.6,0.8-0.9c0.2-0.3,0.4-0.7,0.6-1.1  c0.2-0.4,0.3-0.8,0.4-1.3c0.1-0.4,0.2-0.7,0.3-1.2l0.3-1.8l1.4-7.5l1.5,0l0.7-2.5l-1.8,0l0.2-1.2c0,0,0-0.2,0.1-0.3  c0-0.2,0.1-0.4,0.1-0.5c0.1-0.3,0.1-0.6,0.2-0.8c0.1-0.2,0.2-0.5,0.3-0.7c0.1-0.2,0.3-0.4,0.5-0.5c0.1-0.1,0.2-0.2,0.3-0.2  c0.1-0.1,0.2-0.1,0.3-0.2c0,0,0,0,0,0l0,0c0.2-0.1,0.3-0.1,0.5-0.1c0.2,0,0.3-0.1,0.5-0.1h0c0.2,0,0.3,0,0.5,0  c0.1,0,0.3,0.1,0.4,0.1c0,0,0,0,0.1,0l0,0l0.8-2.6l0,0c-0.1,0-0.3-0.1-0.4-0.1c-0.4-0.1-0.7-0.1-1.1-0.1l-0.1,0  c-0.4,0-0.8,0-1.2,0.1c-0.4,0.1-0.7,0.2-1.1,0.3c-0.3,0.1-0.6,0.3-0.9,0.5c-0.3,0.2-0.5,0.4-0.7,0.6c-0.3,0.3-0.6,0.6-0.8,0.9  c-0.2,0.3-0.4,0.7-0.6,1c-0.1,0.2-0.2,0.5-0.3,0.8c-0.1,0.2-0.1,0.4-0.2,0.7c-0.1,0.3-0.2,0.8-0.2,1.2l0,0.2c0,0.1,0,0.2,0,0.3  l-0.1,0.6l-1.2,0l-0.7,2.5l1.5,0c-0.1,0.6-1.8,9.9-1.8,10c-0.1,0.3-0.1,0.6-0.2,0.8c-0.1,0.3-0.2,0.5-0.3,0.7c0,0,0,0,0,0l0,0  c-0.3,0.4-0.7,0.8-1.1,1c0.4,0.8,0.8,1.5,1.3,2.3c0.3-0.1,0.5-0.2,0.7-0.4C44.8,36.7,45,36.5,45.2,36.3"/>
+    <path class="str6" d="M57.4,25.4c0,0.1-0.1,0.3-0.1,0.4c0.1-0.2,0.1-0.3,0.1-0.5c0.1-0.3,0.1-0.5,0.2-0.8c0-0.1,0-0.3,0.1-0.4  c0,0.1-0.1,0.3-0.1,0.4C57.6,24.8,57.5,25.1,57.4,25.4"/>
+    <path class="str1" d="M57.9,22.7c0,0.2,0,0.5-0.1,0.8c0,0.2,0,0.3-0.1,0.5c0,0.1,0,0.3-0.1,0.4c0,0.3-0.1,0.5-0.2,0.8  c0,0.2-0.1,0.3-0.1,0.5c0,0.2-0.1,0.3-0.1,0.4c-0.1,0.3-0.2,0.5-0.3,0.7c-0.1,0.2-0.3,0.4-0.4,0.6c-0.1,0.1-0.2,0.2-0.3,0.2  c-0.1,0.1-0.2,0.1-0.3,0.2c-0.1,0-0.2,0.1-0.4,0.1c-0.1,0-0.3,0-0.4,0c-0.1,0-0.3,0-0.4,0c-0.1,0-0.2-0.1-0.3-0.1  c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.2-0.1-0.2-0.2c-0.1-0.2-0.2-0.3-0.2-0.6c0-0.2-0.1-0.4,0-0.7c0-0.3,0-0.5,0.1-0.8  c0-0.3,0.1-0.6,0.2-0.9c0.1-0.3,0.1-0.6,0.2-0.9c0.1-0.3,0.1-0.6,0.2-0.8c0.1-0.3,0.2-0.5,0.3-0.7c0.1-0.2,0.3-0.4,0.5-0.5  c0.1-0.1,0.2-0.2,0.3-0.2c0.1-0.1,0.2-0.1,0.3-0.2c0.1,0,0.2-0.1,0.3-0.1c0.1,0,0.3,0,0.4,0c0.1,0,0.3,0,0.4,0  c0.1,0,0.2,0.1,0.3,0.1c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.2,0.1,0.2,0.2c0.1,0.2,0.2,0.3,0.2,0.5C57.8,22.3,57.9,22.5,57.9,22.7   M60.3,21.1c-0.1-0.3-0.3-0.5-0.4-0.8c-0.1-0.2-0.3-0.3-0.5-0.5c-0.2-0.2-0.4-0.3-0.7-0.4c-0.3-0.1-0.5-0.2-0.9-0.3  C57.5,19,57.1,19,56.8,19c-0.4,0-0.8,0-1.1,0.1c-0.3,0.1-0.7,0.2-1,0.3c-0.3,0.1-0.6,0.3-0.8,0.4c-0.2,0.2-0.5,0.3-0.7,0.5  c-0.3,0.3-0.5,0.5-0.8,0.8c-0.2,0.3-0.4,0.6-0.6,0.9c-0.2,0.3-0.3,0.7-0.4,1.1c-0.1,0.4-0.2,0.8-0.3,1.3c-0.1,0.5-0.2,0.9-0.2,1.4  c0,0.4,0,0.8,0,1.1c0,0.3,0.1,0.7,0.2,0.9c0.1,0.3,0.3,0.6,0.5,0.8c0.1,0.2,0.3,0.3,0.5,0.5c0.2,0.2,0.4,0.3,0.7,0.4  c0.3,0.1,0.5,0.2,0.9,0.3C54,30,54.4,30,54.8,30c0.4,0,0.8-0.1,1.1-0.1c0.3-0.1,0.7-0.2,1-0.3c0.3-0.1,0.6-0.3,0.8-0.4  c0.2-0.2,0.5-0.3,0.7-0.5c0.3-0.3,0.5-0.5,0.7-0.8c0.2-0.3,0.4-0.6,0.5-0.9c0.1-0.3,0.3-0.7,0.4-1.1c0.1-0.4,0.2-0.8,0.3-1.3  c0.1-0.5,0.1-0.9,0.2-1.3c0-0.4,0-0.8,0-1.1C60.4,21.7,60.4,21.4,60.3,21.1 M77.9,22.7c0,0.3,0,0.5-0.1,0.8c0,0.2,0,0.3-0.1,0.5  c0,0.1,0,0.3-0.1,0.4c0,0.3-0.1,0.5-0.2,0.8c0,0.2-0.1,0.4-0.1,0.5c0,0.1-0.1,0.3-0.1,0.4c-0.1,0.3-0.2,0.5-0.3,0.7  c-0.1,0.2-0.3,0.4-0.5,0.6c-0.1,0.1-0.2,0.2-0.3,0.2c-0.1,0.1-0.2,0.1-0.3,0.2c-0.1,0-0.2,0.1-0.4,0.1c-0.1,0-0.3,0-0.4,0  c-0.1,0-0.3,0-0.4,0c-0.1,0-0.2-0.1-0.3-0.1c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.2-0.1-0.2-0.2c-0.1-0.2-0.2-0.3-0.2-0.6  c0-0.2-0.1-0.5-0.1-0.7c0-0.3,0-0.5,0.1-0.8c0-0.3,0.1-0.6,0.2-0.9c0.1-0.3,0.1-0.6,0.2-0.9c0.1-0.3,0.2-0.6,0.2-0.8  c0.1-0.3,0.2-0.5,0.3-0.7c0.1-0.2,0.3-0.4,0.5-0.6c0.1-0.1,0.2-0.2,0.3-0.2c0.1-0.1,0.2-0.1,0.3-0.2c0.1,0,0.2-0.1,0.3-0.1  c0.1,0,0.3,0,0.4,0c0.1,0,0.3,0,0.4,0c0.1,0,0.2,0.1,0.3,0.1c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.2,0.1,0.2,0.2  c0.1,0.2,0.2,0.3,0.2,0.6C77.8,22.2,77.9,22.5,77.9,22.7 M80.2,14.7c-0.1,0.1-0.3,0.3-0.4,0.5c-0.1,0.1-0.1,0.2-0.2,0.3  c0,0,0,0.1-0.1,0.1c0,0,0,0,0,0c0,0.1-0.1,0.1-0.1,0.1c-0.1,0.1-0.1,0.2-0.2,0.3c-0.1,0.3-0.3,0.7-0.4,1.1c-0.1,0.4-0.2,0.8-0.3,1.2  c-0.1,0.4-0.2,0.8-0.3,1.2c0,0.2-0.1,0.3-0.1,0.5c-0.1-0.2-0.2-0.3-0.4-0.5c-0.2-0.1-0.3-0.3-0.5-0.4c-0.2-0.1-0.4-0.2-0.6-0.2  C76.6,19,76.3,19,76.1,19c-0.3,0-0.5,0-0.8,0c-0.2,0-0.5,0.1-0.7,0.2c-0.2,0.1-0.5,0.2-0.7,0.3c-0.2,0.1-0.4,0.2-0.6,0.4  c-0.3,0.3-0.6,0.6-0.8,0.9c-0.2,0.3-0.4,0.7-0.6,1.1c-0.2,0.4-0.3,0.8-0.4,1.2c-0.1,0.4-0.2,0.8-0.3,1.2c-0.1,0.4-0.2,0.8-0.2,1.3  C71,26,71,26.4,71,26.8c0,0.4,0,0.8,0.1,1.2c0.1,0.4,0.2,0.7,0.4,1c0.1,0.2,0.3,0.3,0.4,0.4c0.2,0.1,0.4,0.2,0.6,0.3  c0.2,0.1,0.4,0.2,0.7,0.2c0.2,0.1,0.5,0.1,0.7,0.1c0.3,0,0.5,0,0.8,0c0.2,0,0.5-0.1,0.7-0.2c0.2-0.1,0.4-0.2,0.7-0.3  c0.1-0.1,0.2-0.2,0.4-0.3c0,0,0.1-0.1,0.1-0.1c0,0,0,0,0,0c0,0,0.1-0.1,0.1-0.1c0,0,0,0,0,0l0,0c0.1-0.1,0.2-0.2,0.2-0.2  c0.2-0.2,0.3-0.4,0.4-0.6c0.1,0.3,0.2,0.6,0.4,0.9c0.1,0.2,0.3,0.3,0.5,0.4c0.1,0.1,0.2,0.2,0.4,0.2c0,0,0.1,0,0.1,0.1  c0.2,0.1,0.4,0.2,0.6,0.2c0.2,0.1,0.5,0.1,0.7,0.1c0.1,0,0.1,0,0.2,0l0.7-2.3c0,0,0,0,0,0c-0.1,0-0.2-0.1-0.3-0.1  c-0.1,0-0.2-0.1-0.2-0.1c-0.1-0.1-0.1-0.1-0.2-0.2c-0.1-0.1-0.1-0.3-0.2-0.5c0-0.1,0-0.3,0-0.4c0,0,0,0,0,0c0,0,0-0.1,0-0.2  c0,0,0-0.1,0-0.2c0-0.2,0-0.3,0.1-0.5c0,0,0-0.1,0-0.1c0-0.1,0-0.1,0-0.1s0.4-2,0.4-2c0.3-1.6,0.6-3.5,0.6-3.7  c0.1-0.3,0.1-0.7,0.2-1c0.1-0.3,0.2-0.6,0.3-0.9c0.1-0.3,0.2-0.5,0.3-0.7c0.1-0.2,0.3-0.4,0.5-0.6c0.1-0.1,0.2-0.2,0.3-0.2  c0.1-0.1,0.2-0.1,0.3-0.2c0.1,0,0.2-0.1,0.4-0.1h0c-0.4-0.8-0.8-1.6-1.2-2.4C81.3,13.7,80.7,14.2,80.2,14.7 M54.5,35.7v-1.6  c0-0.4-0.2-0.5-0.4-0.5c-0.2,0-0.4,0.1-0.4,0.5v1.6H53V33h0.6v0.2c0.2-0.2,0.4-0.3,0.7-0.3c0.3,0,0.5,0.1,0.6,0.2  c0.2,0.2,0.3,0.5,0.3,0.8v1.7H54.5z M58,33.8c-0.1-0.2-0.2-0.3-0.4-0.3c-0.2,0-0.4,0.1-0.4,0.3c0,0.1-0.1,0.2-0.1,0.3h1  C58,34,58,33.9,58,33.8L58,33.8z M57,34.6c0,0.3,0.2,0.6,0.6,0.6c0.3,0,0.4-0.1,0.6-0.3l0.4,0.4c-0.3,0.3-0.5,0.4-1,0.4  c-0.6,0-1.2-0.3-1.2-1.4c0-0.9,0.5-1.4,1.2-1.4c0.7,0,1.2,0.5,1.2,1.3v0.3H57z M60.7,35.7c-0.5,0-0.8-0.4-0.8-0.8v-1.3h-0.3v-0.5H60  v-0.8h0.7v0.8h0.5v0.5h-0.5v1.3c0,0.2,0.1,0.2,0.2,0.2h0.2v0.6H60.7z"/>
+    <polygon class="str1" points="65.2,35.7 64.6,35.7 64.1,34 63.5,35.7 63,35.7 62.2,33 62.9,33 63.3,34.7 63.8,33 64.3,33 64.9,34.7   65.3,33 66,33 "/>
+    <path class="str1" d="M68.4,33.7c-0.1-0.1-0.2-0.1-0.3-0.1c-0.1,0-0.2,0-0.3,0.1c-0.1,0.1-0.2,0.4-0.2,0.6c0,0.3,0,0.5,0.2,0.7  c0.1,0.1,0.2,0.1,0.3,0.1c0.1,0,0.2,0,0.3-0.1c0.1-0.1,0.2-0.4,0.2-0.7C68.5,34.1,68.5,33.8,68.4,33.7 M68.9,35.4  c-0.2,0.2-0.4,0.3-0.8,0.3c-0.4,0-0.7-0.2-0.8-0.3c-0.2-0.3-0.3-0.6-0.3-1c0-0.5,0.1-0.8,0.3-1c0.2-0.2,0.4-0.3,0.8-0.3  c0.4,0,0.7,0.2,0.8,0.3c0.2,0.3,0.3,0.6,0.3,1C69.2,34.8,69.1,35.1,68.9,35.4 M71.8,33.7c-0.1-0.1-0.2-0.2-0.4-0.2  c-0.2,0-0.4,0.2-0.4,0.5v1.6h-0.7V33H71v0.3c0.1-0.2,0.4-0.3,0.7-0.3c0.3,0,0.4,0.1,0.6,0.3L71.8,33.7z"/>
+    <polygon class="str1" points="74.9,35.7 74.3,34.6 74,34.9 74,35.7 73.3,35.7 73.3,32 74,32 74,34.1 74.9,33 75.7,33 74.7,34.1   75.7,35.7 "/>
+    <path class="str6" d="M85.6,14.4c0,0.5-0.4,0.9-0.9,0.9c-0.5,0-0.9-0.4-0.9-0.9c0-0.5,0.4-0.9,0.9-0.9C85.2,13.6,85.6,14,85.6,14.4  L85.6,14.4z M84,14.4c0,0.4,0.3,0.8,0.8,0.8c0.4,0,0.8-0.3,0.8-0.8c0-0.4-0.3-0.8-0.8-0.8C84.3,13.7,84,14,84,14.4L84,14.4z   M84.8,14c0.2,0,0.3,0.1,0.3,0.3c0,0.1-0.1,0.2-0.2,0.2v0c0.1,0,0.1,0,0.1,0.1c0,0,0,0.1,0,0.2c0,0.1,0,0.1,0.1,0.2H85  c0,0,0-0.1,0-0.1c0-0.2,0-0.3-0.3-0.3h-0.2c0,0,0,0-0.1,0c0,0,0,0,0,0.1v0.4h-0.1v-1H84.8z M84.5,14.1  C84.5,14.1,84.5,14.1,84.5,14.1C84.5,14.1,84.5,14.1,84.5,14.1l0,0.3c0,0,0,0,0,0.1c0,0,0,0,0.1,0h0.2c0.2,0,0.3-0.1,0.3-0.2  c0-0.1-0.1-0.2-0.2-0.2H84.5z"/>
+    <path class="str3" d="M14.9,55.3l15.4-13.4h15.4L30.8,56.2c4.5,9,11.8,16.4,15.8,16.4c1.2,0,4.3,0,5.4,0L52,83.2  c-2.3,0.4-6.7,0.5-8.5,0.5c-8.3,0-13.9-7.8-21.1-20.9l-7.7,6.3l0.2,14.1H2.4V26.1h12.4V55.3z"/>
+    <polygon class="str3" points="299.8,27.3 298,27.3 298,30.6 297.1,30.6 297.1,27.3 295.4,27.3 295.4,26.4 299.8,26.4 "/>
+    <defs>
+	<filter filterUnits="userSpaceOnUse" height="4.2" id="Adobe_OpacityMaskFilter_3_" width="4.7" x="300.7" y="26.4">
+		<feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+	</filter>
+</defs>
+    <mask height="4.2" id="fnk-logo-h_1_" maskUnits="userSpaceOnUse" width="4.7" x="300.7" y="26.4">
+	<g class="str9">
+		<polygon class="str1" id="fnk-logo-g_1_" points="300.7,26.4 305.4,26.4 305.4,30.6 300.7,30.6   "/>
+	</g>
+</mask>
+    <polygon class="str10" points="303.1,29 304.3,26.4 305.4,26.4 305.4,30.6 304.5,30.6 304.5,28 303.3,30.6 302.9,30.6 301.6,28   301.6,30.6 300.7,30.6 300.7,26.4 301.9,26.4 "/>
+</symbol>
+
+                      <use xlink:href="#icon-fnk-logo"></use>
+                    </svg>
+                  
+                </div>
+                <div class="m-BrandPromo__a-PromoText">All your cooking needs in one place</div>
+                <div class="m-BrandPromo m-BrandPromo--Cta m-BrandPromo--Cta-Text" data-animate-item>
+                  
+  <a class="m-BrandPromo__a-Cta" href="https://kitchen.foodnetwork.com/#/get-cooking">Start Free Trial</a>
+
+                </div>
+              </div>
+            </div>
+          
+          
+          
+          
+          <div class="m-DropdownMenu__m-MediaGroup">
+            <div class="m-DropdownMenu__m-Container">
+              
+              
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 1, "cardType": ""}'>
+                  <span class="m-MediaPromo__a-Label"></span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Article " data-animate-item>
+                              <a href="https://www.foodnetwork.com/kitchen/classes" title="Step-by-Step Tutorials" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/navigation/step-by-step.png.rend.hgtvcom.196.196.suffix/1594583170407.png"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/navigation/step-by-step.png.rend.hgtvcom.196.196.suffix/1594583170407.png"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Step-by-Step Tutorials</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Article " data-animate-item>
+                              <a href="https://www.foodnetwork.com/kitchen/meal-planning" title="Browse Meal Plans" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/navigation/browse-meal-plans.png.rend.hgtvcom.196.196.suffix/1607984186760.png"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/navigation/browse-meal-plans.png.rend.hgtvcom.196.196.suffix/1607984186760.png"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Browse Meal Plans</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            
+
+                            
+                              
+                              
+                              
+                              
+		<div class="class-results" data-module="class-results">
+			<script type="text/x-config">
+				{
+					"maxResults": 1,
+					"isHeader": true
+				}
+			</script>
+			
+				<div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Class" data-animate-item>
+					<div class="m-PromoItem__m-MediaWrap">
+						<a href="https://www.foodnetwork.com/kitchen/classes/crispy-meringue-cups-with-berries-and-sorbet_39023a92-2ff2-4a18-ae9e-0abe019161f4" title="Crispy Meringue Cups with Berries and Sorbet">
+							<img class="m-PromoItem__a-Image a-Image" alt="Crispy Meringue Cups with Berries and Sorbet" data-src="https://food.cld.sndimg.com/image/upload/c_fill,w_196,h_196,ar_4:3/v1/fn_core_images/food/plus/fullset/2021/09/01/0/FNKLive_Zac-Young_Crispy-Meringue-Cups-with-Berries-and-Sorbet-3-2_s4x3.jpg"/>
+							
+							
+								<div class="class-info previous">
+									<span class="class-live">PREVIOUSLY LIVE</span>
+								</div>
+							
+						</a>
+						
+					</div>
+					<div class="m-PromoItem__a-Headline">
+						<a href="https://www.foodnetwork.com/kitchen/classes/crispy-meringue-cups-with-berries-and-sorbet_39023a92-2ff2-4a18-ae9e-0abe019161f4" title="Crispy Meringue Cups with Berries and Sorbet" data-truncate="55" alt="Crispy Meringue Cups with Berries and Sorbet">
+							<h4 class="m-PromoItem__a-Headline">Crispy Meringue Cups with Berries and Sorbet</h4>
+						</a>
+					</div>
+				</div>
+			
+		</div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Article m-PromoItem--wide" data-animate-item>
+                              <a href="https://kitchen.foodnetwork.com/#/get-cooking" title="Try Premium" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+  
+    
+    <img class="m-PromoItem__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/navigation/unsized/premium-promo@2x.png"/>
+    <noscript>
+      <img class="m-PromoItem__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/navigation/unsized/premium-promo@2x.png"/>
+    </noscript>
+    
+  
+
+                                  
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Try Premium</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                        </div>
+                </div>
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 2, "cardType": ""}'>
+                  <span class="m-MediaPromo__a-Label"></span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                        </div>
+                </div>
+              
+            </div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+  
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--flyOutNavItem" data-animate-menu="animate">
+  <div class="o-Header__m-NavItem is-Premium premium-flyout" data-type="menu-action" data-dropdown="true">
+      
+        
+          <a class="o-Header__a-NavLink" href="https://www.foodnetwork.com/kitchen/classes">Food Network Kitchen</a>
+          <div class="o-Header__m-NavItemLabel">
+            <span>Premium
+              
+                <svg class="o-Header__a-Icon">
+                  
+                  <use xlink:href="#icon-fn-sparkle"></use>
+                </svg>
+              
+            </span>
+          </div>
+        
+        
+      
+      
+      <div data-type="dropdown-menu" class="o-Header__m-DropdownMenu  o-Header__m-DropdownMenu--FlyOut has-BrandPromo" data-module="flyout-menu">
+        <script type="text/x-config">{"horizontalScroll":{"deferInit":true}}</script>
+        <div class="m-DropdownMenu__m-Body" data-horizontal-scroll>
+          
+          
+          
+          <div class="m-DropdownMenu__m-TextPromo " data-animate-item>
+            
+            
+              <div class="m-DropdownMenu__m-BrandPromo">
+                <div class="m-DropdownMenu__m-Container">
+                  
+                  <div class="m-BrandPromo__a-Logo">
+                    
+                      <svg class="o-Header__a-Icon">
+                        
+                        <use xlink:href="#icon-fnk-logo"></use>
+                      </svg>
+                    
+                  </div>
+                </div>
+              </div>
+            
+            <ul>
+              <li><a href="https://www.foodnetwork.com/kitchen/meal-planning/my-meal-plan" target="_self">My Meal Plan</a>
+              </li>
+            
+              <li><a href="https://www.foodnetwork.com/kitchen/meal-planning" target="_self">Browse Meal Plans</a>
+              </li>
+            
+              <li><a href="https://www.foodnetwork.com/kitchen/classes" target="_self">Classes</a>
+              </li>
+            
+              <li><a href="https://www.foodnetwork.com/kitchen/classes/topics/weeknight_dinners" target="_self">Weeknight Dinners</a>
+              </li>
+            </ul>
+            
+          </div>
+          
+          <div class="m-DropdownMenu__m-MediaGroup">
+            <div class="m-DropdownMenu__m-Container">
+              
+              
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 1, "cardType": "New Meal Plans this Week"}'>
+                  <span class="m-MediaPromo__a-Label">New Meal Plans this Week</span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--MealPlan " data-animate-item>
+                              <a href="https://www.foodnetwork.com/kitchen/meal-planning/instant-pot-to-the-rescue_d1c50578-e0ad-4fe5-9b77-5dbd46e5421f" title="Instant Pot to the Rescue" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+                                  <img class="m-PromoItem__a-Image a-Image" alt="Instant Pot to the Rescue" data-src="https://food.cld.sndimg.com/image/upload/c_fill,h_196,w_198/v1/fn_core_images/food/fullset/2020/11/16/0/FNK_Instant-Pot-Stuffed-Peppers_H2_s4x3.jpg"/>
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Instant Pot to the Rescue</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--MealPlan " data-animate-item>
+                              <a href="https://www.foodnetwork.com/kitchen/meal-planning/no-cook-dinners_b88a59b1-b099-4279-997a-1dd00a26d788" title="No-Cook Dinners" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+                                  <img class="m-PromoItem__a-Image a-Image" alt="No-Cook Dinners" data-src="https://food.cld.sndimg.com/image/upload/c_fill,h_196,w_198/v1/fn_core_images/food/fullset/2020/07/31/QK105_Rotisserie-Chicken-Salad-Sandwich_s4x3_new.jpg"/>
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">No-Cook Dinners</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            <div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--MealPlan " data-animate-item>
+                              <a href="https://www.foodnetwork.com/kitchen/meal-planning/midday-meals_f9dd2365-5a1d-47a1-a962-3e3d5c0f11db" title="Midday Meals" target="_self">
+                                <div class="m-PromoItem__m-MediaWrap">
+                                  
+                                  
+                                  <img class="m-PromoItem__a-Image a-Image" alt="Midday Meals" data-src="https://food.cld.sndimg.com/image/upload/c_fill,h_196,w_198/v1/fn_core_images/food/plus/fullset/2021/07/12/0/FNKLive_Justin-Chapple_Grilled-Halloumi-Fattoush-3_s4x3.jpg"/>
+                                </div>
+                                <h4 class="m-PromoItem__a-Headline">Midday Meals</h4>
+                              </a>
+                            </div>
+
+                            
+                          
+                            
+                            
+
+                            
+                          
+                        </div>
+                </div>
+              
+                
+                <div class="m-DropdownMenu__m-MediaPromo" data-analytics='{"cardPosition": 2, "cardType": "Classes"}'>
+                  <span class="m-MediaPromo__a-Label">Classes</span>
+
+                      <div class="m-MediaPromo__m-Container">
+                          
+                            
+                            
+
+                            
+                              
+                              
+                              
+                              
+		<div class="class-results" data-module="class-results">
+			<script type="text/x-config">
+				{
+					"maxResults": 2,
+					"isHeader": true
+				}
+			</script>
+			
+				<div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Class" data-animate-item>
+					<div class="m-PromoItem__m-MediaWrap">
+						<a href="https://www.foodnetwork.com/kitchen/classes/crispy-meringue-cups-with-berries-and-sorbet_39023a92-2ff2-4a18-ae9e-0abe019161f4" title="Crispy Meringue Cups with Berries and Sorbet">
+							<img class="m-PromoItem__a-Image a-Image" alt="Crispy Meringue Cups with Berries and Sorbet" data-src="https://food.cld.sndimg.com/image/upload/c_fill,w_196,h_196,ar_4:3/v1/fn_core_images/food/plus/fullset/2021/09/01/0/FNKLive_Zac-Young_Crispy-Meringue-Cups-with-Berries-and-Sorbet-3-2_s4x3.jpg"/>
+							
+							
+								<div class="class-info previous">
+									<span class="class-live">PREVIOUSLY LIVE</span>
+								</div>
+							
+						</a>
+						
+					</div>
+					<div class="m-PromoItem__a-Headline">
+						<a href="https://www.foodnetwork.com/kitchen/classes/crispy-meringue-cups-with-berries-and-sorbet_39023a92-2ff2-4a18-ae9e-0abe019161f4" title="Crispy Meringue Cups with Berries and Sorbet" data-truncate="55" alt="Crispy Meringue Cups with Berries and Sorbet">
+							<h4 class="m-PromoItem__a-Headline">Crispy Meringue Cups with Berries and Sorbet</h4>
+						</a>
+					</div>
+				</div>
+			
+				<div class="m-PromoItem m-DropdownMenu__m-PromoItem m-PromoItem--Class" data-animate-item>
+					<div class="m-PromoItem__m-MediaWrap">
+						<a href="https://www.foodnetwork.com/kitchen/classes/carrot-cake-breakfast-cookies_f87fa505-697a-482d-b1bb-2d783a98fb6c" title="Carrot Cake Breakfast Cookies">
+							<img class="m-PromoItem__a-Image a-Image" alt="Carrot Cake Breakfast Cookies" data-src="https://food.cld.sndimg.com/image/upload/c_fill,w_196,h_196,ar_4:3/v1/fn_core_images/food/plus/fullset/2021/09/02/0/FNKLive_Gabriela-Rodiles_Carrot-Cake-Breakfast-Cookies-2_s4x3.jpg"/>
+							
+							
+								<div class="class-info previous">
+									<span class="class-live">PREVIOUSLY LIVE</span>
+								</div>
+							
+						</a>
+						
+					</div>
+					<div class="m-PromoItem__a-Headline">
+						<a href="https://www.foodnetwork.com/kitchen/classes/carrot-cake-breakfast-cookies_f87fa505-697a-482d-b1bb-2d783a98fb6c" title="Carrot Cake Breakfast Cookies" data-truncate="55" alt="Carrot Cake Breakfast Cookies">
+							<h4 class="m-PromoItem__a-Headline">Carrot Cake Breakfast Cookies</h4>
+						</a>
+					</div>
+				</div>
+			
+		</div>
+
+                            
+                          
+                        </div>
+                </div>
+              
+            </div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+  
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--navItem" data-animate-menu="animate">
+<div class="o-Header__m-NavItem" data-type="menu-action">
+  <a class="o-Header__a-NavLink" href="https://www.discoveryplus.com/?xp=fn_navigation_launch" target="_blank">
+    discovery+
+  </a>
+
+  
+</div>
+
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--searchBox" data-animate-menu="animate"><section class="o-SiteSearch" data-module="header-mobile">
+  <script type="text/x-config">
+    {
+      "setNavTop": false,
+      "highlightHeader": true,
+      "headerSelector": "[data-header-main]",
+      "handleGigyaLogin": false,
+      "searchExposed": false
+    }
+  </script>
+  
+  <form action="/search" method="get" data-module="search-form" class="m-SearchForm" data-mobile-search-box>
+    <script type="text/x-config">
+        {
+          "searchSite": "food",
+          "searchType": "desktop header search",
+          "selectorPrefix": "m-SearchForm",
+          "listenForFocusOut": false,
+          "typeAhead": "on"
+        }
+    </script>
+    <div class="m-SearchForm__m-Area m-Area__m-Container" data-search-form-wrapper="" data-search-form-field="">
+        <span class="m-SearchForm__m-InputWrap">
+          <input id="typeaheadinput" class="m-SearchForm__a-Input a-Input" type="text" autocomplete="off" placeholder="What are you looking for?" data-type="search-input"/>
+          
+            <div class="m-SearchBox__a-Button--Clear" data-type="reset-btn">
+              <!--Clear Icon-->
+              
+                <svg class="o-Header__a-Icon a-Icon--clear">
+                  <symbol id="icon-clear" viewBox="0 0 12.51 12.51">
+    <defs>
+        <style>.cls-1{fill:none;stroke:#979797;stroke-linecap:square;}</style>
+    </defs>
+    <title>X out of Search</title>
+    <g id="Designs">
+        <g id="Desktop---Search-Suggestions">
+            <g id="Group-3">
+                <line class="cls-1" id="Line-2" x1="0.71" x2="11.8" y1="0.71" y2="11.8"/>
+                <line class="cls-1" data-name="Line-2" id="Line-2-2" x1="11.8" x2="0.71" y1="0.71" y2="11.8"/>
+            </g>
+        </g>
+    </g>
+</symbol>
+
+                  <use xlink:href="#icon-clear"></use>
+                </svg>
+              
+            </div>
+            <button class="m-SearchBox__a-Button--Search" data-type="search-button">
+              <!--Search Icon-->
+              
+                <svg class="o-SiteSearch__a-Icon a-Icon--search">
+                  <symbol id="icon-discovery-search" viewBox="0 0 26 25">
+    <path d="M18 10a8 8 0 1 0-2.3 5.7A8 8 0 0 0 18 10zm.2 5.8l7.8 7.7-1.5 1.5-7.6-7.7a10 10 0 1 1 1.3-1.5z"/>
+</symbol>
+
+                    <use xlink:href="#icon-discovery-search"></use>
+                </svg>
+              
+            </button>
+             <div class="m-SearchForm__m-HintsContainer">
+            	
+            	<div data-typeahead-hints=""></div>
+            </div>
+          
+        </span>
+        
+    </div>
+  </form>
+</section>
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--iconLink" data-animate-menu="animate">
+    
+    <div class="o-Header__m-Navigation m-Navigation--IconWrap m-Navigation--saves">
+        <a href="//www.foodnetwork.com/saves" title="Saves" aria-label="Saves">
+            
+                <svg class="o-Header__a-Icon a-Icon--saves">
+                    <symbol id="icon-saves" viewBox="0 0 18 23">
+    <path d="M2 1.536h13.75c.345 0 .624.28.624.625v18.527c0 .345-.28.625-.625.625-.116 0-.23-.032-.329-.093l-6.263-3.876c-.202-.125-.459-.125-.66.002L2.33 21.21c-.292.183-.678.095-.861-.197-.063-.1-.096-.215-.096-.332V2.16c0-.346.28-.625.625-.625z" fill-rule="evenodd" stroke="#1C1C1C" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</symbol>
+
+                    <use xlink:href="#icon-saves"></use>
+                </svg>
+            
+        </a>
+    </div>
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--iconLink" data-animate-menu="animate">
+    
+    <div class="o-Header__m-Navigation m-Navigation--IconWrap m-Navigation--shopping-list">
+        <a href="https://www.foodnetwork.com/kitchen/shopping-list" title="Shopping List" aria-label="Shopping List">
+            
+                <svg class="o-Header__a-Icon a-Icon--shopping-list">
+                    <symbol id="icon-shopping-list" viewBox="0 0 24 25">
+    <g fill-rule="evenodd" id="Page-1" stroke="none" stroke-width="1">
+        <g stroke="#000000" transform="translate(1.000000, 1.000000)">
+            <polyline fill="currentColor" id="cart" points="4.41636624 3.61931328 22.1280206 3.61931328 20.4664838 12.8073053 6.09786144 12.8073053" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+            <polyline id="Stroke-1" points="-1.40687462e-14 4.92406116e-14 3.8904624 1.3835448 6.30813744 16.5728138 19.9938974 16.5728138" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+            <path d="M17.713409,19.9618538 C18.0895302,19.9618538 18.4301073,20.1144913 18.6766837,20.3610676 C18.92326,20.6076439 19.0758974,20.9482211 19.0758974,21.3243423 C19.0758974,21.7008564 18.9233018,22.041722 18.6766533,22.2884726 C18.4300957,22.5351321 18.0895238,22.6877738 17.713409,22.6877738 C17.3369012,22.6877738 16.9960409,22.535174 16.7493091,22.2884422 C16.5025773,22.0417104 16.3499774,21.70085 16.3499774,21.3243423 C16.3499774,20.9482275 16.5026192,20.6076556 16.7492787,20.361098 C16.9960293,20.1144495 17.3368948,19.9618538 17.713409,19.9618538 Z" id="Stroke-7" stroke-width="1.836"/>
+            <path d="M7.82924901,19.9618538 C8.20537019,19.9618538 8.54594733,20.1144913 8.79252367,20.3610676 C9.03910001,20.6076439 9.19173744,20.9482211 9.19173744,21.3243423 C9.19173744,21.7008564 9.03914182,22.041722 8.79249328,22.2884726 C8.54593568,22.5351321 8.20536381,22.6877738 7.82924901,22.6877738 C7.45274124,22.6877738 7.11188089,22.535174 6.8651491,22.2884422 C6.6184173,22.0417104 6.46581744,21.70085 6.46581744,21.3243423 C6.46581744,20.9482275 6.61845915,20.6076556 6.86511871,20.361098 C7.11186926,20.1144495 7.45273485,19.9618538 7.82924901,19.9618538 Z" id="Stroke-7-Copy" stroke-width="1.836"/>
+        </g>
+    </g>
+</symbol>
+
+                    <use xlink:href="#icon-shopping-list"></use>
+                </svg>
+            
+        </a>
+    </div>
+</div>
+
+  <div class="o-Header__m-NavItemWrap m-NavItemWrap--profile" data-animate-menu="animate">
+
+  
+  
+    <div class="o-Header__m-NavItem" data-type="menu-action" data-dropdown="true">
+    <div class="o-Header__m-Navigation m-Navigation--IconWrap">
+        <div data-type="button-header-profile">
+    
+        <svg class="o-Header__a-Icon a-Icon--Profile">
+            <symbol id="icon-profile" viewBox="0 0 27 27">
+    <defs>
+        <path d="M17.5 13.75c0 2.761-2.239 5-5 5s-5-2.239-5-5h10z" id="prefix__a"/>
+    </defs>
+    <g fill="none" fill-rule="evenodd" transform="translate(1 1)">
+        <path d="M25 12.5C25 19.404 19.404 25 12.5 25S0 19.404 0 12.5 5.596 0 12.5 0 25 5.596 25 12.5z" fill="#FFF" stroke="#1C1C1C" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+        <path d="M9.643 7.679c0 .592-.48 1.071-1.072 1.071-.59 0-1.071-.48-1.071-1.071 0-.592.48-1.072 1.071-1.072.592 0 1.072.48 1.072 1.072zM17.5 7.679c0 .592-.48 1.071-1.071 1.071-.592 0-1.072-.48-1.072-1.071 0-.592.48-1.072 1.072-1.072.592 0 1.071.48 1.071 1.072z" fill="#000"/>
+        <path d="M18.202 13H6.798c-.238 1.882.434 3.614 1.636 4.816 1.04 1.04 2.478 1.684 4.066 1.684 1.588 0 3.025-.644 4.066-1.684 1.202-1.202 1.874-2.934 1.636-4.816z" stroke="#1C1C1C" stroke-width="1.5"/>
+    </g>
+</symbol>
+
+            <use xlink:href="#icon-profile"></use>
+        </svg>
+     
+    
+    <svg class="o-Header__a-Icon a-Icon--Profile-hover">
+            <symbol id="icon-profile-hover" viewBox="0 0 27 27">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M25 12.5C25 19.404 19.404 25 12.5 25S0 19.404 0 12.5 5.596 0 12.5 0 25 5.596 25 12.5z" fill="#FFDF56" stroke="#1C1C1C" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" transform="translate(1 1)"/>
+        <path d="M9.643 7.679c0 .592-.48 1.071-1.072 1.071-.59 0-1.071-.48-1.071-1.071 0-.592.48-1.072 1.071-1.072.592 0 1.072.48 1.072 1.072zM17.5 7.679c0 .592-.48 1.071-1.071 1.071-.592 0-1.072-.48-1.072-1.071 0-.592.48-1.072 1.072-1.072.592 0 1.071.48 1.071 1.072z" fill="#000" transform="translate(1 1)"/>
+        <g>
+            <path d="M11.202-.75H-.202C-.44 1.132.232 2.864 1.434 4.066 2.474 5.106 3.912 5.75 5.5 5.75c1.588 0 3.025-.644 4.066-1.684 1.202-1.202 1.874-2.934 1.636-4.816z" fill="#E6003D" stroke="#1C1C1C" stroke-linejoin="round" stroke-width="1.5" transform="translate(1 1) translate(7 13.75)"/>
+            <path d="M9.058 3.487C8.15 2.569 6.892 2 5.5 2c-1.418 0-2.698.59-3.608 1.538C1.03 4.436 4.167 5.25 6 5.25c1.5 0 3.95-.86 3.058-1.763z" fill="#FF626A" transform="translate(1 1) translate(7 13.75)"/>
+            <path d="M11.202-.75H-.202C-.44 1.132.232 2.864 1.434 4.066 2.474 5.106 3.912 5.75 5.5 5.75c1.588 0 3.025-.644 4.066-1.684 1.202-1.202 1.874-2.934 1.636-4.816z" stroke="#1C1C1C" stroke-linejoin="round" stroke-width="1.5" transform="translate(1 1) translate(7 13.75)"/>
+        </g>
+    </g>
+</symbol>
+
+            <use xlink:href="#icon-profile-hover"></use>
+    </svg>
+     
+</div>
+    </div>
+    <div data-module="nav-profile" data-type="dropdown-menu" class="o-Header__m-DropdownMenu o-Header__m-DropdownMenu--Profile">
+    <script type="text/x-config">
+      {
+        "gigyaScreensets": {
+          "login": "CoreFn-RegistrationLogin"
+        },
+        "passiveInit": true,
+        "moderationURL": "https://core-moderation.sniaws.com/moderateUserProfile.html",
+        "profilePageUrl": "https://kitchen.foodnetwork.com/#/profile/edit",
+        "subscriptionUrl": "https://kitchen.foodnetwork.com/#/profile/manage-subscription",
+        "regPromoText": "Sign up to save your favorite recipes#o#44#c# videos#o#44#c# Food Network collections or create your own boards."
+      }
+    </script>
+    </div>
+    </div>
+  
+
+  
+  
+
+
+</div>
+
+
+</div>
+    </section>
+
+    <section class="o-Header__m-Area o-Header__m-Area--Bottom">
+
+</section>
+ 
+
+
+
+   
+
+  
+
+   
+  
+
+
+
+
+</header>
+
+   
+   
+
+</div>
+
+
+    
+    
+        
+            <div id="pushdown_adtag" class="iax_outer">
+              <div id="brandscape"></div>
+              <div class="iax_inner">
+                <div id='dfp_pushdown_brandscape'></div>
+              </div>
+             </div>
+        
+        
+    
+
+    
+    
+
+
+
+  
+  
+
+
+
+
+
+<div class="area" data-sni-area="content">
+
+  
+
+<div class="container ">
+	<div class="breadcrumb"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/general/breadcrumb"></span>
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+    
+        
+    
+
+
+
+    
+        
+    
+    
+
+
+
+
+
+
+
+
+
+
+
+    
+
+
+
+
+    
+    
+    
+
+
+
+
+  
+  
+
+
+    
+
+
+    <ul class="o-Breadcrumb o-Breadcrumb--Dark has-Banner">
+        
+            
+        
+            
+                
+                <li>
+                    <a href="//www.foodnetwork.com">
+                        <span>Home</span>
+                    </a>
+                </li>
+            
+        
+            
+                
+                <li>
+                    <a href="//www.foodnetwork.com/recipes">
+                        <span>Recipes</span>
+                    </a>
+                </li>
+            
+        
+            
+                
+                <li>
+                    <a href="//www.foodnetwork.com/recipes/tyler-florence">
+                        <span>Tyler Florence</span>
+                    </a>
+                </li>
+            
+        
+    </ul>
+
+</div>
+
+    <div class="topParsys parsys">
+
+
+
+</div>
+
+</div>
+
+  
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+    
+        
+    
+
+
+
+
+    
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="o-Hub">
+
+    
+    
+    
+
+    
+
+    <div class="container ">
+        
+            <div class="subNavigation"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/hidden/subNavigation"></span>
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+
+        
+    </div>
+</div>
+
+
+  
+  
+  
+  
+  
+  
+  <div class="container-site is-Fluid ">
+    <div class="container-fluid">
+
+      
+<div class="row">
+    <div class="col-md-28">
+        <div class="top parsys">
+
+
+
+</div>
+
+    </div>
+</div>
+
+
+    <div class="row">
+
+      <div class="col-md-18">
+        <div role="contentWell">
+          
+
+
+
+
+  
+  
+
+
+<div class="assetNavigation"><span style="display: none" class="clicktracking" data-resource-type="/apps/foodcom/components/general/assetNavigation"></span>
+  <section class="o-AssetNavigation" data-module="asset-navigation">
+    <script type="text/x-config">
+      {
+        "endAffix": ".recipe-body",
+        "urls":     ["//www.foodnetwork.com/recipes/marc-murphy/spaghetti-alla-carbonara-7590670","//www.foodnetwork.com/recipes/ree-drummond/spaghetti-carbonara-3220423"],
+        "path":     "//www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140"
+      }
+    </script>
+
+    <div class="o-AssetNavigation__m-Body prev-next-wrapper">
+      <div class="l-Columns l-Columns--2up">
+        <a href="#" data-type="previous" class="o-AssetNavigation__a-Button">Prev Recipe</a>
+        <a href="#" data-type="next" class="o-AssetNavigation__a-Button">Next Recipe</a>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<section class="o-Recipe">
+    
+
+
+
+  
+  
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+    
+      
+      
+       
+      
+    
+
+<div class="recipe-lead" data-module="recipe-lead">
+
+  <script type="text/x-config">
+      {
+          "suffixString" : "More",
+          "suffixStringLess" : "Less",
+          "moreLessLinks" : true,
+          "isFnkRecipe": false,
+          "graphQLEndpoint": "https://api.foodnetwork.com/kitchen/v1/graphql",
+          "isMealPlanEnabled": true,
+          "myMealPlanUrl": "https://www.foodnetwork.com/kitchen/meal-planning/my-meal-plan",
+          "upsellUrl": "https://kitchen.foodnetwork.com"
+       }
+  </script>
+  
+    
+    
+        <div class="recipeLead"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/recipe/recipeLead"></span>
+     <section class="o-RecipeLead o-RecipeLead--HasPlaylist o-RecipeLead--HasShortPlaylist o-RecipeLead--HasVideo" data-video-scroll-anchor>
+     <div class="o-RecipeLead__m-RecipeMedia">
+      
+
+      <div class="m-RecipeMedia__m-MediaBlock m-MediaBlock">
+        <div class="m-MediaBlock__m-MediaWrap">
+            <button class="m-MediaBlock__VideoButton" aria-label="Watch 911 Spaghetti Alla Carbonara">
+              
+                
+                
+    
+    <img alt="" class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.826.620.suffix/1431766590243.jpeg" srcset="//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.371.278.suffix/1431766590243.jpeg 371w,//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.441.331.suffix/1431766590243.jpeg 441w,//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.511.384.suffix/1431766590243.jpeg 511w,//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.581.436.suffix/1431766590243.jpeg 581w,//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.686.515.suffix/1431766590243.jpeg 686w,//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.756.567.suffix/1431766590243.jpeg 756w,//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.826.620.suffix/1431766590243.jpeg 826w," sizes="(max-width: 580px) 100vw,(min-width: 581px) and (max-width: 1024px) 685px,(min-width: 1025px) and (max-width: 1149px) 745px,820px"/>
+    
+    
+    
+
+              
+                <span data-type="watch-button" class="m-MediaWrap__a-Button m-MediaBlock__a-Button--Watch a-Button a-Button--Watch" tabindex="-1">
+                
+    
+    <span class="a-Button__a-ButtonText">WATCH</span>
+    
+  
+    
+  
+  
+    
+  <svg class="a-Button__a-Icon--Watch a-Button__a-Icon a-Icon--Watch a-Icon">
+    
+    <symbol id="icon-watch" viewBox="0 0 21 21">
+    <path d="M10.5 19a8.5 8.5 0 1 0 0-17 8.5 8.5 0 0 0 0 17zm0 2a10.5 10.5 0 1 1 0-21 10.5 10.5 0 0 1 0 21z"/>
+    <path d="M15.4 10.9l-8.1 4v-8z"/>
+</symbol>
+
+    <use xlink:href="#icon-watch"></use>
+  </svg>
+
+  
+
+
+    
+    
+    
+    
+  
+
+    <span class="a-Button__a-Loader a-Loader"></span>
+
+               <span class="a-Button__a-Loader a-Loader"></span>
+              </span>
+            </button>
+            
+        </div>
+      </div>
+    </div>
+
+    
+    <button class="a-Button--MealPlan" style="display: none">
+  
+    <svg class="add-to-meal-plan" width="21" height="22" viewBox="0 0 22 22">
+        <symbol id="icon-add-to-meal-plan" viewBox="0 0 23 24">
+    <g fill="none" fill-rule="evenodd">
+        <g>
+            <g>
+                <g>
+                    <g transform="translate(-745 -514) translate(717 502) translate(29 13)">
+                        <path d="M0 9.5L0 0 14 0 14 19 5 19" stroke="#FF626A" stroke-linejoin="round" transform="matrix(-1 0 0 1 14 0)"/>
+                        <rect fill="#FF626A" height="1" rx=".5" width="8" x="3" y="5"/>
+                        <rect fill="#FF626A" height="1" rx=".5" width="8" x="3" y="9"/>
+                        <rect fill="#FF626A" height="1" rx=".5" width="5" x="3" y="13"/>
+                    </g>
+                    <g stroke="#FF626A" transform="translate(-745 -514) translate(717 502) translate(29 13) translate(8 9)">
+                        <circle cx="6.5" cy="6.5" r="6.5"/>
+                        <path d="M6.5 4L6.5 9M4 6.5L9 6.5" stroke-linecap="round" stroke-linejoin="round"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</symbol>
+
+        <use xlink:href="#icon-add-to-meal-plan"></use>
+    </svg>
+  
+  
+    <svg class="added-to-meal-plan" width="21" height="22" viewBox="0 0 22 22">
+        <symbol id="icon-added-to-meal-plan" viewBox="0 0 23 24">
+    <g fill="none" fill-rule="evenodd">
+        <g>
+            <g>
+                <g>
+                    <g transform="translate(-737 -514) translate(717 502) translate(21 13)">
+                        <path d="M0 9.5L0 0 14 0 14 19 5 19" stroke="#FF626A" stroke-linejoin="round" transform="matrix(-1 0 0 1 14 0)"/>
+                        <rect fill="#FF626A" height="1" rx=".5" width="8" x="3" y="5"/>
+                        <rect fill="#FF626A" height="1" rx=".5" width="8" x="3" y="9"/>
+                        <rect fill="#FF626A" height="1" rx=".5" width="5" x="3" y="13"/>
+                    </g>
+                    <g transform="translate(-737 -514) translate(717 502) translate(21 13) translate(8 9)">
+                        <circle cx="6.5" cy="6.5" fill="#FF626A" r="6.5" stroke="#FF626A"/>
+                        <path d="M4 7.347L5.601 9 9 5" stroke="#FFF" stroke-linecap="round" stroke-linejoin="round"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</symbol>
+
+        <use xlink:href="#icon-added-to-meal-plan"></use>
+    </svg>
+  
+  <span class="a-Button-Text"> Add to Meal Plan</span>
+</button>
+
+    
+      
+  
+    <section class="o-VideoPlaylist has-Playlist" data-module="video-playlist">
+      <script type="text/x-config">
+      {
+        "isOverlay": true,
+        "player": {
+            "autoplay": false,
+            "logLevel": "warn",
+            "containerId": "video-player_",
+            "controlHoverColor": "0xffffff",
+            "controlSelectedColor": "0xffffff",
+            "playProgressColor": "0xffffff"
+        },
+        "channels": [{
+            "id": "393939393",
+            "start": 0,
+            "end": 2,
+            "total": 3,
+            "title": "",
+            "description": "",
+            "videos": [{"id":"http://data.media.theplatform.com/media/data/Media/275674179518","title":"911 Spaghetti Alla Carbonara","description":"It's Tyler to the rescue as he helps a fan make spaghetti alla carbonara.","releaseUrl":"http://link.theplatform.com/s/ip77QC/fGqanplLR7w_?format=SMIL&MBR=true","thumbnailUrl":"/content/dam/images/food/video/0/01/016/0169/0169339.jpg","length":"219","duration":"03:39","publisherId":"Food Network","nlvid":"0169339","scrid":"1305338","cmsid":"972c3428-07b7-4163-bd31-6e0685ecb097","sniGUID":"47de2d5b-d98e-4fed-ba61-5ccd56e71975","sponsor":"","mdm":"{\"Type\":\"videoPlaylistOverlay\",\"UniqueID\":\"972c3428-07b7-4163-bd31-6e0685ecb097\"}"},{"id":"http://data.media.theplatform.com/media/data/Media/275955267647","title":"How to Cook Italian Pasta","description":"Try our basic technique to cook perfect \"al dente\" pasta.","releaseUrl":"http://link.theplatform.com/s/ip77QC/Mu_4TM_ASnUV?format=SMIL&MBR=true","thumbnailUrl":"/content/dam/images/food/video/0/01/015/0154/0154994.jpg","length":"87","duration":"01:27","publisherId":"Food Network","nlvid":"0154994","scrid":"1116885","cmsid":"45d33aa7-5144-47ff-9ba7-210ad7d141dd","sniGUID":"63af3bd0-d3c9-012f-8c32-12313b075457","sponsor":"","mdm":"{\"Type\":\"videoPlaylistOverlay\",\"UniqueID\":\"45d33aa7-5144-47ff-9ba7-210ad7d141dd\"}"},{"id":"http://data.media.theplatform.com/media/data/Media/275951171717","title":"Food Network Shows How to Crush, Slice and Mince Garlic","description":"Food Network teaches how to crush, slice and mince garlic. Peel off some of the papery skin from the garlic and then smash the head of garlic with the heel of your hand to loosen the cloves; if you only need a few cloves, leave the head intact and pull some off. Separate the cloves. To peel a clove, cut away the root end with your knife. Lay the flat side of the knife over the clove while holding the knife handle, then with the heel of your free hand carefully whack the knife against the garlic to separate the skin from the clove. To crush the peeled garlic, lay the flat side of the knife over the clove and smash it again. To slice peeled garlic, lay the clove flat on the cutting board and hold it with the fingertips of one hand, keeping them curled under. Using a rocking motion with the knife, make thin slices by moving the knife slowly across the clove. To mince peeled garlic, lay the flat side of a knife over the clove and smash it. Roughly chop the clove then move your free hand flat across the tip of the knife and use a rocking motion to chop the garlic until it\u2019s finely minced.","releaseUrl":"http://link.theplatform.com/s/ip77QC/nWbIpHck9YlV?format=SMIL&MBR=true","thumbnailUrl":"/content/dam/images/food/plus/video/0/01/015/0154/0154943.jpg","length":"84","duration":"01:24","publisherId":"Food Network","nlvid":"0154943","scrid":"1116834","cmsid":"2222cee5-6e9a-4576-b206-af1c025c446b","sniGUID":"51433c20-d3cf-012f-8c32-12313b075457","sponsor":"","mdm":"{\"Type\":\"videoPlaylistOverlay\",\"UniqueID\":\"2222cee5-6e9a-4576-b206-af1c025c446b\"}"}]
+        }]
+      }
+      </script>
+      <script>
+        window.VP_COUNT = (window.VP_COUNT && ++window.VP_COUNT) || 1;
+      </script>
+      <template class="watch-button-template" style="display: none">
+        
+  
+
+
+
+  
+  
+
+
+
+<script>
+  window.VP_COUNT = (window.VP_COUNT && ++window.VP_COUNT) || 1;
+</script>
+
+  <div data-type="watch-button">
+    
+      
+        
+  
+  <a class="a-Button a-Button m-VideoPlayer__a-Button">
+    
+    <span class="a-Button__a-ButtonText">WATCH</span>
+    
+  
+    
+  
+  
+    
+  <svg class="a-Button__a-Icon--Watch a-Button__a-Icon a-Icon--Watch a-Icon">
+    
+    
+    <use xlink:href="#icon-watch"></use>
+  </svg>
+
+  
+
+
+    
+    
+    
+    
+  
+
+  </a>
+
+      
+      
+    
+  </div>
+
+      </template>
+      
+  
+
+      <div class="container container--wide">
+        <div class="o-VideoPlaylist__m-Body">
+          <div class="o-VideoPlaylist__VideoContainer">
+            <div class="o-VideoPlaylist__VideoDragContainer">
+              <div class="o-VideoPlaylist__VideoContentContainer">
+                <div class="o-VideoPlaylist__m-closeContainer">
+                  <a class="o-VideoPlaylist__a-Button--Close m-ButtonWrap" data-type="modal-close" aria-label="Close inline video" title="Close inline video"></a>
+                </div>
+                <button class="o-VideoPlaylist__VideoDragHandle">
+                  
+  <svg class="o-VideoPlaylist__a-Icon--drag o-VideoPlaylist__a-Icon a-Icon--drag a-Icon">
+    
+    <symbol id="icon-drag" viewBox="0 0 23.7 23.7">
+    <path d="M23.6 11.6l-4.1-4.1c-.2-.2-.6-.1-.6.3v2.6h-5.5V4.9H16c.3 0 .5-.4.3-.6L12.2.2c-.2-.2-.4-.2-.6-.1L7.5 4.2c-.2.3-.1.7.3.7h2.6v5.5H4.9V7.8c0-.3-.4-.5-.6-.3L.2 11.6c-.2.1-.2.4-.1.5l4.1 4.1c.2.2.6.1.6-.3v-2.6h5.5v5.5H7.8c-.3 0-.5.4-.3.6l4.1 4.1c.1.1.4.1.5 0l4.1-4.1c.2-.2.1-.6-.3-.6h-2.6v-5.5h5.5V16c0 .3.4.5.6.3l4.1-4.1c.3-.2.3-.5.1-.6z" fill="#ffffff"/>
+</symbol>
+
+    <use xlink:href="#icon-drag"></use>
+  </svg>
+
+                </button>
+                <div class="o-VideoPlaylist__m-VideoPlayer m-VideoPlayer" data-video-player>
+                  <div class="m-VideoPlayer__a-Container" data-video-container>
+                    <div id="video-player_" class="m-VideoPlayer__a-ContainerInner"></div>
+                  </div>
+                  <div class="a-DotLoader a-DotLoader--Loading">
+                    <div class="a-DotLoader__Container">
+                      <span class="a-DotLoader__Label">Loading Video...</span>
+                      <div class="a-DotLoader__CircleContainer a-DotLoader__CircleContainer--Loading loading-screen__load-icon">
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--1"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--2"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--3"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--4"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--5"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--6"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--7"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--8"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--9"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--10"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--11"></div>
+                        <div class="a-DotLoader__Circle a-DotLoader__Circle--12"></div>
+                      </div>
+                    </div>
+                    <div></div>
+                  </div>
+                </div>
+                <div class="o-VideoPlaylist__VideoContainerOverlay"></div>
+              </div>
+            </div>
+          </div>
+          
+          <div class="o-VideoPlaylist__m-Playlist" data-playlist>
+            <section class="m-Carousel o-VideoPlaylist__m-Carousel">
+              <div class="o-VideoPlaylist__m-CarouselContainer m-Carousel__m-CarouselContainer m-CarouselContainer">
+                <div class="m-Carousel__m-Slide o-VideoPlaylist__m-Slide l-List is-Active" data-type="video" data-vid-num="0" data-asset-id="97189181-a964-4cbe-8cdc-bb499cf487fb" data-cta-text="Get the Recipe" data-cta-link="//www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140">
+                  
+    
+    <div class="m-MediaBlock m-Slide__m-MediaBlock">
+    
+      
+      <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+            
+              
+  <a href="#" tabindex="-1" title="911 Spaghetti Alla Carbonara">
+    <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/video/0/01/016/0169/0169339.jpg.rend.hgtvcom.196.110.suffix/1479690440287.jpeg"/>
+    
+    
+    
+  </a>
+
+            
+
+            
+            
+            
+  <span class="m-MediaBlock__a-Label" data-label>First Up</span>
+
+            
+  <span class="m-MediaBlock__a-AssetInfo">03:39</span>
+
+             
+             
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  <span class="m-MediaBlock__a-Label" data-label>First Up</span>
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="#">
+      <span class="m-MediaBlock__a-HeadlineText">911 Spaghetti Alla Carbonara</span>
+      <span class="m-MediaBlock__a-AssetInfo">03:39</span>
+    </a>
+  </h4>
+
+            
+
+            
+  
+
+
+            
+  <div class="m-MediaBlock__a-Description">It's Tyler to the rescue as he helps a fan make spaghetti alla carbonara.</div>
+
+
+            
+  
+
+
+            
+  
+
+
+            
+
+            
+
+        </div>
+
+    
+    </div>
+
+                  
+                </div>
+              
+                <div class="m-Carousel__m-Slide o-VideoPlaylist__m-Slide l-List " data-type="video" data-vid-num="1">
+                  
+                  
+    
+    <div class="m-MediaBlock m-Slide__m-MediaBlock">
+    
+      
+      <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+            
+              
+  <a href="#" tabindex="-1" title="How to Cook Italian Pasta">
+    <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/video/0/01/015/0154/0154994.jpg.rend.hgtvcom.196.110.suffix/1570131617774.jpeg"/>
+    
+    
+    
+  </a>
+
+            
+
+            
+            
+            
+  <span class="m-MediaBlock__a-Label" data-label>Now Playing</span>
+
+            
+  <span class="m-MediaBlock__a-AssetInfo">01:27</span>
+
+             
+             
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  <span class="m-MediaBlock__a-Label" data-label>Now Playing</span>
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="#">
+      <span class="m-MediaBlock__a-HeadlineText">How to Cook Italian Pasta</span>
+      <span class="m-MediaBlock__a-AssetInfo">01:27</span>
+    </a>
+  </h4>
+
+            
+
+            
+  
+
+
+            
+  <div class="m-MediaBlock__a-Description">Try our basic technique to cook perfect &quot;al dente&quot; pasta.</div>
+
+
+            
+  
+
+
+            
+  
+
+
+            
+
+            
+
+        </div>
+
+    
+    </div>
+
+                </div>
+              
+                <div class="m-Carousel__m-Slide o-VideoPlaylist__m-Slide l-List " data-type="video" data-vid-num="2" data-cta-text="Step-by-step photos">
+                  
+                  
+    
+    <div class="m-MediaBlock m-Slide__m-MediaBlock">
+    
+      
+      <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+            
+              
+  <a href="#" tabindex="-1" title="Food Network Shows How to Crush, Slice and Mince Garlic">
+    <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/plus/video/0/01/015/0154/0154943.jpg.rend.hgtvcom.196.110.suffix/1569887222432.jpeg"/>
+    
+    
+    
+  </a>
+
+            
+
+            
+            
+            
+  <span class="m-MediaBlock__a-Label" data-label>Now Playing</span>
+
+            
+  <span class="m-MediaBlock__a-AssetInfo">01:24</span>
+
+             
+             
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  <span class="m-MediaBlock__a-Label" data-label>Now Playing</span>
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="#">
+      <span class="m-MediaBlock__a-HeadlineText">Food Network Shows How to Crush, Slice and Mince Garlic</span>
+      <span class="m-MediaBlock__a-AssetInfo">01:24</span>
+    </a>
+  </h4>
+
+            
+
+            
+  
+
+
+            
+  <div class="m-MediaBlock__a-Description">Food Network teaches how to crush, slice and mince garlic. Peel off some of the papery skin from the garlic and then smash the head of garlic with the heel of your hand to loosen the cloves; if you only need a few cloves, leave the head intact and pull some off. Separate the cloves. To peel a clove, cut away the root end with your knife. Lay the flat side of the knife over the clove while holding the knife handle, then with the heel of your free hand carefully whack the knife against the garlic to separate the skin from the clove. To crush the peeled garlic, lay the flat side of the knife over the clove and smash it again. To slice peeled garlic, lay the clove flat on the cutting board and hold it with the fingertips of one hand, keeping them curled under. Using a rocking motion with the knife, make thin slices by moving the knife slowly across the clove. To mince peeled garlic, lay the flat side of a knife over the clove and smash it. Roughly chop the clove then move your free hand flat across the tip of the knife and use a rocking motion to chop the garlic until it’s finely minced.</div>
+
+
+            
+  
+
+
+            
+  
+
+
+            
+
+            
+
+        </div>
+
+    
+    </div>
+
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+
+      
+        <div class="o-VideoPlaylist__m-Footer m-Footer" style="display: none" data-cta-area>
+          <a class="o-VideoPlaylist__a-Button" data-cta>See more</a>
+          
+  <div class="o-ReviewSummary" style="display: none" data-reviews>
+    <div id="rating-stars-link" class="m-Rating">
+      <a class="m-Rating__a-StarsLink" href="#reviewsTop" data-reviews-link>
+        <span class="gig-rating-stars" title="5 of 5 stars" data-stars-container>
+          <div class="gig-rating-star gig-rating-star-full"></div>
+          <div class="gig-rating-star gig-rating-star-full"></div>
+          <div class="gig-rating-star gig-rating-star-full"></div>
+          <div class="gig-rating-star gig-rating-star-full"></div>
+          <div class="gig-rating-star gig-rating-star-full"></div>
+        </span>
+        <span class="gig-rating-ratingsum" data-reviews-text>(12)</span>
+      </a>
+    </div>
+  </div>
+
+        </div>
+      
+
+    </section>
+
+  
+
+    
+  </section>
+
+</div>
+
+        
+
+
+
+  
+  
+
+
+<!-- Recipe Info (Summary) Section -->
+<div class="m-RecipeSummary" data-module="recipe-summary">
+  <script type="text/x-config">
+        {
+            "suffixString" : "More",
+            "suffixStringLess" : "Less",
+            "moreLessLinks" : true
+         }
+  </script>
+
+  <div class="print-recipe">
+    <svg id="LOGO" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 187 187"><style>.st0{fill:#fff}.st1{fill:#e6003d}</style><path class="st0" d="M93.6 0C42-.1 0 41.8 0 93.4c0 49.9 40 93 93.4 93.6 51.6.1 93.6-41.8 93.6-93.4C187 39.6 142.8.9 93.6 0z"/><path class="st1" d="M113.7 79.3c-.3-.4-.6-.7-.9-.9-.3-.3-.7-.5-1.1-.7-.4-.2-.9-.3-1.3-.4-.5-.1-1-.1-1.6-.1-.6 0-1.1 0-1.6.1s-1 .2-1.4.4c-.4.2-.9.4-1.3.7-.4.3-.8.6-1.2 1-.7.7-1.3 1.4-1.9 2.3-.5.9-1 1.8-1.4 2.8-.4 1-.7 2.2-1 3.3-.3 1.2-.5 2.4-.8 3.8-.3 1.3-.5 2.6-.7 3.8-.2 1.2-.3 2.3-.3 3.4s0 2 .2 2.9c.2.9.5 1.6.9 2.3.3.4.6.7.9 1 .3.3.7.5 1.1.7.4.2.9.3 1.3.4.5.1 1 .1 1.6.1.6 0 1.1-.1 1.6-.2s1-.3 1.5-.4c.5-.2.9-.4 1.3-.7a10.6 10.6 0 0 0 3-3.3c.5-.9 1-1.9 1.3-2.9l.6-1.8c.1-.5.3-1 .4-1.6.3-1.2.5-2.4.8-3.7l.3-1.8c.1-.7.2-1.3.3-1.9.2-1.2.3-2.3.3-3.3s0-2-.2-2.8c0-1.1-.3-1.8-.7-2.5zM72.2 79.3c-.3-.4-.6-.7-.9-.9-.3-.3-.7-.5-1.1-.7-.4-.2-.9-.3-1.3-.4-.5-.1-1-.1-1.6-.1-.6 0-1.1 0-1.6.1s-1 .2-1.4.4c-.5.2-.9.4-1.3.7l-1.2.9c-.7.7-1.3 1.4-1.9 2.3-.5.9-1 1.8-1.4 2.8-.4 1-.7 2.2-1 3.3-.3 1.2-.6 2.4-.8 3.8-.3 1.3-.5 2.6-.7 3.8-.2 1.2-.3 2.3-.3 3.4s0 2 .2 2.9c.2.9.5 1.6.9 2.3.3.4.6.7.9 1a4.95 4.95 0 0 0 2.4 1.1c.5.1 1 .1 1.6.1.6 0 1.1-.1 1.6-.2s1-.3 1.5-.4c.5-.2.9-.4 1.3-.7a10.6 10.6 0 0 0 3-3.3c.5-.9 1-1.8 1.3-2.9l.6-1.8c.1-.5.3-1 .4-1.6.3-1.2.5-2.4.8-3.7l.3-1.8.3-2c.2-1.2.3-2.3.3-3.3s0-2-.2-2.8c0-.9-.3-1.6-.7-2.3zM154 78.3c-.3-.3-.7-.5-1.1-.7-.4-.2-.9-.3-1.3-.4-.5-.1-1-.1-1.6-.1-.6 0-1.1 0-1.6.1s-1 .2-1.4.4c-.5.2-.9.4-1.3.7-.4.3-.8.6-1.2 1-.7.7-1.4 1.4-1.9 2.3-.5.9-1 1.8-1.4 2.9-.4 1-.7 2.2-1 3.4-.3 1.2-.6 2.5-.8 3.8-.3 1.3-.5 2.6-.7 3.8-.2 1.2-.3 2.4-.3 3.4 0 1.1 0 2 .2 2.9.2.9.5 1.7.9 2.3.3.4.6.7.9 1 .3.3.7.5 1.1.7.4.2.9.3 1.3.4.5.1 1 .1 1.6.1.6 0 1.1-.1 1.6-.2s1-.3 1.5-.4c.5-.2.9-.4 1.4-.7.4-.3.8-.6 1.2-1 .7-.7 1.3-1.5 1.9-2.3.5-.9 1-1.9 1.3-2.9l.6-1.8c.2-.7.4-1.4.6-2.2.2-1.1.5-2.2.7-3.3.1-.6.2-1.2.3-1.7l.3-2c.2-1.2.3-2.3.3-3.3s0-2-.2-2.8c-.2-.9-.5-1.6-.9-2.3-.4-.5-.7-.9-1-1.1z"/><path class="st1" d="M179.4 56.3c-.5.1-1 .2-1.5.4s-.9.4-1.4.7c-.4.3-.9.6-1.3 1-.8.7-1.4 1.5-2 2.4-.6.9-1 1.9-1.4 3-.4 1.1-.7 2.3-1.1 3.5-.3 1.2-.6 2.6-.8 4-.2.8-1.5 8.8-2.6 15.2l-1.5 8.4s0 .2-.1.5c0 .2-.1.3-.1.5-.1.7-.2 1.3-.3 1.9 0 .3-.1.5-.1.7V99.3a6.79 6.79 0 0 0 .8 3.8c.2.3.5.6.7.8l.9.6c.3.2.7.3 1.1.4h.2l-3 9.5h-.9c-1.1 0-2.1-.2-3.1-.4-.9-.2-1.8-.5-2.6-.9-.1-.1-.3-.2-.4-.3-.5-.3-1.1-.6-1.6-.9-.7-.5-1.4-1.1-1.9-1.8-.8-1.1-1.4-2.3-1.8-3.6-.5.8-1.1 1.7-1.7 2.5-.3.3-.6.7-.9 1l-.2.2c-.2.1-.3.3-.5.4-.2.1-.3.3-.5.4a14.3 14.3 0 0 1-7.2 3.2c-1 .1-2.1.2-3.3.1-1.1 0-2.1-.2-3.1-.4s-1.9-.5-2.8-.9c-.9-.4-1.6-.9-2.3-1.4-.7-.5-1.3-1.1-1.8-1.8-.9-1.2-1.4-2.6-1.8-4.1-.3-1.5-.4-3.1-.4-4.8.1-1.7.3-3.4.5-5.2.3-1.7.6-3.5 1-5.2.3-1.7.7-3.4 1.2-5.1.4-1.7.9-3.4 1.6-5.1.6-1.6 1.4-3.2 2.3-4.6.9-1.4 2-2.7 3.3-3.7.7-.6 1.5-1.1 2.4-1.6.9-.4 1.8-.8 2.8-1.1 1-.3 2-.5 3-.6 1-.1 2.1-.2 3.1-.1 1.1.1 2.1.2 3 .4.9.2 1.8.5 2.6.9s1.5.9 2.2 1.5c.6.5 1.1 1.2 1.6 1.9l.3-1.9c.3-1.6.7-3.3 1.1-5.1.4-1.8.8-3.5 1.3-5.1.5-1.6 1-3.1 1.5-4.5.2-.5.4-.9.6-1.4.1-.1.1-.3.3-.6 0 0 0-.1.1-.1.1-.2.2-.3.3-.5.2-.4.5-.8.7-1.2.5-.7 1-1.4 1.6-2 1.9-2 4.6-4.2 8.5-4.9A92.9 92.9 0 0 0 93.6 0C42-.1 0 41.8 0 93.4c0 15 3.5 29.2 9.8 41.8a9.6 9.6 0 0 0 4.6-4.1l.1-.1.1-.1c.5-.9 1-1.8 1.4-2.8.4-1 .7-2.1 1-3.3 0-.2 7.1-38.8 7.6-41.1h-6.2l3-10.3h4.9l.5-2.7c.1-.4.1-.7.2-1.1l.2-.9c.3-1.6.6-3.5.9-4.8.3-1.1.5-2 .8-2.8a22 22 0 0 1 1.3-3.4c.7-1.6 1.5-3 2.5-4.3 1-1.4 2.1-2.6 3.4-3.7.9-.8 2-1.6 3.1-2.3 1.2-.7 2.4-1.4 3.7-1.9 1.4-.6 2.9-1 4.4-1.3 1.6-.3 3.3-.5 5-.5h.2c1.7 0 3.3.2 4.7.5.6.1 1.1.3 1.6.4h.1l-3.4 10.9-.1-.1c-.1 0-.1-.1-.2-.1-.5-.2-1.1-.4-1.7-.6-.6-.1-1.3-.2-2-.2h-.1c-.7 0-1.5.1-2.2.2-.6.1-1.2.3-1.9.6h-.1-.1c-.5.2-.9.4-1.4.7-.4.3-.9.6-1.3.9-.7.6-1.4 1.3-1.9 2.2-.5.8-1 1.7-1.3 2.8-.3.9-.7 2-.9 3.3 0 .1-.2 1.1-.3 1.9-.1.7-.2 1.3-.3 1.4l-.7 4.9h7.4l-3.1 10.3h-6.1l-5.6 31.1-1.4 7.6c-.3 1.8-.6 3.3-1.1 4.8-.5 2-1.1 3.7-1.8 5.2-.7 1.6-1.6 3.1-2.6 4.4-1 1.4-2.2 2.6-3.5 3.8-1 .9-2 1.7-3.1 2.3-.9.6-1.9 1.1-3 1.6A93.3 93.3 0 0 0 93.4 187c51.6.1 93.6-41.8 93.6-93.4.1-13.2-2.7-25.8-7.6-37.3zM84.1 85.9c-.1 1.6-.4 3.4-.7 5.4-.3 2-.7 3.8-1.1 5.5-.4 1.7-.9 3.2-1.6 4.6-.6 1.4-1.3 2.7-2.2 3.9-.9 1.2-1.9 2.3-3 3.4-.8.7-1.7 1.4-2.8 2.1a23.43 23.43 0 0 1-7.4 3.1c-1.5.3-3 .5-4.7.5-1.7 0-3.2-.1-4.5-.4-1.3-.3-2.6-.7-3.6-1.2-1.1-.5-2-1.1-2.8-1.7-.8-.7-1.5-1.4-2-2.1-.8-1.1-1.4-2.2-1.9-3.4-.4-1.2-.7-2.5-.8-3.9-.1-1.4-.1-3 .1-4.6.2-1.7.4-3.5.8-5.6.4-2 .8-3.9 1.3-5.5.5-1.7 1-3.2 1.7-4.6.6-1.4 1.4-2.7 2.3-3.8.9-1.2 1.9-2.3 3.1-3.3.8-.7 1.7-1.4 2.8-2 1-.6 2.1-1.2 3.4-1.7a21.9 21.9 0 0 1 8.6-1.6c1.6 0 3.1.2 4.4.5 1.3.3 2.5.7 3.5 1.2s1.9 1.1 2.7 1.7c.8.6 1.4 1.3 2 2 .8 1 1.4 2.1 1.9 3.3.4 1.2.7 2.4.8 3.8-.2 1.3-.2 2.8-.3 4.4zm41.5 0c-.1 1.6-.4 3.4-.7 5.4-.3 2-.7 3.8-1.1 5.5-.4 1.7-1 3.2-1.6 4.6-.6 1.4-1.3 2.7-2.2 3.9-.9 1.2-1.9 2.3-3 3.4-.8.7-1.7 1.4-2.8 2.1a23.43 23.43 0 0 1-7.4 3.1c-1.5.3-3 .5-4.7.5-1.7 0-3.2-.1-4.5-.4-1.4-.3-2.6-.7-3.6-1.2-1.1-.5-2-1.1-2.8-1.7-.8-.7-1.5-1.4-2-2.1-.8-1.1-1.4-2.2-1.9-3.4-.4-1.2-.7-2.5-.8-3.9-.1-1.4-.1-3 .1-4.7.2-1.7.4-3.5.8-5.6.4-2 .8-3.9 1.3-5.5.5-1.7 1-3.2 1.7-4.6.7-1.4 1.4-2.7 2.3-3.8.9-1.2 1.9-2.3 3.1-3.3.8-.7 1.7-1.4 2.8-2 1-.6 2.1-1.2 3.4-1.7 1.2-.5 2.5-.9 4-1.1 1.4-.3 2.9-.4 4.6-.4 1.6 0 3.1.2 4.4.5 1.3.3 2.5.7 3.5 1.2s1.9 1.1 2.7 1.7c.8.6 1.4 1.3 2 2 .8 1 1.4 2.1 1.9 3.3.4 1.2.7 2.4.8 3.8-.2 1.3-.2 2.8-.3 4.4z"/><g><path class="st0" d="M59.5 137.9v-6.7c0-1.5-.9-2-1.8-2s-1.8.5-1.8 2v6.7h-2.8v-11h2.7v1c.7-.8 1.7-1.1 2.8-1.1 1.1 0 2 .4 2.6 1 .9.9 1.1 1.9 1.1 3.1v7h-2.8zM69.9 133.2c0 1.4.9 2.5 2.4 2.5 1.2 0 1.8-.3 2.5-1l1.7 1.6a5.27 5.27 0 0 1-4.2 1.7c-2.6 0-5.1-1.2-5.1-5.6 0-3.6 1.9-5.6 4.8-5.6 3.1 0 4.8 2.2 4.8 5.3v1.2h-6.9zm3.9-3c-.3-.7-.9-1.1-1.8-1.1s-1.5.5-1.8 1.1c-.2.4-.2.7-.3 1.2h4.2c0-.5-.1-.8-.3-1.2zM85.3 137.9c-2.2 0-3.2-1.6-3.2-3.2v-5.5h-1.2v-2.1h1.2v-3.3h2.8v3.3h1.9v2.1h-1.9v5.3c0 .6.3 1 1 1h1v2.3h-1.6zM103.6 137.9h-2.3L99 131l-2.3 6.9h-2.3l-3.4-11h3l1.8 6.8 2.2-6.8h2l2.3 6.8 1.8-6.8h2.9l-3.4 11zM119 136.7c-.7.7-1.8 1.4-3.4 1.4-1.6 0-2.7-.6-3.4-1.4-1-1-1.2-2.3-1.2-4.3s.3-3.2 1.2-4.3c.7-.7 1.8-1.4 3.4-1.4 1.6 0 2.7.6 3.4 1.4 1 1 1.2 2.3 1.2 4.3s-.2 3.2-1.2 4.3zm-2.1-7c-.3-.3-.7-.5-1.3-.5-.6 0-1 .2-1.3.5-.6.6-.6 1.5-.6 2.7 0 1.1.1 2.1.6 2.7.3.3.7.5 1.3.5.5 0 1-.2 1.3-.5.6-.6.6-1.5.6-2.7 0-1.2-.1-2.1-.6-2.7zM130.9 129.9c-.4-.4-.8-.7-1.5-.7-.8 0-1.8.6-1.8 2v6.6h-2.7v-11h2.7v1.1c.5-.6 1.6-1.2 2.8-1.2 1.1 0 1.8.3 2.6 1l-2.1 2.2zM143.9 137.9l-2.7-4.6-1.2 1.3v3.3h-2.8v-15.1h2.8v8.5l3.7-4.5h3.3l-3.9 4.4 4.2 6.6h-3.4z"/></g></svg>
+
+  </div>
+  
+       <div class="print-recipe assetTitle"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/article/assetTitle"></span>
+
+
+  
+    
+  
+
+
+<section class="o-AssetTitle">
+  <h1 class="o-AssetTitle__a-Headline">
+    <span class="o-AssetTitle__a-HeadlineText">Spaghetti alla Carbonara</span>
+  </h1>
+</section>
+</div>
+
+  
+  
+   
+   
+
+        <div class="attribution"><span style="display: none" class="clicktracking" data-resource-type="/apps/foodcom/components/recipe/attribution"></span>
+
+
+
+  
+  
+
+
+
+
+
+
+ 
+ 
+    
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+  
+    
+  
+
+
+
+  
+    <div class="o-Attribution">
+      <div class="o-Attribution__m-Body">
+      
+        
+          
+          <div class="o-Attribution__m-MediaWrap">
+            
+              
+                
+                  <a href="//www.foodnetwork.com/profiles/talent/tyler-florence" aria-hidden="true" tabindex="-1">
+                    <img class="o-Attribution__a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/tyler-florence/FN-TalentAvatar-Tyler-Florence-colorblock.jpg.rend.hgtvcom.126.126.suffix/1531174611134.jpeg"/>
+                  </a>
+                
+                
+              
+            
+          </div>
+        
+        <div class="o-Attribution__m-TextWrap">
+          
+          
+            <div class="o-Attribution__m-Author">
+              <span class="o-Attribution__a-Author--Prefix">
+                
+                
+                  
+                  <span class="o-Attribution__a-Name">
+                    
+                     
+                      
+                          Recipe courtesy of <a href="//www.foodnetwork.com/profiles/talent/tyler-florence">Tyler Florence</a>
+                      
+                      
+                    
+                  </span>
+                
+                
+                
+                
+                
+              </span>
+            </div>
+          
+
+           
+          
+
+         
+      	</div>
+      		
+      </div>
+    	
+    </div>
+  
+  
+    
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+  
+  
+  
+
+
+
+  
+  
+
+
+ 
+
+</div>
+
+        <div class="print-recipe">
+             <div class="attribution"><span style="display: none" class="clicktracking" data-resource-type="/apps/foodcom/components/recipe/attribution"></span>
+
+
+
+  
+  
+
+
+
+
+
+
+ 
+ 
+    
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+  
+    
+  
+
+
+
+  
+    <div class="o-Attribution">
+      <div class="o-Attribution__m-Body">
+      
+        
+          
+          <div class="o-Attribution__m-MediaWrap">
+            
+              
+                
+                  <a href="//www.foodnetwork.com/profiles/talent/tyler-florence" aria-hidden="true" tabindex="-1">
+                    <img class="o-Attribution__a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/talent/tyler-florence/FN-TalentAvatar-Tyler-Florence-colorblock.jpg.rend.hgtvcom.126.126.suffix/1531174611134.jpeg"/>
+                  </a>
+                
+                
+              
+            
+          </div>
+        
+        <div class="o-Attribution__m-TextWrap">
+          
+          
+            <div class="o-Attribution__m-Author">
+              <span class="o-Attribution__a-Author--Prefix">
+                
+                
+                  
+                  <span class="o-Attribution__a-Name">
+                    
+                     
+                      
+                          Recipe courtesy of <a href="//www.foodnetwork.com/profiles/talent/tyler-florence">Tyler Florence</a>
+                      
+                      
+                    
+                  </span>
+                
+                
+                
+                
+                
+              </span>
+            </div>
+          
+
+           
+                
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+  
+ 
+    
+    
+    
+        
+            <div class="m-MediaBlock__a-Source">
+              <span class="m-MediaBlock__a-Source--Prefix">Show:</span>
+              
+                
+                
+                <span class="m-MediaBlock__a-Source--Name">
+                  
+                    
+                        <a href="//www.foodnetwork.com/shows/food-911">Food 911</a>
+                    
+                    
+                  
+                </span>
+              
+            </div>
+            
+              <div class="m-MediaBlock__a-Source">
+                  <span class="m-MediaBlock__a-Source--Prefix">Episode:</span>
+                    
+                        
+                        
+                        <span class="m-MediaBlock__a-Source--Name">
+                            
+                                
+                                    <a href="//www.foodnetwork.com/shows/food-911/episodes/mangia-mangia">Mangia! Mangia!</a>
+                                
+                                
+                            
+                        </span>
+                    
+                </div>
+            
+      
+      
+    
+  
+  
+
+
+
+           
+          
+
+         
+      	</div>
+      		
+      </div>
+    	
+    </div>
+  
+  
+  
+
+
+ 
+
+</div>
+
+        </div>
+         
+            <div class="assetTitle"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/article/assetTitle"></span>
+
+
+  
+    
+  
+
+
+<section class="o-AssetTitle">
+  <h1 class="o-AssetTitle__a-Headline">
+    <span class="o-AssetTitle__a-HeadlineText">Spaghetti alla Carbonara</span>
+  </h1>
+</section>
+</div>
+
+          
+        <div class="review reviewSummary"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/hidden/reviewSummary"></span>
+
+
+
+  
+  
+
+
+
+
+  
+    
+
+
+
+  
+  
+
+
+
+
+  
+    
+  
+  
+  
+
+
+<div class="o-ReviewSummary" data-module="user/rating-summary">
+  <script type="text/x-config">
+  {
+    "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+    "mode": "page-top",
+    "link": "#reviewsTop",
+    "assetId": "97189181-a964-4cbe-8cdc-bb499cf487fb",
+    "assetType": "recipe"
+  }
+  </script>
+  <div class="review-summary">
+  <div class="rating-stars" title="loading">
+  <div class="rating-star rating-star-empty"></div><div class="rating-star rating-star-empty"></div><div class="rating-star rating-star-empty"></div><div class="rating-star rating-star-empty"></div><div class="rating-star rating-star-empty"></div>
+  </div>
+  <span class="loading">Getting reviews...</span>
+  </div>
+</div>
+
+  
+  
+
+</div>
+
+   
+  
+</div>
+
+    
+  
+
+
+
+  <div class="assetDescription"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/article/assetDescription"></span>
+
+
+  
+    
+  
+
+
+
+</div>
+
+  <div class="o-AssetActions o-AssetActions--saves">
+      
+         <div class="assetSave"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/general/assetSave"></span>
+
+  
+  
+
+  <div class="o-AssetSave" data-module="asset-save">
+    <script type="text/x-config">{"savesEndpointUrl": "https://api.foodnetwork.com/fn-web/v1"}</script>
+
+    <a class="o-AssetActions__a-Button o-AssetSave__a-Button--Save a-Button--Save" data-type="save-asset" data-asset-type="Recipe">
+      
+  
+    
+  <svg class="a-Button__a-Icon--Bookmark a-Button__a-Icon a-Icon--Bookmark a-Icon">
+    
+    <symbol id="icon-bookmark" viewBox="0 0 14 19">
+    <path d="M12.5 16.9V1.5h-11v15.4l5.06-3.2a.75.75 0 0 1 .8 0l5.14 3.2zm-5.54-1.67l-5.81 3.65A.75.75 0 0 1 0 18.25V.75C0 .34.34 0 .75 0h12.5c.41 0 .75.34.75.75v17.5c0 .59-.65.95-1.15.64l-5.89-3.66z"/>
+</symbol>
+
+    <use xlink:href="#icon-bookmark"></use>
+  </svg>
+
+  
+
+      <span class="a-Button__a-ButtonText">Save Recipe</span>
+    </a>
+
+  </div>
+
+</div>
+
+         <div class="assetPrint"><span style="display: none" class="clicktracking" data-resource-type="/apps/foodcom/components/general/assetPrint"></span>
+
+  <div class="o-AssetPrint" data-module="asset-print">
+    <a class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--print" href="//www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140.recipePrint" title="Print Recipe" aria-label="Print Recipe" data-type="print-asset">
+      
+  
+    
+  <svg class="a-Button__a-Icon--Print a-Button__a-Icon a-Icon--Print a-Icon">
+    
+    <symbol id="icon-print" viewBox="0 0 21 19">
+    <path d="M5.3 13v6H16v-6H5.3zm1.3 2.3h8v-1.2h-8v1.2zm0 2.5h8v-1.3h-8v1.3zM5.3 0v6H16V0z"/>
+    <path d="M18.3 3.7H17v3.9H4v-4H2.5C1.3 3.7 0 5 0 6.4v6.4c0 1.3 1.3 2.6 2.6 2.6H4v-3.9H17v3.9h1.3c1.3 0 2.6-1.3 2.6-2.6V6.3c0-1.3-1.3-2.6-2.6-2.6"/>
+</symbol>
+
+    <use xlink:href="#icon-print"></use>
+  </svg>
+
+  
+
+    </a>
+  </div>
+
+
+</div>
+
+      
+  </div>
+
+<div class="categories"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/recipe/categories"></span>
+  
+
+</div>
+
+
+<div class="recipeInfo"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/recipe/recipeInfo"></span>
+
+  
+
+  
+    <div class="o-RecipeInfo">
+      
+  
+
+  
+    
+    
+      <ul class="o-RecipeInfo__m-Level">
+        
+  <li>
+    <span class="o-RecipeInfo__a-Headline">Level:</span>
+    <span class="o-RecipeInfo__a-Description">Intermediate</span>
+  </li>
+
+
+        <li>
+          <span class="o-RecipeInfo__a-Headline m-RecipeInfo__a-Headline--Total">Total:</span>
+          <span class="o-RecipeInfo__a-Description m-RecipeInfo__a-Description--Total"> 25 min</span>
+          
+        </li>
+      </ul>
+      <ul class="o-RecipeInfo__m-Time">
+        <li>
+          <span class="o-RecipeInfo__a-Headline">Prep:</span>
+          <span class="o-RecipeInfo__a-Description"> 15 min</span>
+        </li>
+        
+        <li>
+          <span class="o-RecipeInfo__a-Headline">Cook:</span>
+          <span class="o-RecipeInfo__a-Description"> 10 min</span>
+        </li>
+      </ul>
+    
+  
+  
+
+
+      <ul class="o-RecipeInfo__m-Yield">
+        <span style="display: none" class="clicktracking" data-resource-type="sni-foundation/components/recipe/yield"></span>
+  <li>
+    <span class="o-RecipeInfo__a-Headline">Yield:</span>
+    <span class="o-RecipeInfo__a-Description">4 to 6 servings</span>
+  </li>
+
+
+        <span style="display: none" class="clicktracking" data-resource-type="sni-foundation/components/recipe/nutritionInfo"></span>
+  
+
+
+      </ul>
+    </div>
+  
+
+</div>
+
+ 
+     <div class="wallOfText"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/recipe/wallOfText"></span>
+  
+</div>
+
+ 
+
+ 
+
+
+
+
+
+
+
+  
+  
+
+
+
+<!-- Asset Actions == save + meal plan + print + social in beta -->
+  <div class="o-AssetActions">
+    
+    
+    <div class="o-AssetActions__o-SocialShare o-SocialShare" id="vote-modal">
+      
+        <span class="o-SocialShare__a-Title">Share This Recipe</span>
+      
+      <div class="socialToolbar socialSharing"><span style="display: none" class="clicktracking" data-resource-type="/apps/foodcom/components/general/socialSharing"></span>
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+  
+
+
+
+
+  
+  
+
+
+    
+
+
+  
+  
+  
+  
+
+  <div class="o-SocialShare" data-module="social-share">
+  <script type="text/x-config">
+  {
+    "socialShareServices": "PI-FB-TW-EM",
+    "publisherName": "Food Network" 
+  }
+  </script>
+  
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+
+
+  
+
+
+<ul class="m-SocialIcons " data-social-share-wrap >
+
+
+
+
+  
+  <li>
+    <a href="https://www.pinterest.com/pin/create/button?url=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140%3fsoc%3dsharepin&description=&title=Spaghetti+alla+Carbonara&media=" target="_blank" title="Share on Pinterest" aria-label="Share on Pinterest" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--pinterest" data-type="social-share" data-mode="pinterest" data-pin-custom="true" data-pin-do="buttonPin">
+      
+      <span class="o-SocialShare__m-IconWrap">
+        <svg class="a-Icon a-Icon--pinterest o-SocialShare__a-Icon o-SocialShare__a-Icon--pinterest" ><symbol id="icon-pinterest" viewBox="0 0 23 29">
+    <path d="M9.30200913,19.1876287 C8.88664247,21.1889408 8.38632195,23.0769427 7.80103257,24.8516912 C7.21574318,26.6264396 6.22454216,28.0235611 4.82739976,29.0430974 C4.4120331,26.022249 4.55363324,23.3035262 5.25220444,20.8868474 C5.95077565,18.4701687 6.54549626,16.0535262 7.03638413,13.6368474 C6.20565081,12.239705 6.17733078,10.5405033 6.95142319,8.53919117 C7.72551561,6.53787908 8.99991692,5.89595841 10.7746654,6.61340992 C11.8319623,7.02877658 12.2662028,7.81229739 12.0773998,8.96399586 C11.8885967,10.1156943 11.5959564,11.3240156 11.1994701,12.5889959 C10.8029837,13.8539761 10.5669835,15.0150973 10.4914623,16.0723943 C10.415941,17.1296912 11.0578617,17.8093719 12.4172435,18.1114568 C13.8521465,18.375781 15.0510278,17.9981806 16.0139232,16.9786443 C16.9768186,15.9591079 17.6659393,14.6941466 18.081306,13.1837224 C18.4966727,11.6732982 18.6193928,10.1156966 18.4494701,8.51087086 C18.2795473,6.90604512 17.7603468,5.65052382 16.8918529,4.74426929 C15.6079923,3.46040871 14.1259108,2.77128799 12.4455638,2.67688648 C10.7652169,2.58248497 9.20761526,2.92232532 7.77271226,3.69641773 C6.33780925,4.47051014 5.16724804,5.5844313 4.26099351,7.03821461 C3.35473898,8.49199792 3.05265866,10.1439996 3.35474351,11.9942693 C3.50578593,12.8627632 3.84562628,13.570764 4.37427476,14.1182927 C4.90292323,14.6658215 4.80852314,15.5626224 4.09107163,16.8087224 C2.4673656,16.4311164 1.36288445,15.6475956 0.777595069,14.4581365 C0.192305684,13.2686774 -0.0625745792,11.8243559 0.0129466317,10.1251287 C0.126228448,7.33084386 1.19294955,5.02748148 3.21314194,3.21497242 C5.23333434,1.40246336 7.43285661,0.364062282 9.81177476,0.0997380433 C12.8703838,-0.240107406 15.6363067,0.288533141 18.1096263,1.68567554 C20.582946,3.08281795 22.0272675,5.21626015 22.4426341,8.08606617 C22.6691978,9.7097722 22.6125577,11.3240139 22.2727123,12.9288396 C21.9328668,14.5336653 21.3664662,15.9591068 20.5734935,17.2052068 C19.7805208,18.4513068 18.7515597,19.4330678 17.4865794,20.1505193 C16.2215992,20.8679708 14.7772777,21.1700511 13.1535716,21.0567693 C12.2850777,20.9812481 11.595957,20.7546878 11.0861888,20.3770818 C10.5764206,19.9994757 9.98170003,19.6029953 9.30200913,19.1876287 Z"/>
+</symbol>
+<use xlink:href="#icon-pinterest"></use></svg>
+      </span>
+      <span class="o-SocialShare__a-Label">Pinterest</span>
+    </a>
+  </li>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+
+
+
+
+  
+
+  
+  <li>
+    <a href="https://www.facebook.com/sharer.php?u=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140%3fsoc%3dsharefb" target="_blank" title="Share on Facebook" aria-label="Share on Facebook" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--facebook" data-type="social-share" data-mode="facebook">
+      <span class="o-SocialShare__m-IconWrap">
+        <svg class="a-Icon a-Icon--facebook o-SocialShare__a-Icon o-SocialShare__a-Icon--facebook" ><symbol id="icon-facebook" viewBox="0 0 12 27">
+    <path d="M8.26953125,8.72265625 L12.4042969,8.72265625 L11.9511719,13.3671875 L8.26953125,13.3671875 L8.26953125,26.6777344 L2.77539062,26.6777344 L2.77539062,13.3671875 L0,13.3671875 L0,8.72265625 L2.77539062,8.72265625 L2.77539062,6.00390625 C2.77539062,4.04035477 3.22851109,2.54883322 4.13476562,1.52929688 C5.07878076,0.509760527 6.60806234,0 8.72265625,0 L12.4042969,0 L12.4042969,4.58789062 L10.0820312,4.58789062 C9.66666459,4.58789062 9.32682424,4.62565066 9.0625,4.70117188 C8.83593637,4.77669309 8.66601619,4.90885322 8.55273438,5.09765625 C8.43945256,5.28645928 8.36393248,5.47525947 8.32617188,5.6640625 C8.28841127,5.85286553 8.26953125,6.1171858 8.26953125,6.45703125 L8.26953125,8.72265625 Z"/>
+</symbol>
+<use xlink:href="#icon-facebook"></use></svg>
+      </span>
+      <span class="o-SocialShare__a-Label">Facebook</span>
+    </a>
+  </li>
+  
+
+  
+
+  
+
+  
+
+  
+
+
+
+
+
+  
+
+  
+
+  
+  <li>
+    <a href="https://twitter.com/intent/tweet?text=Spaghetti+alla+Carbonara&url=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140%3fsoc%3dsharetw&original_referer=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140" target="_blank" title="Share on Twitter" aria-label="Share on Twitter" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--twitter" data-type="social-share" data-mode="twitter">
+      <span class="o-SocialShare__m-IconWrap">
+        <svg class="a-Icon a-Icon--twitter o-SocialShare__a-Icon o-SocialShare__a-Icon--twitter" ><symbol id="icon-twitter" viewBox="0 0 25 21">
+    <path d="M25.4882812,2.43554688 C24.7708297,3.49284383 23.9023488,4.39908477 22.8828125,5.15429688 L22.8828125,5.83398438 C22.8828125,7.23112678 22.6751323,8.62824822 22.2597656,10.0253906 C21.844399,11.422533 21.2213583,12.7630144 20.390625,14.046875 C19.5598917,15.3307356 18.5592506,16.4635368 17.3886719,17.4453125 C16.2558537,18.4270882 14.8776123,19.2200491 13.2539062,19.8242188 C11.5924396,20.3906278 9.83659779,20.6738281 7.98632813,20.6738281 C5.0787615,20.6738281 2.41667875,19.8997473 0,18.3515625 C0.377606055,18.3893231 0.792966484,18.4082031 1.24609375,18.4082031 C3.6627725,18.4082031 5.81509473,17.6718824 7.703125,16.1992188 C6.57030684,16.1614581 5.5696658,15.8027378 4.70117188,15.1230469 C3.79491734,14.443356 3.1718767,13.5937551 2.83203125,12.5742188 C3.2096373,12.6119794 3.54947766,12.6308594 3.8515625,12.6308594 C4.30468977,12.6308594 4.75781023,12.5742193 5.2109375,12.4609375 C4.00259812,12.1966133 3.00195709,11.5924526 2.20898438,10.6484375 C1.41601166,9.70442236 1.01953125,8.59050121 1.01953125,7.30664062 L1.01953125,7.25 C1.73698275,7.66536666 2.52994357,7.89192689 3.3984375,7.9296875 C2.680986,7.43879963 2.11458541,6.81575898 1.69921875,6.06054688 C1.24609148,5.30533477 1.01953125,4.47461391 1.01953125,3.56835938 C1.01953125,2.62434424 1.2649715,1.75586334 1.75585938,0.962890625 C3.07748057,2.54883605 4.66340221,3.83267738 6.51367187,4.81445312 C8.40170215,5.75846826 10.4029842,6.28710881 12.5175781,6.40039062 C12.4420569,5.98502396 12.4042969,5.58854355 12.4042969,5.2109375 C12.4042969,3.77603449 12.9140574,2.54883322 13.9335938,1.52929688 C14.9531301,0.509760527 16.1803314,0 17.6152344,0 C19.1256586,0 20.4094999,0.547520566 21.4667969,1.64257813 C22.6373756,1.41601449 23.7324168,1.00065406 24.7519531,0.396484375 C24.3743471,1.60482375 23.6191463,2.54882473 22.4863281,3.22851562 C23.4681039,3.15299441 24.4687449,2.88867414 25.4882812,2.43554688 Z"/>
+</symbol>
+<use xlink:href="#icon-twitter"></use></svg>
+      </span>
+      <span class="o-SocialShare__a-Label">Twitter</span>
+    </a>
+  </li>
+  
+
+  
+
+  
+
+  
+
+
+
+
+
+  
+
+  
+
+  
+
+  
+  <li>
+    <a href="mailto:?body=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140&subject=Shared%20from%20Food Network" target="_blank" title="Share by Email" aria-label="Share by Email" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--email" data-type="social-share" data-mode="email">
+      <span class="o-SocialShare__m-IconWrap">
+        <svg class="a-Icon a-Icon--email o-SocialShare__a-Icon o-SocialShare__a-Icon--email" ><symbol id="icon-email" viewBox="0 0 18 14">
+    <path d="M18 1.1L9 7.9 0 1.1C0 0.8 0.1 0.5 0.3 0.3 0.5 0.1 0.8 0 1.1 0L16.9 0C17.2 0 17.5 0.1 17.7 0.3 17.9 0.5 18 0.8 18 1.1ZM0 3.2L9 9.9 18 3.2 18 12.4C18 12.7 17.9 13 17.7 13.2 17.5 13.4 17.2 13.5 16.9 13.5L1.1 13.5C0.8 13.5 0.5 13.4 0.3 13.2 0.1 13 0 12.7 0 12.4L0 3.2Z"/>
+</symbol>
+<use xlink:href="#icon-email"></use></svg>
+      </span>
+      <span class="o-SocialShare__a-Label">Email</span>
+    </a>
+  </li>
+  
+
+  
+
+  
+
+
+
+
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+  
+  <li>
+    <a href="http://facebook.com/dialog/send?link=https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140&redirect_uri=https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140&app_id=582148248497951" target="_blank" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--facebookMessenger" title="Share on Facebook Messenger" aria-label="Share on Facebook Messenger" data-type="social-share" data-mode="messenger">
+      <svg class="a-Icon a-Icon--messenger a-Button__a-Icon a-Button__a-Icon--messenger" ><symbol id="icon-messenger" viewBox="0 0 28 13">
+    <path d="M16.3 12.5l-5.6-5.8L0 12.6 11.7.1 17.3 6 28 0z"/>
+</symbol>
+<use xlink:href="#icon-messenger"></use></svg>
+    </a>
+  </li>
+  
+
+  
+
+
+
+
+</ul>
+
+  </div>
+
+</div>
+
+      
+    </div>
+  </div>
+
+</div>
+
+
+    
+
+
+
+  
+  
+
+
+
+  
+  
+  <div class="recipe-body">
+    <div class="bodyLeft">
+      <div class="print-recipe">
+        <section>
+
+  
+
+  
+    <div class="o-RecipeInfo">
+      
+  
+
+  
+    
+    
+      <ul class="o-RecipeInfo__m-Level">
+        
+  <li>
+    <span class="o-RecipeInfo__a-Headline">Level:</span>
+    <span class="o-RecipeInfo__a-Description">Intermediate</span>
+  </li>
+
+
+        <li>
+          <span class="o-RecipeInfo__a-Headline m-RecipeInfo__a-Headline--Total">Total:</span>
+          <span class="o-RecipeInfo__a-Description m-RecipeInfo__a-Description--Total"> 25 min</span>
+          
+        </li>
+      </ul>
+      <ul class="o-RecipeInfo__m-Time">
+        <li>
+          <span class="o-RecipeInfo__a-Headline">Prep:</span>
+          <span class="o-RecipeInfo__a-Description"> 15 min</span>
+        </li>
+        
+        <li>
+          <span class="o-RecipeInfo__a-Headline">Cook:</span>
+          <span class="o-RecipeInfo__a-Description"> 10 min</span>
+        </li>
+      </ul>
+    
+  
+  
+
+
+      <ul class="o-RecipeInfo__m-Yield">
+        
+  <li>
+    <span class="o-RecipeInfo__a-Headline">Yield:</span>
+    <span class="o-RecipeInfo__a-Description">4 to 6 servings</span>
+  </li>
+
+
+        
+  
+
+
+      </ul>
+    </div>
+  
+
+</section>
+      </div>
+      <section>
+
+  <section class="o-Ingredients" data-module="recipe-ingredients">
+  <script type="text/x-config">
+   {
+    "graphQLEndpoint": "https://api.foodnetwork.com/kitchen/v1/graphql",
+	"shoppingListUrl": "https://www.foodnetwork.com/kitchen/shopping-list"
+   }
+  </script>
+    
+    <header class="o-Ingredients__m-Header">
+      <div class="o-Ingredients__m-TextWrap">
+        
+  <h3 class="o-Ingredients__a-Headline">
+    
+      <span class="o-Ingredients__a-HeadlineText">Ingredients</span>
+      
+    
+  </h3>
+
+      </div>
+    </header>
+
+    <div class="o-Ingredients__m-Body">
+      <!-- Terms are food and cook, isFood is food OR cook -->
+      
+        <p class="o-Ingredients__a-Ingredient o-Ingredients__a-Ingredient--SelectAll">
+          <label class="checkbox-text">
+            <input type="checkbox" class="o-Ingredients__a-Ingredient--Checkbox" checked="" value="Deselect All"/>
+            <span class="o-Ingredients__a-Ingredient--CheckboxMock"></span>
+            <span class="o-Ingredients__a-Ingredient--CheckboxLabel">Deselect All</span>
+          </label>
+        </p>
+      
+      
+      
+        
+        
+
+        
+        
+          <p class="o-Ingredients__a-Ingredient">
+            <label class="checkbox-text">
+              
+                <input type="checkbox" class="o-Ingredients__a-Ingredient--Checkbox" checked="" value="1 pound dry spaghetti"/>
+                <span class="o-Ingredients__a-Ingredient--CheckboxMock"></span>
+              
+              <span class="o-Ingredients__a-Ingredient--CheckboxLabel">1 pound dry spaghetti</span>
+            </label>
+          </p>
+        
+          <p class="o-Ingredients__a-Ingredient">
+            <label class="checkbox-text">
+              
+                <input type="checkbox" class="o-Ingredients__a-Ingredient--Checkbox" checked="" value="2 tablespoons extra-virgin olive oil"/>
+                <span class="o-Ingredients__a-Ingredient--CheckboxMock"></span>
+              
+              <span class="o-Ingredients__a-Ingredient--CheckboxLabel">2 tablespoons extra-virgin olive oil</span>
+            </label>
+          </p>
+        
+          <p class="o-Ingredients__a-Ingredient">
+            <label class="checkbox-text">
+              
+                <input type="checkbox" class="o-Ingredients__a-Ingredient--Checkbox" checked="" value="4 ounces pancetta or slab bacon, cubed or sliced into small strips"/>
+                <span class="o-Ingredients__a-Ingredient--CheckboxMock"></span>
+              
+              <span class="o-Ingredients__a-Ingredient--CheckboxLabel">4 ounces pancetta or slab bacon, cubed or sliced into small strips</span>
+            </label>
+          </p>
+        
+          <p class="o-Ingredients__a-Ingredient">
+            <label class="checkbox-text">
+              
+                <input type="checkbox" class="o-Ingredients__a-Ingredient--Checkbox" checked="" value="4 garlic cloves, finely chopped"/>
+                <span class="o-Ingredients__a-Ingredient--CheckboxMock"></span>
+              
+              <span class="o-Ingredients__a-Ingredient--CheckboxLabel">4 garlic cloves, finely chopped</span>
+            </label>
+          </p>
+        
+          <p class="o-Ingredients__a-Ingredient">
+            <label class="checkbox-text">
+              
+                <input type="checkbox" class="o-Ingredients__a-Ingredient--Checkbox" checked="" value="2 large eggs"/>
+                <span class="o-Ingredients__a-Ingredient--CheckboxMock"></span>
+              
+              <span class="o-Ingredients__a-Ingredient--CheckboxLabel">2 large eggs</span>
+            </label>
+          </p>
+        
+          <p class="o-Ingredients__a-Ingredient">
+            <label class="checkbox-text">
+              
+                <input type="checkbox" class="o-Ingredients__a-Ingredient--Checkbox" checked="" value="1 cup freshly grated Parmigiano-Reggiano, plus more for serving"/>
+                <span class="o-Ingredients__a-Ingredient--CheckboxMock"></span>
+              
+              <span class="o-Ingredients__a-Ingredient--CheckboxLabel">1 cup freshly grated Parmigiano-Reggiano, plus more for serving</span>
+            </label>
+          </p>
+        
+          <p class="o-Ingredients__a-Ingredient">
+            <label class="checkbox-text">
+              
+                <input type="checkbox" class="o-Ingredients__a-Ingredient--Checkbox" checked="" value="Freshly ground black pepper"/>
+                <span class="o-Ingredients__a-Ingredient--CheckboxMock"></span>
+              
+              <span class="o-Ingredients__a-Ingredient--CheckboxLabel">Freshly ground black pepper</span>
+            </label>
+          </p>
+        
+          <p class="o-Ingredients__a-Ingredient">
+            <label class="checkbox-text">
+              
+                <input type="checkbox" class="o-Ingredients__a-Ingredient--Checkbox" checked="" value="1 handful fresh flat-leaf parsley, chopped"/>
+                <span class="o-Ingredients__a-Ingredient--CheckboxMock"></span>
+              
+              <span class="o-Ingredients__a-Ingredient--CheckboxLabel">1 handful fresh flat-leaf parsley, chopped</span>
+            </label>
+          </p>
+        
+      
+    </div>
+    <div class="o-Ingredients__m-Footer">
+      <div class="o-Ingredients__Button-Container">
+        
+          <button class="o-Ingredients__a-Button a-Button--AddToShoppingList">
+           
+            <svg class="" width="23" height="23" viewBox="0 0 23 23">
+                <symbol id="icon-add-circle" viewBox="0 0 23 23">
+    <g fill="none" fill-rule="evenodd" stroke="#FFF" stroke-width="1.7" transform="translate(1 1)">
+        <circle cx="10.56" cy="10.56" r="10.56"/>
+        <path d="M10.56 6.276L10.56 15.14" stroke-linecap="round"/>
+        <path d="M10.56 6.276L10.56 15.14" stroke-linecap="round" transform="rotate(-90 10.56 10.708)"/>
+    </g>
+</symbol>
+
+                <use xlink:href="#icon-add-circle"></use>
+            </svg>
+          
+
+          <span class="o-Ingredients__a-Button-Text"> Add to Shopping List</span>
+          </button>
+          <a href="https://www.foodnetwork.com/kitchen/shopping-list" class="o-Ingredients__a-Button a-Button--ViewShoppingList">
+            <!-- Aaron - Replace with shopping-cart.svg  -->
+            
+              <svg class="" width="24" height="24" viewBox="0 0 24 24">
+                <symbol id="icon-shopping-cart" viewBox="0 0 24 25">
+    <g fill="none" fill-rule="evenodd">
+        <g stroke="#FFF">
+            <g>
+                <g>
+                    <path d="M0 0L3.89 1.384 6.308 16.573 19.994 16.573" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.7" transform="translate(-169 -1806) translate(122 1715) translate(48 92)"/>
+                    <path d="M4.416 3.619L22.128 3.619 20.466 12.807 6.098 12.807" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.7" transform="translate(-169 -1806) translate(122 1715) translate(48 92)"/>
+                    <path d="M17.713 19.962c.377 0 .717.152.964.4.246.246.399.586.399.962 0 .377-.153.718-.4.964-.246.247-.586.4-.963.4-.376 0-.717-.153-.964-.4-.246-.246-.399-.587-.399-.964 0-.376.153-.716.4-.963.246-.247.587-.4.963-.4zM7.83 19.962c.375 0 .716.152.963.4.246.246.399.586.399.962 0 .377-.153.718-.4.964-.246.247-.587.4-.963.4s-.717-.153-.964-.4c-.247-.246-.4-.587-.4-.964 0-.376.153-.716.4-.963.247-.247.588-.4.964-.4z" fill="#FFF" stroke-width="1.836" transform="translate(-169 -1806) translate(122 1715) translate(48 92)"/>
+                </g>
+            </g>
+        </g>
+    </g>
+</symbol>
+
+                <use xlink:href="#icon-shopping-cart"></use>
+              </svg>
+            
+            <span class="o-Ingredients__a-Button-Text"> View Shopping List</span>
+          </a>
+        
+        
+        
+        <div id="CCKU-VPLO-TYHX-LNGN" class="whisk-container">
+
+        </div>
+        <div id="whisk-sp-unit-block-1">
+
+        </div>
+      </div>
+      <div id="dfp_native_ingredient"></div>
+    </div>
+
+  </section>
+
+</section>
+    </div>
+
+    <div class="bodyRight">
+      
+    <div class="print-recipe" id="print-recipe-lead">
+
+    </div>
+
+
+      
+      
+        <header class="o-Method__m-Header">
+          <div class="o-Method__m-TextWrap">
+            
+  <h3 class="o-Method__a-Headline">
+    
+      <span class="o-Method__a-HeadlineText">Directions</span>
+      
+    
+  </h3>
+
+          </div>
+        </header>
+      
+      
+        
+        
+  <div class="o-VideoPromo" data-module="launch-lead-video">
+    <div class="l-List">
+      <div class="m-MediaBlock">
+        <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+          
+  <a href="#launch-lead-video" data-type="launch-lead-video" tabindex="-1">
+    <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.126.95.suffix/1431766590243.jpeg"/>
+    
+    
+    
+  </a>
+
+          
+  
+    
+      
+  <a href="#launch-lead-video" data-type="launch-lead-video" class="m-MediaBlock__a-Button m-MediaBlock__a-Button--Watch a-Button a-Button--Watch">
+    
+    WATCH
+    
+  
+    
+  
+  
+    
+  <svg class="a-Button__a-Icon--Watch a-Button__a-Icon a-Icon--Watch a-Icon">
+    
+    
+    <use xlink:href="#icon-watch"></use>
+  </svg>
+
+  
+
+
+    
+    
+    
+    
+  
+
+  </a>
+
+    
+    
+  
+
+        </div>
+        <div class="m-MediaBlock__m-TextWrap">
+          
+  <a class="m-MediaBlock__a-Cta" href="#launch-lead-video" data-type="launch-lead-video">Watch how to make this recipe.</a>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+      
+
+      
+
+      
+  <section class="o-Method" data-module="recipe-method" data-read-more-target>
+
+    
+
+    
+    <div class="o-Method__m-Body">
+
+      
+      
+        
+        
+         
+        <ol>
+          
+          
+            <li class="o-Method__m-Step">
+              Prepare the sauce while the pasta is cooking to ensure that the spaghetti will be hot and ready when the sauce is finished; it is very important that the pasta is hot when adding the egg mixture, so that the heat of the pasta cooks the raw eggs in the sauce.
+            </li>
+          
+            <li class="o-Method__m-Step">
+              Bring a large pot of salted water to a boil, add the pasta and cook for 8 to 10 minutes or until tender yet firm (as they say in Italian &quot;al dente.&quot;) Drain the pasta well, reserving 1/2 cup of the starchy cooking water to use in the sauce if you wish.
+            </li>
+          
+            <li class="o-Method__m-Step">
+              Meanwhile, heat the olive oil in a deep skillet over medium flame. Add the pancetta and saute for about 3 minutes, until the bacon is crisp and the fat is rendered. Toss the garlic into the fat and saute for less than 1 minute to soften.
+            </li>
+          
+            <li class="o-Method__m-Step">
+              Add the hot, drained spaghetti to the pan and toss for 2 minutes to coat the strands in the bacon fat. Beat the eggs and Parmesan together in a mixing bowl, stirring well to prevent lumps. Remove the pan from the heat and pour the egg/cheese mixture into the pasta, whisking quickly until the eggs thicken, but do not scramble (this is done off the heat to ensure this does not happen.) Thin out the sauce with a bit of the reserved pasta water, until it reaches desired consistency. Season the carbonara with several turns of freshly ground black pepper and taste for salt. Mound the spaghetti carbonara into warm serving bowls and garnish with chopped parsley. Pass more cheese around the table.
+            </li>
+           
+        </ol>
+      
+       
+      
+       
+    </div>
+  </section>
+
+
+      
+
+      <section class="bodyRight-footer">
+        
+
+        
+
+        
+
+      </section>
+
+
+    </div>
+
+  </div>
+
+  <div class="recipe-body-footer">
+    
+      
+  <div class='private-notes' data-module="recipe-private-notes">
+    <script type="text/x-config">{
+          "recipeBoxUrl": "https://api.foodnetwork.com/fn-web/v1"
+        }
+    </script>
+    <header class="o-Capsule__m-Header">
+      <div class="o-Capsule__m-TextWrap">
+        <h3 class="o-Capsule__a-Headline">
+          <span class="o-Capsule__a-HeadlineText">My Private Notes</span>
+        </h3>
+      </div>
+    </header>
+
+    <div class="private-notes-body">
+      <section class="add-note" data-type="add-note">
+        
+  
+    
+  <svg class="a-Button__a-Icon--Add a-Button__a-Icon a-Icon--Add a-Icon">
+    
+    <symbol id="icon-add" viewBox="0 0 20 20">
+    <path d="M8.3 8.3V1.7C8.3.7 9.1 0 10 0c.9 0 1.7.7 1.7 1.7v6.7h6.7c.9 0 1.7.7 1.7 1.7 0 .9-.7 1.7-1.7 1.7h-6.7v6.7c0 .9-.7 1.7-1.7 1.7-.9 0-1.7-.7-1.7-1.7v-6.7H1.7C.7 11.7 0 10.9 0 10s.7-1.7 1.7-1.7h6.6z"/>
+</symbol>
+
+    <use xlink:href="#icon-add"></use>
+  </svg>
+
+  
+
+        <span class="add-note__title">Add a Note</span>
+      </section>
+    </div>
+  </div>
+
+
+    
+    <!-- More Related Component -->
+    
+  
+
+
+
+    <!-- Video Promo Component -->
+    
+      
+  <div class="o-VideoPromo" data-module="launch-lead-video">
+    <div class="l-List">
+      <div class="m-MediaBlock">
+        <div aria-hidden="true" class="m-MediaBlock__m-MediaWrap">
+          
+  <a href="#launch-lead-video" data-type="launch-lead-video" tabindex="-1">
+    <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.126.95.suffix/1431766590243.jpeg"/>
+    
+    
+    
+  </a>
+
+          
+  
+    
+      
+  <a href="#launch-lead-video" data-type="launch-lead-video" class="m-MediaBlock__a-Button m-MediaBlock__a-Button--Watch a-Button a-Button--Watch">
+    
+    WATCH
+    
+  
+    
+  
+  
+    
+  <svg class="a-Button__a-Icon--Watch a-Button__a-Icon a-Icon--Watch a-Icon">
+    
+    
+    <use xlink:href="#icon-watch"></use>
+  </svg>
+
+  
+
+
+    
+    
+    
+    
+  
+
+  </a>
+
+    
+    
+  
+
+        </div>
+        <div class="m-MediaBlock__m-TextWrap">
+          
+
+
+
+  
+  
+
+
+
+
+
+
+ 
+ 
+    
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+  
+    
+  
+
+
+
+  
+  
+    
+
+
+
+
+
+
+  
+  
+
+
+
+
+
+  
+ 
+    
+    
+    
+        
+            <div class="m-MediaBlock__a-Source">
+              <span class="m-MediaBlock__a-Source--Prefix">Show:</span>
+              
+                
+                
+                <span class="m-MediaBlock__a-Source--Name">
+                  
+                    
+                        <a href="//www.foodnetwork.com/shows/food-911">Food 911</a>
+                    
+                    
+                  
+                </span>
+              
+            </div>
+            
+              <div class="m-MediaBlock__a-Source">
+                  <span class="m-MediaBlock__a-Source--Prefix">Episode:</span>
+                    
+                        
+                        
+                        <span class="m-MediaBlock__a-Source--Name">
+                            
+                                
+                                    <a href="//www.foodnetwork.com/shows/food-911/episodes/mangia-mangia">Mangia! Mangia!</a>
+                                
+                                
+                            
+                        </span>
+                    
+                </div>
+            
+      
+      
+    
+  
+  
+
+
+
+  
+  
+
+
+ 
+
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+    
+
+    <!-- Categories Component -->
+    
+
+
+
+
+
+  
+  
+
+
+
+
+
+  
+
+
+
+  
+    
+  
+  
+
+
+
+  
+    
+  
+  
+
+
+
+
+
+  
+  
+
+
+
+
+  
+  
+
+
+    
+
+
+  <section class="o-Capsule o-Tags">
+    <div class="o-Capsule__m-Body">
+      <h5 class="o-Capsule__a-Subheadline a-Subheadline">Categories:</h5>
+      <div class="o-Capsule__m-TagList m-TagList">
+        
+          <a href="//www.foodnetwork.com/topics/italian" class="o-Capsule__a-Tag a-Tag" title="Italian">Italian</a>
+        
+          <a href="//www.foodnetwork.com/topics/european" class="o-Capsule__a-Tag a-Tag" title="European Recipes">European Recipes</a>
+        
+          <a href="//www.foodnetwork.com/topics/eggs" class="o-Capsule__a-Tag a-Tag" title="Egg Recipes">Egg Recipes</a>
+        
+          <a href="//www.foodnetwork.com/topics/bacon" class="o-Capsule__a-Tag a-Tag" title="Bacon Recipes">Bacon Recipes</a>
+        
+          <a href="//www.foodnetwork.com/topics/spaghetti-recipes" class="o-Capsule__a-Tag a-Tag" title="Spaghetti">Spaghetti</a>
+        
+          <a href="//www.foodnetwork.com/topics/parmesan-cheese" class="o-Capsule__a-Tag a-Tag" title="Parmesan Cheese Recipes">Parmesan Cheese Recipes</a>
+        
+          <a href="//www.foodnetwork.com/topics/main-dish" class="o-Capsule__a-Tag a-Tag" title="Main Dish">Main Dish</a>
+        
+      </div>
+    </div>
+  </section>
+
+
+
+    <!-- More From Component -->
+    
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+  
+  
+    
+  
+
+
+
+  
+
+
+
+
+  
+  
+
+
+    
+
+
+  <section class="o-Capsule o-PackagePromo">
+      <header class="o-Capsule__m-Header"></header>
+      <div class="o-Capsule__m-Body">
+          
+          
+          
+              
+              
+                  <div class="o-PackagePromo__a-SubHeadline">More from: </div>
+              
+              
+          
+          
+              
+              
+                  <h3 class="o-PackagePromo__a-Headline"><a class="o-PackagePromo__a-HeadlineText" href="//www.foodnetwork.com/recipes/packages/weeknight-dinners-winter">Winter Weeknight Dinners</a></h3>
+              
+              
+          
+      </div>
+  </section>
+
+
+
+  </div>   
+
+  
+    <div id="dfp_cartridge"></div>
+    
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+
+
+
+    <div class="lookingForSomethingElse"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/recipe/lookingForSomethingElse"></span>
+  <section class="o-Recommendations">
+    <header class="o-Recommendations__m-Header m-Header">
+  <div class="o-Recommendations__m-TextWrap m-TextWrap">
+    <h3 class="o-Recommendations__a-Headline a-Headline">
+      <span class="o-Recommendations__a-HeadlineText a-HeadlineText">Looking for Something Else?</span>
+    </h3>
+  </div>
+</header>
+
+    <div class="o-Recommendations__m-Body m-Body" data-module="looking-for-something">
+        <div class="m-Tabs">
+          <div class="m-ScrollContainer">
+            
+              <a class="a-Tab" href="#" data-type="quickAndEasy">Quick &amp; Easy</a>
+            
+              <a class="a-Tab" href="#" data-type="moreMainIngredient">More Eggs Recipes</a>
+            
+              <a class="a-Tab" href="#" data-type="fiveIngredientsOrLess">5 Ingredients or Less</a>
+            
+              <a class="a-Tab" href="#" data-type="highlyRated">Highly Rated</a>
+            
+          </div>
+        </div>
+        <div class="m-Content">
+        
+  <div class="m-ScrollContainer" data-module="multi-content-stream">
+    <div class="o-Recommendations__TileContainer o-Recommendations__TileContainer--general l-Columns l-Columns--4up">
+    
+  
+  <div class="m-MediaBlock o-Recommendations__m-MediaBlock">
+    <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+      
+  <a href="//www.foodnetwork.com/recipes/ina-garten/real-meatballs-and-spaghetti-recipe-1946027" tabindex="-1" title="Real Meatballs and Spaghetti">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2012/11/12/0/FN_Ina-Garten-Real-Meatballs-and-Spaghetti_s4x3.jpg.rend.hgtvcom.406.305.suffix/1384540886901.jpeg" alt="FN_Ina Garten Real Meatballs and Spaghetti.tif" title="FN_Ina Garten Real Meatballs and Spaghetti.tif"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2012/11/12/0/FN_Ina-Garten-Real-Meatballs-and-Spaghetti_s4x3.jpg.rend.hgtvcom.406.305.suffix/1384540886901.jpeg" alt="FN_Ina Garten Real Meatballs and Spaghetti.tif" title="FN_Ina Garten Real Meatballs and Spaghetti.tif"/>
+    </noscript>
+    
+  </a>
+
+      
+      
+  
+
+      
+    </div>
+    <div class="m-MediaBlock__m-TextWrap">
+      
+      
+  
+
+
+      
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/ina-garten/real-meatballs-and-spaghetti-recipe-1946027">
+      <span class="m-MediaBlock__a-HeadlineText">Real Meatballs and Spaghetti</span>
+      
+    </a>
+  </h4>
+
+
+      
+  
+
+
+      
+  
+
+
+      
+  
+
+
+      
+
+      
+
+    </div>
+    
+  
+    
+    <section class="m-ReviewSummary" data-module="user/rating-summary">
+      <script type="text/x-config">
+      {
+        "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+        "mode": "compact",
+        "link": "//www.foodnetwork.com/recipes/ina-garten/real-meatballs-and-spaghetti-recipe-1946027#reviewsTop",
+        "assetId": "8da3356c-5eef-4fbb-9be9-4e4184169818",
+        "assetType": "recipe"
+      }
+      </script>
+      <div class="review-summary"></div>
+    </section>
+  
+
+  </div>
+
+    
+    
+  
+  <div class="m-MediaBlock o-Recommendations__m-MediaBlock">
+    <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+      
+  <a href="//www.foodnetwork.com/recipes/marc-murphy/spaghetti-alla-carbonara-7590670" tabindex="-1" title="Spaghetti alla Carbonara">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2019/10/23/KC2213__spaghetti-alla-carbonara_s4x3.jpg.rend.hgtvcom.406.305.suffix/1571866375202.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2019/10/23/KC2213__spaghetti-alla-carbonara_s4x3.jpg.rend.hgtvcom.406.305.suffix/1571866375202.jpeg"/>
+    </noscript>
+    
+  </a>
+
+      
+      
+  
+
+      
+    </div>
+    <div class="m-MediaBlock__m-TextWrap">
+      
+      
+  
+
+
+      
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/marc-murphy/spaghetti-alla-carbonara-7590670">
+      <span class="m-MediaBlock__a-HeadlineText">Spaghetti alla Carbonara</span>
+      
+    </a>
+  </h4>
+
+
+      
+  
+
+
+      
+  
+
+
+      
+  
+
+
+      
+
+      
+
+    </div>
+    
+  
+    
+    <section class="m-ReviewSummary" data-module="user/rating-summary">
+      <script type="text/x-config">
+      {
+        "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+        "mode": "compact",
+        "link": "//www.foodnetwork.com/recipes/marc-murphy/spaghetti-alla-carbonara-7590670#reviewsTop",
+        "assetId": "8936e619aa3304cc5652fc2328662e2f",
+        "assetType": "recipe"
+      }
+      </script>
+      <div class="review-summary"></div>
+    </section>
+  
+
+  </div>
+
+    
+    
+  
+  <div class="m-MediaBlock o-Recommendations__m-MediaBlock">
+    <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+      
+  <a href="//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-recipe-1911738" tabindex="-1" title="Spaghetti alla Carbonara">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/homepage/fn-feature.jpg.rend.hgtvcom.406.305.suffix/1474463768097.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/homepage/fn-feature.jpg.rend.hgtvcom.406.305.suffix/1474463768097.jpeg"/>
+    </noscript>
+    
+  </a>
+
+      
+      
+  
+
+      
+    </div>
+    <div class="m-MediaBlock__m-TextWrap">
+      
+      
+  
+
+
+      
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-recipe-1911738">
+      <span class="m-MediaBlock__a-HeadlineText">Spaghetti alla Carbonara</span>
+      
+    </a>
+  </h4>
+
+
+      
+  
+
+
+      
+  
+
+
+      
+  
+
+
+      
+
+      
+
+    </div>
+    
+  
+    
+    <section class="m-ReviewSummary" data-module="user/rating-summary">
+      <script type="text/x-config">
+      {
+        "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+        "mode": "compact",
+        "link": "//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-recipe-1911738#reviewsTop",
+        "assetId": "31bddd06-f94c-4523-a9e4-78adae576ad5",
+        "assetType": "recipe"
+      }
+      </script>
+      <div class="review-summary"></div>
+    </section>
+  
+
+  </div>
+
+    
+    
+  
+  <div class="m-MediaBlock o-Recommendations__m-MediaBlock">
+    <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+      
+  <a href="//www.foodnetwork.com/recipes/anne-burrell/spaghetti-alla-carbonara-recipe-1946891" tabindex="-1" title="Spaghetti alla Carbonara">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/4/23/0/LR0301-1_Spaghetti-alla-Carbonara_s4x3.jpg.rend.hgtvcom.406.305.suffix/1383163803923.jpeg" alt="575" title="575"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2009/4/23/0/LR0301-1_Spaghetti-alla-Carbonara_s4x3.jpg.rend.hgtvcom.406.305.suffix/1383163803923.jpeg" alt="575" title="575"/>
+    </noscript>
+    
+  </a>
+
+      
+      
+  
+
+      
+    </div>
+    <div class="m-MediaBlock__m-TextWrap">
+      
+      
+  
+
+
+      
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/anne-burrell/spaghetti-alla-carbonara-recipe-1946891">
+      <span class="m-MediaBlock__a-HeadlineText">Spaghetti alla Carbonara</span>
+      
+    </a>
+  </h4>
+
+
+      
+  
+
+
+      
+  
+
+
+      
+  
+
+
+      
+
+      
+
+    </div>
+    
+  
+    
+    <section class="m-ReviewSummary" data-module="user/rating-summary">
+      <script type="text/x-config">
+      {
+        "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+        "mode": "compact",
+        "link": "//www.foodnetwork.com/recipes/anne-burrell/spaghetti-alla-carbonara-recipe-1946891#reviewsTop",
+        "assetId": "a17ba10f-100d-4316-b33b-06eed299513a",
+        "assetType": "recipe"
+      }
+      </script>
+      <div class="review-summary"></div>
+    </section>
+  
+
+  </div>
+
+    
+    
+  
+  <div class="m-MediaBlock o-Recommendations__m-MediaBlock">
+    <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+      
+  <a href="//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-recipe1-1940769" tabindex="-1" title="Spaghetti alla Carbonara">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2003/10/27/0/ad1a17_carbonara.jpg.rend.hgtvcom.406.305.suffix/1387051962821.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2003/10/27/0/ad1a17_carbonara.jpg.rend.hgtvcom.406.305.suffix/1387051962821.jpeg"/>
+    </noscript>
+    
+  </a>
+
+      
+      
+  
+
+      
+    </div>
+    <div class="m-MediaBlock__m-TextWrap">
+      
+      
+  
+
+
+      
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-recipe1-1940769">
+      <span class="m-MediaBlock__a-HeadlineText">Spaghetti alla Carbonara</span>
+      
+    </a>
+  </h4>
+
+
+      
+  
+
+
+      
+  
+
+
+      
+  
+
+
+      
+
+      
+
+    </div>
+    
+  
+    
+    <section class="m-ReviewSummary" data-module="user/rating-summary">
+      <script type="text/x-config">
+      {
+        "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+        "mode": "compact",
+        "link": "//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-recipe1-1940769#reviewsTop",
+        "assetId": "6bb60849-9112-4c4e-ac25-1d1990282f42",
+        "assetType": "recipe"
+      }
+      </script>
+      <div class="review-summary"></div>
+    </section>
+  
+
+  </div>
+
+    
+    
+  
+  <div class="m-MediaBlock o-Recommendations__m-MediaBlock">
+    <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+      
+  <a href="//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-recipe0-1956431" tabindex="-1" title="Spaghetti alla Carbonara">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/homepage/fn-feature.jpg.rend.hgtvcom.406.305.suffix/1474463768097.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/homepage/fn-feature.jpg.rend.hgtvcom.406.305.suffix/1474463768097.jpeg"/>
+    </noscript>
+    
+  </a>
+
+      
+      
+  
+
+      
+    </div>
+    <div class="m-MediaBlock__m-TextWrap">
+      
+      
+  
+
+
+      
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-recipe0-1956431">
+      <span class="m-MediaBlock__a-HeadlineText">Spaghetti alla Carbonara</span>
+      
+    </a>
+  </h4>
+
+
+      
+  
+
+
+      
+  
+
+
+      
+  
+
+
+      
+
+      
+
+    </div>
+    
+  
+    
+    <section class="m-ReviewSummary" data-module="user/rating-summary">
+      <script type="text/x-config">
+      {
+        "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+        "mode": "compact",
+        "link": "//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-recipe0-1956431#reviewsTop",
+        "assetId": "15d5736d-03b9-490d-9191-a68ca9fa11a9",
+        "assetType": "recipe"
+      }
+      </script>
+      <div class="review-summary"></div>
+    </section>
+  
+
+  </div>
+
+    
+    
+  
+  <div class="m-MediaBlock o-Recommendations__m-MediaBlock">
+    <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+      
+  <a href="//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-2104329" tabindex="-1" title="Spaghetti Alla Carbonara">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/editorial/homepage/fn-feature.jpg.rend.hgtvcom.406.305.suffix/1474463768097.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/editorial/homepage/fn-feature.jpg.rend.hgtvcom.406.305.suffix/1474463768097.jpeg"/>
+    </noscript>
+    
+  </a>
+
+      
+      
+  
+
+      
+    </div>
+    <div class="m-MediaBlock__m-TextWrap">
+      
+      
+  
+
+
+      
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-2104329">
+      <span class="m-MediaBlock__a-HeadlineText">Spaghetti Alla Carbonara</span>
+      
+    </a>
+  </h4>
+
+
+      
+  
+
+
+      
+  
+
+
+      
+  
+
+
+      
+
+      
+
+    </div>
+    
+  
+    
+    <section class="m-ReviewSummary" data-module="user/rating-summary">
+      <script type="text/x-config">
+      {
+        "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+        "mode": "compact",
+        "link": "//www.foodnetwork.com/recipes/spaghetti-alla-carbonara-2104329#reviewsTop",
+        "assetId": "feb885f67b48855c25f9942aa82ac352",
+        "assetType": "recipe"
+      }
+      </script>
+      <div class="review-summary"></div>
+    </section>
+  
+
+  </div>
+
+    
+    
+  
+  <div class="m-MediaBlock o-Recommendations__m-MediaBlock">
+    <div class="m-MediaBlock__m-MediaWrap" aria-hidden="true">
+      
+  <a href="//www.foodnetwork.com/recipes/rachael-ray/saffron-spaghetti-alla-carbonara-recipe-1940681" tabindex="-1" title="Saffron Spaghetti alla Carbonara">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2008/10/3/0/TM1904_Saffron-Spaghetti.jpg.rend.hgtvcom.406.305.suffix/1371587709599.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2008/10/3/0/TM1904_Saffron-Spaghetti.jpg.rend.hgtvcom.406.305.suffix/1371587709599.jpeg"/>
+    </noscript>
+    
+  </a>
+
+      
+      
+  
+
+      
+    </div>
+    <div class="m-MediaBlock__m-TextWrap">
+      
+      
+  
+
+
+      
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/rachael-ray/saffron-spaghetti-alla-carbonara-recipe-1940681">
+      <span class="m-MediaBlock__a-HeadlineText">Saffron Spaghetti alla Carbonara</span>
+      
+    </a>
+  </h4>
+
+
+      
+  
+
+
+      
+  
+
+
+      
+  
+
+
+      
+
+      
+
+    </div>
+    
+  
+    
+    <section class="m-ReviewSummary" data-module="user/rating-summary">
+      <script type="text/x-config">
+      {
+        "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+        "mode": "compact",
+        "link": "//www.foodnetwork.com/recipes/rachael-ray/saffron-spaghetti-alla-carbonara-recipe-1940681#reviewsTop",
+        "assetId": "5bae7556-eeeb-44ad-ab70-c48c2baafafe",
+        "assetType": "recipe"
+      }
+      </script>
+      <div class="review-summary"></div>
+    </section>
+  
+
+  </div>
+
+    </div>
+  </div>
+
+
+
+
+      </div>
+    </div>
+  </section>
+  
+
+</div>
+
+    
+  
+
+
+
+
+
+  
+
+  
+
+  
+
+
+
+  
+  
+
+
+
+
+  
+    
+
+
+
+  
+  
+
+
+
+
+  
+    
+  
+  
+  
+
+
+<section class="o-RatingsAndReviews o-RatingsAndReviews--NoReviews o-Capsule">
+  <header class="o-Capsule__m-Header" id="reviewsTop" data-module="user/rating-summary">
+  <script type="text/x-config">
+  {
+    "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/",
+    "mode": "reviews-top",
+    "assetId": "97189181-a964-4cbe-8cdc-bb499cf487fb",
+    "assetType": "recipe"
+  }
+  </script>
+  
+  <div class="review-summary"></div>
+  </header>
+
+  
+  <div class="o-UserComments" data-module="user/comments-feed">
+    <script type="text/x-config">
+    {
+      "chitterProxyEndpoint": "https://api.sni.foodnetwork.com/moderation-chitter-proxy/v1/"
+    }
+    </script>
+  </div>
+
+</section>
+
+  
+  
+
+
+
+
+
+
+</section>
+
+        </div>
+      </div>
+
+        <div class="col-md-10">
+          
+
+
+
+  
+  
+
+
+
+   
+     
+     
+        
+
+
+
+  
+  
+
+
+<div class="container-aside">
+    <div class="module text-center">
+      <div id="dfp_bigbox_recipe_top"></div>
+    </div>
+    <div class="rightRail">
+       
+    
+    <div class="relatedClasses_rightRailTop relatedClasses capsule"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/hidden/relatedClasses"></span>
+  
+
+
+
+
+</div>
+
+    
+    <div class="reference_rightRailTop reference"><div class="cq-dd-paragraph"><div class="rightRailTop parsys">
+
+
+<div class="editorialPromo capsule section"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/promotion/editorialPromo"></span>
+
+  
+
+
+
+
+   <section class="o-Capsule o-EditorialPromo  ">
+
+    
+    
+
+
+  <header class="o-Capsule__m-Header">
+    <div class="o-Capsule__m-TextWrap">
+      
+  
+
+      
+    </div>
+    
+  
+
+  </header>
+
+
+
+    
+    <div class="o-Capsule__m-Body">
+        
+
+  
+  
+    
+  
+
+
+  
+  
+  
+  
+  
+
+    
+    
+    
+    <div class="l-List   " data-module="editorial-promo">
+
+      
+      
+      
+      
+    
+    <div class="m-MediaBlock o-Capsule__m-MediaBlock">
+        <div class="m-MediaBlock__m-MediaWrap">
+            
+  <a href="https://nycwff.org?utm_source=FoodNetwork&utm_medium=Banners+&utm_campaign=General+Sale+" title="The New York City Wine &amp; Food Festival">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2021/08/23/FN-digital_NYCWFF-for-recipe-right-rail_196x147-5.jpg.rend.hgtvcom.161.121.suffix/1629768586138.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2021/08/23/FN-digital_NYCWFF-for-recipe-right-rail_196x147-5.jpg.rend.hgtvcom.161.121.suffix/1629768586138.jpeg"/>
+    </noscript>
+    
+  </a>
+
+            
+            
+  
+
+            
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  
+
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="https://nycwff.org?utm_source=FoodNetwork&utm_medium=Banners+&utm_campaign=General+Sale+">
+      <span class="m-MediaBlock__a-HeadlineText">The New York City Wine &amp; Food Festival</span>
+      
+    </a>
+  </h4>
+
+
+            
+  
+
+
+            
+  <div class="m-MediaBlock__a-Description"><p data-pm-slice="1 1 []">Four days of eating, drinking and all your favorite chefs.</p></div>
+
+
+            
+
+            
+  <a class="m-MediaBlock__a-Cta" href="https://nycwff.org?utm_source=FoodNetwork&utm_medium=Banners+&utm_campaign=General+Sale+">Buy Your Tickets</a>
+
+
+            
+
+            
+
+        </div>
+
+    </div>
+
+
+    </div>
+  
+  
+  
+
+
+    </div>
+
+    
+    
+
+
+  <footer class="o-Capsule__m-Footer">
+
+      
+  
+
+
+  </footer>
+
+
+
+  </section>
+
+</div>
+<div class="editorialPromo capsule section"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/promotion/editorialPromo"></span>
+
+  
+
+
+
+
+   <section class="o-Capsule o-EditorialPromo  ">
+
+    
+    
+
+
+  <header class="o-Capsule__m-Header">
+    <div class="o-Capsule__m-TextWrap">
+      
+  <h3 class="o-Capsule__a-Headline">
+    
+      <span class="o-Capsule__a-HeadlineText">👩‍🍳 What's Cooking</span>
+      
+    
+  </h3>
+
+      
+    </div>
+    
+  
+
+  </header>
+
+
+
+    
+    <div class="o-Capsule__m-Body">
+        
+
+  
+  
+    
+  
+
+
+  
+  
+  
+  
+  
+
+    
+    
+    
+    <div class="l-List   " data-module="editorial-promo">
+
+      
+      
+      
+      
+    
+    <div class="m-MediaBlock o-Capsule__m-MediaBlock m-MediaBlock--gallery">
+        <div class="m-MediaBlock__m-MediaWrap">
+            
+  <a href="//www.foodnetwork.com/healthy/packages/healthy-every-week/quick-and-simple/healthy-dinners-in-40-minutes-or-less#item-8" title="Quick + Healthy Meals">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2020/06/10/0/FNK_Healthy-Thai-Tuna-Grain-Bowls_H1_s4x3.jpg.rend.hgtvcom.161.121.suffix/1591824749231.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2020/06/10/0/FNK_Healthy-Thai-Tuna-Grain-Bowls_H1_s4x3.jpg.rend.hgtvcom.161.121.suffix/1591824749231.jpeg"/>
+    </noscript>
+    
+  </a>
+
+            
+            
+  
+
+            
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  
+
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/healthy/packages/healthy-every-week/quick-and-simple/healthy-dinners-in-40-minutes-or-less#item-8">
+      <span class="m-MediaBlock__a-HeadlineText">Quick + Healthy Meals</span>
+      <span class="m-MediaBlock__a-AssetInfo">
+            
+            
+  <svg class="m-MediaBlock__a-Icon--gallery m-MediaBlock__a-Icon a-Icon--gallery a-Icon">
+    
+    <symbol id="icon-gallery" viewBox="0 0 32 32">
+    <path d="M21.333 25.333h-14.667v-12h14.667v12zM24 10.667h2.667v10.667h-2.667v-10.667zM10.667 8h16v2.667h-16v-2.667z"/>
+</symbol>
+
+    <use xlink:href="#icon-gallery"></use>
+  </svg>
+
+      </span>
+    </a>
+  </h4>
+
+
+            
+  
+
+
+            
+  
+
+
+            
+
+            
+  
+
+
+            
+
+            
+
+        </div>
+
+    </div>
+
+
+    
+
+      
+      
+      
+      
+    
+    <div class="m-MediaBlock o-Capsule__m-MediaBlock m-MediaBlock--gallery">
+        <div class="m-MediaBlock__m-MediaWrap">
+            
+  <a href="//www.foodnetwork.com/recipes/photos/food-network-kitchen-s-best-recipes#item-29" title="Our Very Best Recipes">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2019/7/11/0/FNK_the-best-beef-stew_H_s4x3.jpg.rend.hgtvcom.161.121.suffix/1562853899529.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2019/7/11/0/FNK_the-best-beef-stew_H_s4x3.jpg.rend.hgtvcom.161.121.suffix/1562853899529.jpeg"/>
+    </noscript>
+    
+  </a>
+
+            
+            
+  
+
+            
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  
+
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/photos/food-network-kitchen-s-best-recipes#item-29">
+      <span class="m-MediaBlock__a-HeadlineText">Our Very Best Recipes</span>
+      <span class="m-MediaBlock__a-AssetInfo">
+            
+            
+  <svg class="m-MediaBlock__a-Icon--gallery m-MediaBlock__a-Icon a-Icon--gallery a-Icon">
+    
+    
+    <use xlink:href="#icon-gallery"></use>
+  </svg>
+
+      </span>
+    </a>
+  </h4>
+
+
+            
+  
+
+
+            
+  
+
+
+            
+
+            
+  
+
+
+            
+
+            
+
+        </div>
+
+    </div>
+
+
+    
+
+      
+      
+      
+      
+    
+    <div class="m-MediaBlock o-Capsule__m-MediaBlock m-MediaBlock--gallery">
+        <div class="m-MediaBlock__m-MediaWrap">
+            
+  <a href="//www.foodnetwork.com/recipes/photos/plant-based-recipes#item-3" title="Plant-Based Ideas">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2016/10/30/0/FNK_Cherry-Almon-Pepita-Snack-Bar_s4x3.jpg.rend.hgtvcom.161.121.suffix/1478160043729.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2016/10/30/0/FNK_Cherry-Almon-Pepita-Snack-Bar_s4x3.jpg.rend.hgtvcom.161.121.suffix/1478160043729.jpeg"/>
+    </noscript>
+    
+  </a>
+
+            
+            
+  
+
+            
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  
+
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/recipes/photos/plant-based-recipes#item-3">
+      <span class="m-MediaBlock__a-HeadlineText">Plant-Based Ideas</span>
+      <span class="m-MediaBlock__a-AssetInfo">
+            
+            
+  <svg class="m-MediaBlock__a-Icon--gallery m-MediaBlock__a-Icon a-Icon--gallery a-Icon">
+    
+    
+    <use xlink:href="#icon-gallery"></use>
+  </svg>
+
+      </span>
+    </a>
+  </h4>
+
+
+            
+  
+
+
+            
+  
+
+
+            
+
+            
+  
+
+
+            
+
+            
+
+        </div>
+
+    </div>
+
+
+    </div>
+  
+  
+  
+
+
+    </div>
+
+    
+    
+
+
+  <footer class="o-Capsule__m-Footer">
+
+      
+  <a class="o-Capsule__a-Cta" href="//www.foodnetwork.com/recipes" data-type="EditorialPromo">Discover More Recipes...</a>
+
+
+  </footer>
+
+
+
+  </section>
+
+</div>
+<div class="freeFormHTMLArea section"></div>
+
+</div>
+</div>
+</div>
+
+    </div>
+    <div class="module text-center">
+      <div id="dfp_bigbox_2"></div>
+    </div>
+    <div class="reference_rightRail reference"><div class="cq-dd-paragraph"><div class="rightRail parsys">
+
+
+<div class="editorialPromo capsule section"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/promotion/editorialPromo"></span>
+
+  
+
+
+
+
+   <section class="o-Capsule o-EditorialPromo  ">
+
+    
+    
+
+
+  <header class="o-Capsule__m-Header">
+    <div class="o-Capsule__m-TextWrap">
+      
+  <h3 class="o-Capsule__a-Headline">
+    
+      <span class="o-Capsule__a-HeadlineText">What's New</span>
+      
+    
+  </h3>
+
+      
+    </div>
+    
+  
+
+  </header>
+
+
+
+    
+    <div class="o-Capsule__m-Body">
+        
+
+  
+  
+    
+  
+
+
+  
+  
+  
+  
+  
+
+    
+    
+    
+    <div class="l-List   " data-module="editorial-promo">
+
+      
+      
+      
+      
+    
+    <div class="m-MediaBlock o-Capsule__m-MediaBlock">
+        <div class="m-MediaBlock__m-MediaWrap">
+            
+  <a href="//www.foodnetwork.com/how-to/packages/shopping/product-reviews/best-slow-cookers" target="_blank" title="7 Best Slow Cookers, Tested by Food Network Kitchen">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/products/2019/6/6/fn_slow-Cookers-product-review_s4x3.jpg.rend.hgtvcom.161.121.suffix/1559847842717.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/products/2019/6/6/fn_slow-Cookers-product-review_s4x3.jpg.rend.hgtvcom.161.121.suffix/1559847842717.jpeg"/>
+    </noscript>
+    
+  </a>
+
+            
+            
+  
+
+            
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  
+
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/how-to/packages/shopping/product-reviews/best-slow-cookers" target="_blank">
+      <span class="m-MediaBlock__a-HeadlineText">7 Best Slow Cookers, Tested by Food Network Kitchen</span>
+      
+    </a>
+  </h4>
+
+
+            
+  
+
+
+            
+  
+
+
+            
+
+            
+  
+
+
+            
+
+            
+
+        </div>
+
+    </div>
+
+
+    
+
+      
+      
+      
+      
+    
+    <div class="m-MediaBlock o-Capsule__m-MediaBlock">
+        <div class="m-MediaBlock__m-MediaWrap">
+            
+  <a href="//www.foodnetwork.com/how-to/packages/shopping/product-reviews/best-kitchen-towels" target="_blank" title="3 Best Kitchen Towels, Tested by Food Network Kitchen">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2020/01/28/0/fn_kitchen-towel-utensils-getty_s4x3.jpg.rend.hgtvcom.161.121.suffix/1580238967857.jpeg" alt="1171690276" title="1171690276"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/fullset/2020/01/28/0/fn_kitchen-towel-utensils-getty_s4x3.jpg.rend.hgtvcom.161.121.suffix/1580238967857.jpeg" alt="1171690276" title="1171690276"/>
+    </noscript>
+    
+  </a>
+
+            
+            
+  
+
+            
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  
+
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/how-to/packages/shopping/product-reviews/best-kitchen-towels" target="_blank">
+      <span class="m-MediaBlock__a-HeadlineText">3 Best Kitchen Towels, Tested by Food Network Kitchen</span>
+      
+    </a>
+  </h4>
+
+
+            
+  
+
+
+            
+  
+
+
+            
+
+            
+  
+
+
+            
+
+            
+
+        </div>
+
+    </div>
+
+
+    
+
+      
+      
+      
+      
+    
+    <div class="m-MediaBlock o-Capsule__m-MediaBlock">
+        <div class="m-MediaBlock__m-MediaWrap">
+            
+  <a href="//www.foodnetwork.com/how-to/packages/shopping/product-reviews/best-touchless-trash-cans" target="_blank" title="The 5 Best Touchless Trash Cans">
+    
+    <img class="m-MediaBlock__a-Image a-Image" data-src="//food.fnr.sndimg.com/content/dam/images/food/products/2021/3/30/rx_81nWerLjHxL._AC_SL1500_.jpg.rend.hgtvcom.161.121.suffix/1617141508918.jpeg"/>
+    <noscript>
+      <img class="m-MediaBlock__a-Image a-Image" src="//food.fnr.sndimg.com/content/dam/images/food/products/2021/3/30/rx_81nWerLjHxL._AC_SL1500_.jpg.rend.hgtvcom.161.121.suffix/1617141508918.jpeg"/>
+    </noscript>
+    
+  </a>
+
+            
+            
+  
+
+            
+        </div>
+
+        <div class="m-MediaBlock__m-TextWrap">
+            
+            
+  
+
+
+            
+  <h4 class="m-MediaBlock__a-Headline">
+    <a href="//www.foodnetwork.com/how-to/packages/shopping/product-reviews/best-touchless-trash-cans" target="_blank">
+      <span class="m-MediaBlock__a-HeadlineText">The 5 Best Touchless Trash Cans</span>
+      
+    </a>
+  </h4>
+
+
+            
+  
+
+
+            
+  
+
+
+            
+
+            
+  
+
+
+            
+
+            
+
+        </div>
+
+    </div>
+
+
+    </div>
+  
+  
+  
+
+
+    </div>
+
+    
+    
+
+
+  <footer class="o-Capsule__m-Footer">
+
+      
+  <a class="o-Capsule__a-Cta" href="//www.foodnetwork.com/how-to/packages/shopping/product-reviews" data-type="EditorialPromo">More Product Reviews</a>
+
+
+  </footer>
+
+
+
+  </section>
+
+</div>
+<div class="freeFormHTMLArea section"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/general/freeFormHTMLArea"></span>
+
+<section class="o-Capsule o-FreeFormHTMLArea">
+  <div id="dfp_bigbox_extra"></div>
+</section>
+
+</div>
+<div class="newsletter capsule section"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/general/newsletter"></span>
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+
+  
+  
+
+  
+  
+
+  
+
+
+
+
+  
+  
+
+
+    
+
+
+
+  <div class="o-Capsule o-Newsletter" data-module="newsletter">
+    <script type="text/x-config">
+    {
+	  "newsletterSource": "2021_FOODNET_SPAGHETTI-ALLA-CARBONARA-RECIPE_RIGHTRAIL",
+      "newsletterId": "fn_shopping",
+      "newsletterName": "Food Network Shopping",
+      "newsletterSite": "Easy Recipes, Healthy Eating Ideas and Chef Recipe Videos",
+      "newsletterShowMore": "",
+      "newsletterBrand": "foodnet",
+      "subscriptionEndpoint": "/apps/sni-foundation/servlets/blueshiftNewsletterAPI",
+      "selectors": {
+        "state1": ".o-Newsletter__m-State1",
+        "state2": ".o-Newsletter__m-State2",
+        "state3": ".o-Newsletter__m-State3",
+        "statePrefix": ".o-Newsletter__m-State",
+        "stateNamePrefix": "o-Newsletter__m-State",
+        "errors": ".m-Form__a-Errors",
+        "description": ".o-Newsletter__a-Description"
+      }
+    }
+    </script>
+
+    <header class="o-Capsule__m-Header">
+      <div class="o-Capsule__m-TextWrap">
+        <h3 class="o-Capsule__a-Headline">
+            <span class="o-Capsule__a-HeadlineText">Our Newsletter</span>
+        </h3>
+      </div>
+    </header>
+
+    <div class="o-Capsule__m-Body">
+      <noscript class="o-Newsletter__a-Description m-Form__a-Errors">
+        <strong>To sign up, please enable JavaScript.</strong>
+      </noscript>
+      <div class="o-Newsletter__m-State1">
+        <p class="o-Newsletter__a-Description">Sign up for the Food Network Shopping Newsletter <a href="https://corporate.discovery.com/privacy-policy/" target="_blank"> Privacy Policy</a></p>
+
+        <form class="m-Form__m-InputWrap" method="POST">
+          <input type="text" name="email" class="o-Capsule__a-Input a-Input" placeholder="Enter email address" />
+          <button name="submit" type="submit" class="o-Capsule__a-Button a-Button" data-type="subscribe-initial">Sign Up</button>
+        </form>
+        <div class="m-Form__a-Errors"></div>
+      </div>
+
+      <div class="o-Newsletter__m-State2">
+        <p class="o-Newsletter__a-Description"></p>
+        
+
+      </div>
+
+      <div class="o-Newsletter__m-State3">
+        <p class="o-Newsletter__a-Description a-Description"></p>
+      </div>
+
+      <!--/*include the loader area*/-->
+      
+
+    <div class="a-LoaderWrap" data-ui-loader>
+  <div class="a-Loader">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+</div>
+
+
+
+
+
+    </div> 
+
+  </div> 
+
+ 
+</div>
+
+</div>
+</div>
+</div>
+
+</div>
+<div class="container-aside sticky-rr">
+    <div class="module">
+      <div id="dfp_prog_bigbox" class="bigbox-ad rr-ad"></div>
+    </div>
+</div>
+
+     
+   
+
+
+        </div>
+
+      </div>
+
+    </div>
+  </div>
+
+</div>
+
+
+    
+    <div id='dfp_utility1'></div>
+    <div id='dfp_utility2'></div>
+
+    
+    
+    
+    	<!-- to include this file in an jsp use the following:
+  <cq:include script="brightEdge.html"/>
+-->
+<div>
+  
+
+    <!--
+    If need to hardcode pagePath use this- pagePath='/outdoors/outdoor-remodel/patio-gazebos',country=''
+    -->
+    
+      
+  
+    
+  
+
+      <div class="o-AutoPilot__m-AutoPilot-Wrap">
+        <div class="o-AutoPilot__m-Body">
+          
+<!-- be_ixf, sdk, gho-->
+<meta name="be:sdk" content="java_sdk_1.5.3" />
+<meta name="be:timer" content="16ms" />
+<meta name="be:norm_url" content="https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140" />
+<meta name="be:capsule_url" content="https://ixfd-api.bc0a.com/api/ixf/1.0.0/get_capsule/f00000000001425/681419184" />
+<meta name="be:api_dt" content="pny_2021; pnm_08; pnd_01; pnh_16; pnmh_59; pn_epoch:1627862399571" />
+<meta name="be:mod_dt" content="pny_1969; pnm_12; pnd_31; pnh_16; pnmh_00; pn_epoch:0" />
+<meta name="be:orig_url" content="https://www.foodnetwork.com//recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140" />
+<meta name="be:messages" content="310" />
+ 
+<script data-cfasync="false" data-testmode="true" id="marvel" data-customerid="f00000000001425" src="https://marvel-b2-cdn.bc0a.com/marvel.js"></script>
+
+    <script>
+      (function() {
+      var bec = document.createElement('script');
+      bec.type = 'text/javascript';
+      bec.async = true;
+      bec.setAttribute("data-id", "bec");
+      bec.setAttribute("org-id", "f00000000001425");
+      bec.setAttribute("domain", ".foodnetwork.com");
+      bec.setAttribute("session-timeout", 86400000);
+      bec.src = document.location.protocol + '//cdn.b0e8.com/conv_v3.js';
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(bec, s);
+})();
+</script>
+
+          <h3 class="m-AutoPilot-title">Related Pages</h3>
+          <ul class="m-AutoPilot__m-ItemList">
+            <li class="m-AutoPilot__m-Item"><a href="https://www.foodnetwork.com/recipes/giada-de-laurentiis/chicken-carbonara-recipe-1944377">Chicken Carbonara Recipe</a></li>
+          
+            <li class="m-AutoPilot__m-Item"><a href="https://www.foodnetwork.com/recipes/trisha-yearwood/country-ham-carbonara-3251221">Country Ham Carbonara Recipe</a></li>
+          
+            <li class="m-AutoPilot__m-Item"><a href="https://www.foodnetwork.com/recipes/food-network-kitchen/spaghetti-squash-carbonara-4590186">Spaghetti Squash Carbonara Recipe</a></li>
+          
+            <li class="m-AutoPilot__m-Item"><a href="https://www.foodnetwork.com/recipes/classic-spaghetti-carbonara-3644415">Classic Spaghetti Carbonara Recipe</a></li>
+          
+            <li class="m-AutoPilot__m-Item"><a href="https://www.foodnetwork.com/recipes/food-network-kitchen/spaghetti-carbonara-3362483">Spaghetti Carbonara Recipe</a></li>
+          
+            <li class="m-AutoPilot__m-Item"><a href="https://www.foodnetwork.com/recipes/geoffrey-zakarian/bucatini-carbonara-9855312">Bucatini Carbonara Recipe</a></li>
+          </ul>
+          
+        </div>
+      </div>
+    
+  
+</div>
+
+    
+    <div class="footer"><span style="display: none" class="clicktracking" data-resource-type="foodcom/components/footer"></span>
+
+
+
+  
+  
+
+
+
+
+
+  
+    
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+<footer class="o-FooterFresh" data-module="footer">
+  <div class="o-FooterFresh__m-BodyWrap">
+    <div class="o-FooterFresh__m-Body">
+      <div class="m-Body__m-PromoList">
+        <ul>
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="//www.foodnetwork.com/site/site-map">Site Map</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="https://corporate.discovery.com/visitor-agreement/">Visitor Agreement</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="is-AdChoices">
+                    <a href="http://info.evidon.com/pub_info/1212?v=1&nt=0&nw=false">AdChoices</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="https://corporate.discovery.com/privacy-policy/">Privacy Notice</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="//www.foodnetwork.com/site/about-foodnetwork-com">About</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="https://corporate.discovery.com/discovery-newsroom/">Newsroom</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="https://corporate.discovery.com/contact/advertising/">Advertise</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="https://help.foodnetwork.com/">Help</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="http://www.tvguidelines.org/ratings.html">TV Ratings</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="https://corporate.discovery.com/online-closed-captioning/">Online Closed Captioning</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="https://corporate.discovery.com/privacy-policy/#cappi">California Privacy Notice</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="https://corporate.discovery.com/california_dns/">CA Do Not Sell My Info</a>
+                  </li>
+                
+              
+          
+              
+              
+                
+                
+                  <li class="">
+                    <a href="https://corporate.discovery.com/">Discovery, Inc.</a>
+                  </li>
+                
+              
+          
+        </ul>
+      </div>
+      <ul class="o-FooterFresh__m-Info">
+        
+          
+            <li class="o-FooterFresh__m-International has-DropdownMenu" data-type="menu-action">
+              <a href="javascript:void(0);">International Editions</a>
+              <ul class="m-DropdownMenu">
+                <li><a href="https://www.foodnetwork.com">United States</a></li>
+                <li><a href="http://www.asianfoodnetwork.com">Asia</a></li>
+                <li><a href="http://www.foodnetwork.com.br">Brazil</a></li>
+                <li><a href="http://www.foodnetwork.ca">Canada</a></li>
+                <li><a href="http://www.foodnetworktv.com">Europe, Middle East &amp; Africa</a></li>
+                <li><a href="http://www.foodnetwork.co.uk">United Kingdom</a></li>
+                <li><a href="http://www.foodnetworklatam.com">Latin America</a></li>
+              </ul>
+            </li>
+          
+          <li class="o-FooterFresh__m-Brands has-DropdownMenu" data-type="menu-action">
+            <a href="javascript:void(0);">The Discovery Family of Networks</a>
+            <ul class="m-DropdownMenu">
+              
+                
+                <li><a href="https://www.cookingchanneltv.com">Cooking Channel</a></li>
+              
+                
+                <li><a href="https://www.food.com/">Food.com</a></li>
+              
+                
+                <li><a href="https://www.hgtv.com">HGTV</a></li>
+              
+                
+                <li><a href="https://www.diynetwork.com">DIY Network</a></li>
+              
+                
+                <li><a href="https://www.travelchannel.com">Travel Channel</a></li>
+              
+                
+                <li><a href="https://www.gactv.com">Great American Country</a></li>
+              
+            </ul>
+          </li>
+        
+        <li class="o-FooterFresh__a-Copyright">
+          © 2021  Discovery or its subsidiaries and affiliates. All rights reserved.
+        </li>
+      </ul>
+    </div>
+  </div>
+  
+</footer>
+
+  
+  
+
+</div>
+
+
+  </section>
+
+  
+
+  
+  
+
+
+
+  
+  
+
+
+
+
+
+<template style="display: none;" data-ui-loader-clone><div class="a-LoaderWrap" data-ui-loader>
+  <div class="a-Loader">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+</div>
+</template>
+<template style="display: none;" data-sharebar-clone>
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+
+
+  
+
+
+<ul class="m-SocialIcons " data-social-share-wrap >
+
+
+
+
+  
+  <li>
+    <a href="https://www.pinterest.com/pin/create/button?url=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140%3fsoc%3dsharepin&description=&title=Spaghetti+alla+Carbonara&media=" target="_blank" title="Share on Pinterest" aria-label="Share on Pinterest" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--pinterest" data-type="social-share" data-mode="pinterest" data-pin-custom="true" data-pin-do="buttonPin">
+      
+      <span class="o-SocialShare__m-IconWrap">
+        <svg class="a-Icon a-Icon--pinterest o-SocialShare__a-Icon o-SocialShare__a-Icon--pinterest" ><use xlink:href="#icon-pinterest"></use></svg>
+      </span>
+      <span class="o-SocialShare__a-Label">Pinterest</span>
+    </a>
+  </li>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+
+
+
+
+  
+
+  
+  <li>
+    <a href="https://www.facebook.com/sharer.php?u=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140%3fsoc%3dsharefb" target="_blank" title="Share on Facebook" aria-label="Share on Facebook" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--facebook" data-type="social-share" data-mode="facebook">
+      <span class="o-SocialShare__m-IconWrap">
+        <svg class="a-Icon a-Icon--facebook o-SocialShare__a-Icon o-SocialShare__a-Icon--facebook" ><use xlink:href="#icon-facebook"></use></svg>
+      </span>
+      <span class="o-SocialShare__a-Label">Facebook</span>
+    </a>
+  </li>
+  
+
+  
+
+  
+
+  
+
+  
+
+
+
+
+
+  
+
+  
+
+  
+  <li>
+    <a href="https://twitter.com/intent/tweet?text=Spaghetti+alla+Carbonara&url=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140%3fsoc%3dsharetw&original_referer=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140" target="_blank" title="Share on Twitter" aria-label="Share on Twitter" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--twitter" data-type="social-share" data-mode="twitter">
+      <span class="o-SocialShare__m-IconWrap">
+        <svg class="a-Icon a-Icon--twitter o-SocialShare__a-Icon o-SocialShare__a-Icon--twitter" ><use xlink:href="#icon-twitter"></use></svg>
+      </span>
+      <span class="o-SocialShare__a-Label">Twitter</span>
+    </a>
+  </li>
+  
+
+  
+
+  
+
+  
+
+
+
+
+
+  
+
+  
+
+  
+
+  
+  <li>
+    <a href="mailto:?body=https%3a%2f%2fwww.foodnetwork.com%2frecipes%2ftyler-florence%2fspaghetti-alla-carbonara-recipe-1914140&subject=Shared%20from%20Food Network" target="_blank" title="Share by Email" aria-label="Share by Email" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--email" data-type="social-share" data-mode="email">
+      <span class="o-SocialShare__m-IconWrap">
+        <svg class="a-Icon a-Icon--email o-SocialShare__a-Icon o-SocialShare__a-Icon--email" ><use xlink:href="#icon-email"></use></svg>
+      </span>
+      <span class="o-SocialShare__a-Label">Email</span>
+    </a>
+  </li>
+  
+
+  
+
+  
+
+
+
+
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+  
+  <li>
+    <a href="http://facebook.com/dialog/send?link=https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140&redirect_uri=https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140&app_id=582148248497951" target="_blank" class="o-SocialShare__m-ShareButton o-SocialShare__m-ShareButton--facebookMessenger" title="Share on Facebook Messenger" aria-label="Share on Facebook Messenger" data-type="social-share" data-mode="messenger">
+      <svg class="a-Icon a-Icon--messenger a-Button__a-Icon a-Button__a-Icon--messenger" ><use xlink:href="#icon-messenger"></use></svg>
+    </a>
+  </li>
+  
+
+  
+
+
+
+
+</ul>
+</template>
+
+
+
+
+
+  
+  
+
+
+
+
+
+
+
+  
+  
+    <script src="//food.fnr.sndimg.com/etc/clientlibs/assets/v2/js/recipeDesktop.md5-776d82b637fc9535d9a6833029eb94dc.js"></script>
+  
+  
+
+
+
+
+
+  <script defer src="https://cdns.gigya.com/JS/socialize.js?apikey=3_ClDcX23A7tU8pcydnKyENXSYP5kxCbwH4ZO741ZOujPRY8Ksj2UBnj8Zopb0OX0K"></script>
+
+
+
+
+
+
+
+  
+  
+
+
+
+
+  <script src="//code.adsales.snidigital.com/datmcp/mcp-loader.js"></script>
+
+
+
+<script>SNILoadEvents.trigger(['mdm', 'core', 'analytics', 'ads', 'sni-all']);</script>
+
+
+
+
+
+  
+  
+
+
+
+
+  
+  
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-935057167"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'AW-935057167');
+  </script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<script type="text/javascript">
+  (function(mdManager){
+    var pageHasVideo = "true";
+    var videoCount = window.VP_COUNT || 0;
+    if (typeof enableForAutomation !== "undefined"){
+      if (typeof newrelic === "object"){
+        console.log("Automation: New Relic object is valid");
+      }
+      else {
+        console.log("Automation: New Relic object is NOT valid");
+      }
+    }
+
+    if (typeof newrelic === "object"){//If new relic agent is enabled
+      if (typeof newrelic.setCustomAttribute === "function"){
+        newrelic.setCustomAttribute("platform", "CORE");//send page type to new relic
+        if (typeof mdManager  === "object"){
+          if (typeof mdManager.getPageType === "function"){
+            newrelic.setCustomAttribute("pageType", mdManager.getPageType());//send page type to new relic
+          }
+          if (typeof mdManager.getParameter  === "function"){
+            newrelic.setCustomAttribute("deliveryChannel", mdManager.getParameter("Delivery_Channel"));//send device type to new relic
+          }
+          if (typeof mdManager.getSite  === "function"){
+            newrelic.setCustomAttribute("site", mdManager.getSite().split('-')[0] );//send site/brand to new relic
+          }
+          if (typeof pageHasVideo !== "undefined") {
+            newrelic.setCustomAttribute("video", pageHasVideo);
+          }
+          if (typeof videoCount !== "undefined") {
+            newrelic.setCustomAttribute("videoCount", videoCount);
+          }
+        }
+      }
+    }
+  })(mdManager);
+
+</script>
+
+
+
+
+  
+  
+
+  
+  <script>
+    (function () {
+      if(!$('.legalCopy').length && $('.shopping-link-no-style').length) {
+        if($('.assetDescription').length) {
+          $('.assetDescription').after($('<div class=legalCopy> <div class="o-AssetLegalCopy__a-LegalText a-LegalText"> ' + "Keep in mind: Price and stock could change after publish date, and we may make money from these links." + '</div> </div>'));
+        }
+      }
+    })();
+  </script>
+
+  <script type="text/javascript">
+
+    $(function(){
+      if( typeof SniAds === "object" ) {
+        var adConfig = {
+          breakpoints: {
+            small: [0,0],
+            medium: [600,0],
+            large: [800,0],
+            xlarge:[1920,0]
+          },
+          enableRepeatBigbox: {
+            adClass: 'rr-ad bigbox-ad',
+            mobile: {
+              disable: ($('body.articlePage').length === 0)
+            }
+          }
+          
+        };
+
+        SniAds.init( adConfig );
+      }
+    });
+  </script>
+
+  
+  
+
+
+  <script>
+   if (window.cqIncludeVideo && window.cqWCMDisabled) {
+    SNI.Config.VPC.insertJs();
+    SNI.Config.VPC.insertCss();
+   }
+  </script>
+
+
+  
+
+  
+
+
+
+  
+  
+
+
+
+
+
+
+
+
+
+
+
+  <script type="application/ld+json">[{"@context":"http://schema.org","@type":"Recipe","mainEntityOfPage":true,"name":"Spaghetti alla Carbonara","url":"https://www.foodnetwork.com/recipes/tyler-florence/spaghetti-alla-carbonara-recipe-1914140","headline":"Spaghetti alla Carbonara","description":"For a quick dinner, whip up Tyler Florence's authentic Spaghetti alla Carbonara recipe, a rich tangle of pasta, pancetta and egg, from Food Network.","author":[{"@type":"Person","name":"Tyler Florence","url":"https://www.foodnetwork.com/profiles/talent/tyler-florence"}],"image":{"@type":"ImageObject","url":"https://food.fnr.sndimg.com/content/dam/images/food/fullset/2009/6/12/2/FO1D41_23785_s4x3.jpg.rend.hgtvcom.406.305.suffix/1431766590243.jpeg","height":"406","width":"305","description":"Food Network \nTyler Florence Spaghetti Alla Carbonara\nWinter Weeknight Dinners in 60"},"datePublished":"2015-07-22T10:03:44.111-04:00","dateModified":"2014-09-09T14:45:57.999-04:00","publisher":{"@type":"Organization","name":"Food Network","url":"https://www.foodnetwork.com","logo":{"@type":"ImageObject","url":"https://food.fnr.sndimg.com/etc/clientlibs/assets/images/food/fn-logo-flat-60x60.png","height":"60","width":"60"}},"keywords":"Italian,European Recipes,Egg Recipes,Bacon Recipes,Spaghetti,Parmesan Cheese Recipes,Main Dish","cookTime":"P0Y0M0DT0H10M0.000S","prepTime":"P0Y0M0DT0H15M0.000S","totalTime":"P0Y0M0DT0H25M0.000S","recipeIngredient":["1 pound dry spaghetti","2 tablespoons extra-virgin olive oil","4 ounces pancetta or slab bacon, cubed or sliced into small strips","4 garlic cloves, finely chopped","2 large eggs","1 cup freshly grated Parmigiano-Reggiano, plus more for serving","Freshly ground black pepper","1 handful fresh flat-leaf parsley, chopped"],"recipeInstructions":[{"@type":"HowToStep","text":"Prepare the sauce while the pasta is cooking to ensure that the spaghetti will be hot and ready when the sauce is finished; it is very important that the pasta is hot when adding the egg mixture, so that the heat of the pasta cooks the raw eggs in the sauce."},{"@type":"HowToStep","text":"Bring a large pot of salted water to a boil, add the pasta and cook for 8 to 10 minutes or until tender yet firm (as they say in Italian \"al dente.\") Drain the pasta well, reserving 1/2 cup of the starchy cooking water to use in the sauce if you wish."},{"@type":"HowToStep","text":"Meanwhile, heat the olive oil in a deep skillet over medium flame. Add the pancetta and saute for about 3 minutes, until the bacon is crisp and the fat is rendered. Toss the garlic into the fat and saute for less than 1 minute to soften."},{"@type":"HowToStep","text":"Add the hot, drained spaghetti to the pan and toss for 2 minutes to coat the strands in the bacon fat. Beat the eggs and Parmesan together in a mixing bowl, stirring well to prevent lumps. Remove the pan from the heat and pour the egg/cheese mixture into the pasta, whisking quickly until the eggs thicken, but do not scramble (this is done off the heat to ensure this does not happen.) Thin out the sauce with a bit of the reserved pasta water, until it reaches desired consistency. Season the carbonara with several turns of freshly ground black pepper and taste for salt. Mound the spaghetti carbonara into warm serving bowls and garnish with chopped parsley. Pass more cheese around the table."}],"aggregateRating":{"@type":"AggregateRating","ratingValue":4.7,"reviewCount":495},"recipeYield":"4 to 6 servings","review":[{"@type":"Review","author":{"@type":"Person","name":"jtyler"},"reviewRating":{"@type":"Rating","ratingValue":5,"worstRating":"1","bestRating":"5"},"reviewBody":"I\u2019ve tried a few carbonara recipes and decided I was done trying, I didn\u2019t think I liked pasta carbonara. But I am so glad I was craving pasta and found this recipe!!! The eggs were perfectly cooked and so creamy and so cheesy!!! Absolutely recommend! ","datePublished":"2021-08-26"},{"@type":"Review","author":{"@type":"Person","name":"Luv2cook125"},"reviewRating":{"@type":"Rating","ratingValue":5,"worstRating":"1","bestRating":"5"},"reviewBody":"This was so easy and so good!  I tempered the egg/Parmesan mixture with hot pasta water before adding it in with the hot pasta - worked perfectly.  Don\u2019t be afraid to try this if you haven\u2019t made carbonara before!","datePublished":"2021-08-15"},{"@type":"Review","author":{"@type":"Person","name":"Anonymous"},"reviewRating":{"@type":"Rating","ratingValue":1,"worstRating":"1","bestRating":"5"},"reviewBody":"For Carbonara you need guanciale, nor bacon or pancetta. Only guanciale, I found it here in Us so you can do too.","datePublished":"2021-07-21"},{"@type":"Review","author":{"@type":"Person","name":"daphnedcf"},"reviewRating":{"@type":"Rating","ratingValue":5,"worstRating":"1","bestRating":"5"},"datePublished":"2021-06-29"},{"@type":"Review","author":{"@type":"Person","name":"FredBT"},"reviewRating":{"@type":"Rating","ratingValue":5,"worstRating":"1","bestRating":"5"},"reviewBody":"Really good. I think it\u2019s supposed to be made using pecorino rather than parmesan and guanciale instead of pancetta, but guanciale is not easy to find. It still tastes great.","datePublished":"2021-06-08"},{"@type":"Review","author":{"@type":"Person","name":"Shannon W."},"reviewRating":{"@type":"Rating","ratingValue":5,"worstRating":"1","bestRating":"5"},"datePublished":"2021-06-07"},{"@type":"Review","author":{"@type":"Person","name":"Rhonda H."},"reviewRating":{"@type":"Rating","ratingValue":5,"worstRating":"1","bestRating":"5"},"reviewBody":"This is so delicious and easy! Now my favorite pasta dish 😋 ","datePublished":"2021-05-01"},{"@type":"Review","author":{"@type":"Person","name":"Lauren New"},"reviewRating":{"@type":"Rating","ratingValue":5,"worstRating":"1","bestRating":"5"},"reviewBody":"Delicious","datePublished":"2021-04-08"},{"@type":"Review","author":{"@type":"Person","name":"Teri Markel Card"},"reviewRating":{"@type":"Rating","ratingValue":5,"worstRating":"1","bestRating":"5"},"reviewBody":"We loved this. ","datePublished":"2021-03-27"}],"video":{"@type":"VideoObject","name":"911 Spaghetti Alla Carbonara","description":"It's Tyler to the rescue as he helps a fan make spaghetti alla carbonara.","duration":"PT0H3M39S","thumbnailUrl":"https://food.fnr.sndimg.com/content/dam/images/food/video/0/01/016/0169/0169339.jpg.rend.hgtvcom.406.305.suffix/1479690440287.jpeg","contentUrl":"https://www.foodnetwork.com/videos/911-spaghetti-alla-carbonara-0169339","embedUrl":"http://link.theplatform.com/s/ip77QC/fGqanplLR7w_?format=SMIL&MBR=true","uploadDate":"2018-11-12T10:50:36.293-05:00"},"recipeCuisine":"italian","recipeCategory":"main-dish"}, {"@context":"http://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"item":{"@id":"https://www.foodnetwork.com","name":"Home"}},{"@type":"ListItem","position":2,"item":{"@id":"https://www.foodnetwork.com/recipes","name":"Recipes"}},{"@type":"ListItem","position":3,"item":{"@id":"https://www.foodnetwork.com/recipes/tyler-florence","name":"Tyler Florence"}}]}]</script>
+
+
+
+
+  
+  
+
+
+
+<script>
+var whisk = whisk || {};
+whisk.queue = whisk.queue || [];
+
+
+window.addEventListener('load',function(){
+	
+  whisk.queue.push(function () {
+    whisk.shoppingList.defineWidget("CCKU-VPLO-TYHX-LNGN", {
+      trackingId: "wx-ff0875ab-60031cc4",
+      // hidden: true, //widget hidden. View using ?whisk-enable=1 in URL. Remove line to make Whisk visible to everyone.
+      whiteLabel: "FoodNetworkOnlyCart",
+      styles: {
+        size: "large"
+      },
+    });
+  });
+  
+  whisk.queue.push(function() {
+	    whisk.ads.defineBlock('whisk-sp-unit-block-1', {
+	      trackingId: "wx-ff0875ab-60031cc4"
+	    });
+	  });
+
+  whisk.queue.push(function () {
+    whisk.display("CCKU-VPLO-TYHX-LNGN");
+  });
+  
+  whisk.queue.push(function () {
+    whisk.display('whisk-sp-unit-block-1');
+  });
+});
+</script>
+<script async src="https://cdn.whisk.com/sdk/shopping-list-sp.js" type="text/javascript"></script>
+
+</body>
+
+</html>

--- a/tests/laodeai_fixture/stackexchange.html
+++ b/tests/laodeai_fixture/stackexchange.html
@@ -1,0 +1,2604 @@
+
+<!DOCTYPE html>
+
+
+<html itemscope itemtype="https://schema.org/QAPage" class="html__responsive ">
+
+<head>
+
+    <title>date - Why does man print &quot;gimme gimme gimme&quot; at 00:30? - Unix &amp; Linux Stack Exchange</title>
+    <link rel="shortcut icon" href="https://cdn.sstatic.net/Sites/unix/Img/favicon.ico?v=fb86ccabb921">
+    <link rel="apple-touch-icon" href="https://cdn.sstatic.net/Sites/unix/Img/apple-touch-icon.png?v=5cf7fe716a89">
+    <link rel="image_src" href="https://cdn.sstatic.net/Sites/unix/Img/apple-touch-icon.png?v=5cf7fe716a89"> 
+    <link rel="search" type="application/opensearchdescription+xml" title="Unix &amp; Linux Stack Exchange" href="/opensearch.xml">
+    <link rel="canonical" href="https://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030" />
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, minimum-scale=1.0">
+    <meta property="og:type" content= "website" />
+    <meta property="og:url" content="https://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030"/>
+    <meta property="og:site_name" content="Unix &amp; Linux Stack Exchange" />
+    <meta property="og:image" itemprop="image primaryImageOfPage" content="https://cdn.sstatic.net/Sites/unix/Img/apple-touch-icon@2.png?v=32fb07f7ce26" />
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:domain" content="unix.stackexchange.com"/>
+    <meta name="twitter:title" property="og:title" itemprop="name" content="Why does man print &quot;gimme gimme gimme&quot; at 00:30?" />
+    <meta name="twitter:description" property="og:description" itemprop="description" content="We&#x27;ve noticed that some of our automatic tests fail when they run at 00:30 but work fine the rest of the day. They fail with the message&#xA;gimme gimme gimme&#xA;&#xA;in stderr, which wasn&#x27;t expected. Why are..." />
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="https://cdn.sstatic.net/Js/stub.en.js?v=79a71d5c5f05"></script>
+
+    <link rel="stylesheet" type="text/css" href="https://cdn.sstatic.net/Shared/stacks.css?v=d6e71d1b13f1">
+    <link rel="stylesheet" type="text/css" href="https://cdn.sstatic.net/Sites/unix/primary.css?v=05191001d020">
+
+
+        <link rel="alternate" type="application/atom+xml" title="Feed for question &#x27;Why does man print &quot;gimme gimme gimme&quot; at 00:30?&#x27;" href="/feeds/question/405783">
+        <meta name="twitter:app:country" content="US" />
+        <meta name="twitter:app:name:iphone" content="Stack Exchange iOS" />
+        <meta name="twitter:app:id:iphone" content="871299723" />
+        <meta name="twitter:app:url:iphone" content="se-zaphod://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030" />
+        <meta name="twitter:app:name:ipad" content="Stack Exchange iOS" />
+        <meta name="twitter:app:id:ipad" content="871299723" />
+        <meta name="twitter:app:url:ipad" content="se-zaphod://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030" />
+        <meta name="twitter:app:name:googleplay" content="Stack Exchange Android">
+        <meta name="twitter:app:url:googleplay" content="https://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030">
+        <meta name="twitter:app:id:googleplay" content="com.stackexchange.marvin">
+    <script>
+        StackExchange.ready(function () {
+
+            StackExchange.using("postValidation", function () {
+                StackExchange.postValidation.initOnBlurAndSubmit($('#post-form'), 2, 'answer');
+            });
+
+
+            StackExchange.question.init({showAnswerHelp:true,totalCommentCount:6,shownCommentCount:5,enableTables:true,questionId:405783});
+
+            styleCode();
+
+                StackExchange.realtime.subscribeToQuestion('106', '405783');
+                StackExchange.using("gps", function () { StackExchange.gps.trackOutboundClicks('#content', '.js-post-body'); });
+
+
+
+        });
+    </script>
+
+    
+    
+    
+    <link rel="stylesheet" type="text/css" href="https://cdn.sstatic.net/Shared/Channels/channels.css?v=2ae6bc4e4e29">
+    
+    
+    
+
+
+<script>
+    StackExchange.ready(function () {
+        StackExchange.realtime.init('wss://qa.sockets.stackexchange.com');
+            StackExchange.realtime.subscribeToReputationNotifications('106');
+    StackExchange.realtime.subscribeToTopBarNotifications('106');
+    });
+</script>
+<script>
+    StackExchange.init({"locale":"en","serverTime":1630687058,"routeName":"Questions/Show","stackAuthUrl":"https://stackauth.com","networkMetaHostname":"meta.stackexchange.com","site":{"name":"Unix & Linux Stack Exchange","description":"Q&A for users of Linux, FreeBSD and other Un*x-like operating systems","isNoticesTabEnabled":true,"enableNewTagCreationWarning":true,"insertSpaceAfterNameTabCompletion":false,"id":106,"cookieDomain":".stackexchange.com","childUrl":"https://unix.meta.stackexchange.com","styleCodeWithHighlightjs":true,"negativeVoteScoreFloor":null,"enableSocialMediaInSharePopup":true,"protocol":"https"},"user":{"fkey":"9becbfd26429ca9b4f98563b18c9dfb7757c553ac6d93c2cccf8545d64a3d14b","tid":"4a10eab0-c0cd-185f-9e96-29ee0777b70e","rep":0,"isAnonymous":true,"isAnonymousNetworkWide":true},"realtime":{"newest":true,"active":true,"tagged":true,"staleDisconnectIntervalInHours":0},"events":{"postType":{"question":1},"postEditionSection":{"title":1,"body":2,"tags":3}},"story":{"minCompleteBodyLength":75,"likedTagsMaxLength":300,"dislikedTagsMaxLength":300},"jobPreferences":{"maxNumDeveloperRoles":2,"maxNumIndustries":4},"svgIconPath":"https://cdn.sstatic.net/Img/stacks-icons","svgIconHash":"d569c09cdf59"}, {"userProfile":{},"userMessaging":{"showNewFeatureNotice":true},"tags":{},"subscriptions":{"defaultBasicMaxTrueUpSeats":250,"defaultFreemiumMaxTrueUpSeats":50,"defaultMaxTrueUpSeats":1000},"snippets":{"renderDomain":"stacksnippets.net"},"site":{"allowImageUploads":true,"enableImgurHttps":true,"enableUserHovercards":true,"forceHttpsImages":true,"styleCode":true},"questions":{"enableQuestionTitleLengthLiveWarning":true,"maxTitleSize":150,"questionTitleLengthStartLiveWarningChars":50},"intercom":{"appId":"inf0secd","hostBaseUrl":"https://stacksnippets.net"},"paths":{},"monitoring":{"clientTimingsAbsoluteTimeout":30000,"clientTimingsDebounceTimeout":1000},"mentions":{"maxNumUsersInDropdown":50},"markdown":{"enableTables":true},"legal":{"oneTrustConfigId":"cb0f3c87-b769-4e66-bbaa-377f9194216d"},"flags":{"allowRetractingCommentFlags":true,"allowRetractingFlags":true},"elections":{"opaVoteResultsBaseUrl":"https://www.opavote.com/results/"},"comments":{},"accounts":{"currentPasswordRequiredForChangingStackIdPassword":true}});
+    StackExchange.using.setCacheBreakers({"js/adops.en.js":"25a6dce41c18","js/ask.en.js":"447d8f97a584","js/begin-edit-event.en.js":"96dbbddc01e9","js/copy-transpiled.en.js":"4e0329c46565","js/cm.en.js":"a2b9cdc1646a","js/events.en.js":"934b97736887","js/explore-qlist.en.js":"be3b9d8380ea","js/full-anon.en.js":"9d41bd9d6131","js/full.en.js":"f65af00107b8","js/help.en.js":"300463afbc58","js/highlightjs-loader.en.js":"abcd2eac2df1","js/inline-tag-editing.en.js":"09ea2ed643d6","js/keyboard-shortcuts.en.js":"b1e797abfff6","js/markdown-it-loader.en.js":"2e21bfe993e4","js/modElections.en.js":"1cd54410daf7","js/mobile.en.js":"a909c49353d2","js/moderator.en.js":"3682b88f73b8","js/postCollections-transpiled.en.js":"ef2292afbb54","js/post-validation.en.js":"2a61a92fb1fc","js/prettify-full.en.js":"c667d678adab","js/question-editor.en.js":"","js/review.en.js":"ed4493fefa46","js/review-v2-transpiled.en.js":"971e3b3ad5a2","js/revisions.en.js":"d1bd84a6d22d","js/stacks-editor.en.js":"5ba70edb6d3f","js/tageditor.en.js":"4f30af0fdc59","js/tageditornew.en.js":"f998c672574e","js/tagsuggestions.en.js":"bdfe20bf5338","js/unlimited-transpiled.en.js":"7ad49802cfd3","js/wmd.en.js":"c3caee44f113"});
+    StackExchange.using("gps", function() {
+         StackExchange.gps.init(true);
+    });
+</script>
+<noscript id="noscript-css"><style>body,.top-bar{margin-top:1.9em}</style></noscript>
+</head>
+<body class="question-page unified-theme">
+<div id="notify-container"></div>
+<div id="custom-header"></div>
+    
+<header class="top-bar js-top-bar top-bar__network">
+<div class="wmx12 mx-auto d-flex ai-center h100" role="menubar">
+    <div class="-main flex--item">
+            <a href="#" class="left-sidebar-toggle p0 ai-center jc-center js-left-sidebar-toggle" role="menuitem" aria-haspopup="true" aria-controls="left-sidebar" aria-expanded="false"><span class="ps-relative"></span></a>
+            <div class="topbar-dialog leftnav-dialog js-leftnav-dialog dno">
+                <div class="left-sidebar js-unpinned-left-sidebar" data-can-be="left-sidebar" data-is-here-when="sm"></div>
+            </div>
+            <a href="#" class="-logo js-gps-track js-network-logo network-logo"
+               data-gps-track="stack_exchange_popup.show" role="menuitem" aria-haspopup="true" aria-controls="topbar-network-logo-dialog" aria-expanded="false">
+                <svg aria-hidden="true" class="native mtn1 svg-icon iconLogoSEAlternativeSm" width="107" height="15" viewBox="0 0 107 15"><path d="m48.41 11.93-1.96-3.2-1.04 1.16v2.04h-1.42V2.18h1.42v6.01L48.14 5h1.72l-2.44 2.7 2.74 4.22h-1.75zm-7.06.08c-1.59 0-3.14-.96-3.14-3.56s1.55-3.54 3.14-3.54c.97 0 1.65.27 2.31.97l-.97.93c-.44-.48-.79-.66-1.34-.66s-1 .22-1.3.62c-.31.38-.42.87-.42 1.68 0 .81.1 1.32.41 1.7.3.4.76.62 1.3.62.56 0 .9-.18 1.35-.66l.97.92c-.66.7-1.34.98-2.31.98zm-5.66-3.15h-1.65c-.83 0-1.26.37-1.26 1s.4.99 1.3.99c.53 0 .93-.04 1.3-.4.22-.2.31-.53.31-1.03v-.56zm.03 3.07v-.63c-.51.5-1 .71-1.87.71-.87 0-1.46-.2-1.89-.63a2.1 2.1 0 01-.55-1.49c0-1.16.82-2 2.42-2h1.86v-.5c0-.87-.44-1.3-1.54-1.3-.77 0-1.15.18-1.54.68l-.92-.86c.66-.77 1.35-1 2.52-1 1.93 0 2.9.8 2.9 2.38v4.64h-1.39zm-5.9 0c-1.32 0-1.93-.93-1.93-1.93V6.18h-.8V5.1h.8V3h1.41v2.1h1.36v1.07H29.3v3.75c0 .5.25.81.78.81h.58v1.2h-.85zm-6.33.08c-1.48 0-2.55-.34-3.49-1.28l1-.98c.72.72 1.51.94 2.52.94 1.3 0 2.04-.55 2.04-1.5 0-.42-.13-.78-.39-1.01-.25-.23-.5-.33-1.08-.41l-1.16-.17a3.4 3.4 0 01-1.88-.78 2.41 2.41 0 0 1-.72-1.86c0-1.7 1.25-2.86 3.3-2.86 1.3 0 2.22.33 3.07 1.1l-.96.94a2.92 2.92 0 00-2.15-.75c-1.16 0-1.8.65-1.8 1.52 0 .35.1.67.37.9.25.22.65.38 1.11.45l1.13.17c.91.13 1.42.35 1.84.72.54.47.8 1.17.8 2 0 1.8-1.48 2.86-3.55 2.86z" fill="#FEFEFE"/><path d="M104.16 7.09c-.2-.42-.6-.74-1.2-.74s-.99.32-1.18.74c-.1.25-.15.44-.16.75h2.7a2 2 0 00-.16-.75zm-2.54 1.96c0 .9.56 1.57 1.55 1.57.78 0 1.16-.21 1.61-.66l1.08 1.04a3.4 3.4 0 01-2.7 1.11c-1.68 0-3.29-.76-3.29-3.62 0-2.3 1.26-3.6 3.1-3.6 1.97 0 3.1 1.44 3.1 3.37v.79h-4.45zm-5.48-2.57C95.1 6.48 95 7.37 95 8.3c0 .94.1 1.85 1.15 1.85 1.05 0 1.18-.91 1.18-1.85 0-.93-.13-1.82-1.18-1.82zm-.17 8.22c-1.1 0-1.84-.21-2.58-.92l1.1-1.11c.4.38.8.54 1.4.54 1.06 0 1.43-.74 1.43-1.46v-.72c-.47.51-1 .7-1.7.7-.69 0-1.29-.23-1.68-.62-.67-.66-.73-1.57-.73-2.8 0-1.24.06-2.13.73-2.8.4-.39 1-.62 1.7-.62.75 0 1.24.2 1.73.75v-.67h1.72v6.8c0 1.7-1.21 2.93-3.12 2.93zm-5.76-2.67V7.76c0-.96-.61-1.28-1.17-1.28-.56 0-1.18.32-1.18 1.28v4.27h-1.78V4.97h1.73v.65a2.44 2.44 0 011.78-.73c.7 0 1.28.23 1.67.62.58.57.73 1.24.73 2v4.52H90.2zm-7.1-2.98h-1.4c-.64 0-1 .3-1 .8 0 .49.33.81 1.02.81.5 0 .8-.04 1.12-.34.2-.17.26-.46.26-.89v-.38zm.04 2.98v-.6c-.48.47-.93.67-1.74.67-.8 0-1.4-.2-1.82-.62-.38-.4-.58-.97-.58-1.59 0-1.12.77-2.05 2.42-2.05h1.68V7.5c0-.77-.38-1.11-1.32-1.11-.68 0-1 .16-1.37.58l-1.13-1.1c.7-.75 1.38-.97 2.57-.97 1.99 0 3.02.84 3.02 2.5v4.64h-1.73zm-6.93 0v-4.3c0-.94-.6-1.25-1.15-1.25-.56 0-1.15.32-1.15 1.24v4.31h-1.77V2.38h1.77v3.24a2.35 2.35 0 011.7-.73c1.56 0 2.38 1.08 2.38 2.57v4.57h-1.78zm-6.96.08c-1.42 0-3.18-.76-3.18-3.62 0-2.85 1.76-3.6 3.18-3.6.98 0 1.72.3 2.34.95l-1.2 1.2c-.36-.4-.68-.56-1.14-.56-.42 0-.75.14-1.01.46-.27.33-.4.8-.4 1.55s.13 1.24.4 1.58c.26.3.59.46 1 .46.47 0 .79-.16 1.15-.56l1.2 1.18c-.62.65-1.36.96-2.34.96zm-5.53-.08-1.3-2.11-1.3 2.11H59l2.45-3.6-2.35-3.46h2.12L62.42 7l1.21-2.02h2.13L63.4 8.43l2.46 3.6h-2.13zm-11.75 0V2.06h6.6V3.8h-4.65v2.33h3.96v1.74h-3.96v2.42h4.65v1.74h-6.6z" fill="#2F96E8"/><path d="M0 3c0-1.1.9-2 2-2h8a2 2 0 012 2H0z" fill="#8FD8F7"/><path d="M12 10H0c0 1.1.9 2 2 2h5v3l3-3a2 2 0 002-2z" fill="#155397"/><path fill="#46A2D9" d="M0 4h12v2H0z"/><path fill="#2D6DB5" d="M0 7h12v2H0z"/></svg>
+            </a>
+            <div class="topbar-dialog network-logo-dialog js-network-logo-dialog dno" id="topbar-network-logo-dialog" role="dialog" aria-labelledby="topbar-network-logo-dialog-title" aria-describedby="topbar-network-logo-dialog-body">
+                <div class="dialog-content">
+                    <h4 class="bold" id="topbar-network-logo-dialog-title">Stack Exchange Network</h4>
+                    <p id="topbar-network-logo-dialog-body">
+                        Stack Exchange network consists of 178 Q&amp;A communities including <a href="https://stackoverflow.com">Stack Overflow</a>, the largest, most trusted online community for developers to learn, share their knowledge, and build their careers.
+                    </p>
+                    <a class="s-btn s-btn__filled" href="https://stackexchange.com"
+                    data-gps-track="stack_exchange_popup.click">Visit Stack Exchange</a>
+                    <button class="icon-close js-close-button s-btn s-btn__unset" aria-label="Close"><svg aria-hidden="true" class="svg-icon iconClear" width="18" height="18" viewBox="0 0 18 18"><path d="M15 4.41 13.59 3 9 7.59 4.41 3 3 4.41 7.59 9 3 13.59 4.41 15 9 10.41 13.59 15 15 13.59 10.41 9 15 4.41z"/></svg></button>
+                </div>
+            </div>
+
+
+
+    </div>
+
+
+        <form id="search" role="search" action=/search class="flex--item fl-grow1 searchbar px12 js-searchbar " autocomplete="off">
+                <div class="ps-relative">
+                    <input name="q"
+                           type="text"
+                           placeholder="Search on Unix &amp; Linux&#x2026;"
+                           value=""
+                           autocomplete="off"
+                           maxlength="240"
+                           class="s-input s-input__search js-search-field "
+                           aria-label="Search"
+                           aria-controls="top-search" 
+                           data-controller="s-popover"
+                           data-action="focus->s-popover#show"
+                           data-s-popover-placement="bottom-start"/>
+                    <svg aria-hidden="true" class="s-input-icon s-input-icon__search svg-icon iconSearch" width="18" height="18" viewBox="0 0 18 18"><path d="m18 16.5-5.14-5.18h-.35a7 7 0 10-1.19 1.19v.35L16.5 18l1.5-1.5zM12 7A5 5 0 112 7a5 5 0 0110 0z"/></svg>
+                    <div class="s-popover p0 wmx100 wmn4 sm:wmn-initial js-top-search-popover" id="top-search" role="menu">
+<div class="s-popover--arrow"></div>
+<div class="js-spinner p24 d-flex ai-center jc-center d-none">
+    <div class="s-spinner s-spinner__sm fc-orange-400">
+        <div class="v-visible-sr">Loading&#x2026;</div>
+    </div>
+</div>
+
+<span class="v-visible-sr js-screen-reader-info"></span>
+<div class="js-ac-results overflow-y-auto hmx3 d-none"></div>
+
+<div class="js-search-hints" aria-describedby="Tips for searching"></div>
+</div>
+                </div>
+        </form>
+    
+    
+
+<ol class="overflow-x-auto ml-auto -secondary d-flex ai-center list-reset h100 user-logged-out" role="presentation">
+    <li class="-item searchbar-trigger"><a href="#" class="-link js-searchbar-trigger" role="button" aria-label="Search" aria-haspopup="true" aria-controls="search" title="Click to show search"><svg aria-hidden="true" class="svg-icon iconSearch" width="18" height="18" viewBox="0 0 18 18"><path d="m18 16.5-5.14-5.18h-.35a7 7 0 10-1.19 1.19v.35L16.5 18l1.5-1.5zM12 7A5 5 0 112 7a5 5 0 0110 0z"/></svg></a></li>
+    <li class="-item inbox-button-item">
+        <a href="#" class="-link js-inbox-button"
+           aria-label="Inbox" title="Recent inbox messages" role="menuitem" aria-haspopup="true" aria-expanded="false" data-unread-count="0">
+            <svg aria-hidden="true" class="svg-icon iconInbox" width="20" height="18" viewBox="0 0 20 18"><path d="M4.63 1h10.56a2 2 0 011.94 1.35L20 10.79V15a2 2 0 01-2 2H2a2 2 0 01-2-2v-4.21l2.78-8.44c.25-.8 1-1.36 1.85-1.35zm8.28 12 2-2h2.95l-2.44-7.32a1 1 0 00-.95-.68H5.35a1 1 0 00-.95.68L1.96 11h2.95l2 2h6z"/></svg>
+            <span class="indicator-badge js-unread-count _important d-none">0</span>
+        </a>
+    </li>
+    <li class="-item achievements-button-item">
+        <a href="#" class="-link js-achievements-button" data-unread-class="_highlighted-positive"
+           aria-label="Achievements" title="Recent achievements: reputation, badges, and privileges earned" role="menuitem" aria-haspopup="true" aria-expanded="false" data-unread-count="0" data-lit-up="false">
+            <svg aria-hidden="true" class="svg-icon iconAchievements" width="18" height="18" viewBox="0 0 18 18"><path d="M15 2V1H3v1H0v4c0 1.6 1.4 3 3 3v1c.4 1.5 3 2.6 5 3v2H5s-1 1.5-1 2h10c0-.4-1-2-1-2h-3v-2c2-.4 4.6-1.5 5-3V9c1.6-.2 3-1.4 3-3V2h-3zM3 7c-.5 0-1-.5-1-1V4h1v3zm8.4 2.5L9 8 6.6 9.4l1-2.7L5 5h3l1-2.7L10 5h2.8l-2.3 1.8 1 2.7h-.1zM16 6c0 .5-.5 1-1 1V4h1v2z"/></svg>
+            <span class="indicator-badge js-unread-count _positive d-none">+0</span>
+        </a>
+    </li>
+    <li class="-item help-button-item">
+        <a href="#" class="-link js-help-button" title="Help Center and other resources" role="menuitem" aria-haspopup="true" aria-controls="topbar-help-dialog"
+           data-ga="[&quot;top navigation&quot;,&quot;help menu click&quot;,null,null,null]"><svg aria-hidden="true" class="svg-icon iconHelp" width="18" height="18" viewBox="0 0 18 18"><path d="M9 1C4.64 1 1 4.64 1 9c0 4.36 3.64 8 8 8 4.36 0 8-3.64 8-8 0-4.36-3.64-8-8-8zm.81 12.13c-.02.71-.55 1.15-1.24 1.13-.66-.02-1.17-.49-1.15-1.2.02-.72.56-1.18 1.22-1.16.7.03 1.2.51 1.17 1.23zM11.77 8c-.59.66-1.78 1.09-2.05 1.97a4 4 0 00-.09.75c0 .05-.03.16-.18.16H7.88c-.16 0-.18-.1-.18-.15.06-1.35.66-2.2 1.83-2.88.39-.29.7-.75.7-1.24.01-1.24-1.64-1.82-2.35-.72-.21.33-.18.73-.18 1.1H5.75c0-1.97 1.03-3.26 3.03-3.26 1.75 0 3.47.87 3.47 2.83 0 .57-.2 1.05-.48 1.44z"/></svg></a>
+    </li>
+    <div class="topbar-dialog help-dialog js-help-dialog dno" id="topbar-help-dialog" role="menu">
+        <div class="modal-content">
+            <ul>
+                    <li>
+                        <a href="/tour" class="js-gps-track" data-gps-track="help_popup.click({ item_type:1 })"
+                           data-ga="[&quot;top navigation&quot;,&quot;tour submenu click&quot;,null,null,null]">
+                            Tour
+                            <span class="item-summary">
+                                Start here for a quick overview of the site
+                            </span>
+                        </a>
+                    </li>
+                <li>
+                    <a href="/help" class="js-gps-track"
+                       data-gps-track="help_popup.click({ item_type:4 })"
+                       data-ga="[&quot;top navigation&quot;,&quot;help center&quot;,null,null,null]">
+                        Help Center
+                        <span class="item-summary">
+                            Detailed answers to any questions you might have
+                        </span>
+                    </a>
+                </li>
+                            <li>
+                                <a href="https://unix.meta.stackexchange.com" class="js-gps-track" data-gps-track="help_popup.click({ item_type:2 })"
+                                   data-ga="[&quot;top navigation&quot;,&quot;meta submenu click&quot;,null,null,null]">
+                                    Meta
+                                    <span class="item-summary">
+                                        Discuss the workings and policies of this site
+                                    </span>
+                                </a>
+                            </li>
+                        <li>
+                            <a href="https://stackoverflow.com/company" class="js-gps-track" data-gps-track="help_popup.click({ item_type:6 })"
+                               data-ga="[&quot;top navigation&quot;,&quot;about us submenu click&quot;,null,null,null]">
+                                About Us
+                                <span class="item-summary">
+                                    Learn more about Stack Overflow the company
+                                </span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://stackoverflowbusiness.com/?ref=topbar_help" class="js-gps-track" data-gps-track="help_popup.click({ item_type:7 })"
+                               data-ga="[&quot;top navigation&quot;,&quot;business submenu click&quot;,null,null,null]">
+                                Business
+                                <span class="item-summary">
+                                    Learn more about hiring developers or posting ads with us
+                                </span>
+                            </a>
+                        </li>
+            </ul>
+        </div>
+    </div>
+    <li class="-item site-switcher-item">
+        <a href="https://stackexchange.com" class="-link js-site-switcher-button js-gps-track" data-gps-track="site_switcher.show"
+           aria-label="Site switcher"
+           title="A list of all 178 Stack Exchange sites"
+           role="menuitem" aria-haspopup="true" aria-expanded="false"
+           data-ga="[&quot;top navigation&quot;,&quot;stack exchange click&quot;,null,null,null]">
+            <svg aria-hidden="true" class="svg-icon iconStackExchange" width="18" height="18" viewBox="0 0 18 18"><path d="M15 1H3a2 2 0 00-2 2v2h16V3a2 2 0 00-2-2zM1 13c0 1.1.9 2 2 2h8v3l3-3h1a2 2 0 002-2v-2H1v2zm16-7H1v4h16V6z"/></svg>
+        </a>
+    </li>
+
+        <li class="-ctas">
+                        <a href="https://unix.stackexchange.com/users/login?ssrc=head&returnurl=https%3a%2f%2funix.stackexchange.com%2fquestions%2f405783%2fwhy-does-man-print-gimme-gimme-gimme-at-0030" class="login-link s-btn s-btn__filled py8 js-gps-track" rel="nofollow"
+                           data-gps-track="login.click" data-ga="[&quot;top navigation&quot;,&quot;login button click&quot;,null,null,null]">Log in</a>
+                        <a href="https://unix.stackexchange.com/users/signup?ssrc=head&returnurl=https%3a%2f%2funix.stackexchange.com%2fquestions%2f405783%2fwhy-does-man-print-gimme-gimme-gimme-at-0030" class="login-link s-btn s-btn__primary py8" rel="nofollow" data-ga="[&quot;sign up&quot;,&quot;Sign Up Navigation&quot;,&quot;Header&quot;,null,null]">Sign up</a>
+
+        </li>
+
+<li class="js-topbar-dialog-corral" role="presentation">
+        
+
+<div class="topbar-dialog siteSwitcher-dialog dno" role="menu">
+    <div class="header fw-wrap">
+        <h3 class="flex--item">
+            <a href="https://unix.stackexchange.com">current community</a>
+        </h3>
+        <div class="flex--item fl1">
+            <div class="ai-center d-flex jc-end">
+                <button
+                    class="js-close-button s-btn s-btn__muted p0 ml8 d-none sm:d-block"
+                    type="button"
+                    aria-label="Close"
+                >
+                    <svg aria-hidden="true" class="svg-icon iconClear" width="18" height="18" viewBox="0 0 18 18"><path d="M15 4.41 13.59 3 9 7.59 4.41 3 3 4.41 7.59 9 3 13.59 4.41 15 9 10.41 13.59 15 15 13.59 10.41 9 15 4.41z"/></svg>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="modal-content bg-powder-050 current-site-container">
+        <ul class="current-site ">
+                <li class="d-flex">
+                        <div class="fl1">
+            <a href="https://unix.stackexchange.com"
+   class="current-site-link site-link js-gps-track d-flex gs8 gsx"
+   data-id="106"
+   data-gps-track="site_switcher.click({ item_type:3 })">
+    <div class="favicon favicon-unix site-icon flex--item" title="Unix &amp; Linux"></div>
+    <span class="flex--item fl1">
+        Unix &amp; Linux
+    </span>
+</a>
+
+</div>
+<div class="related-links">
+        <a href="https://unix.stackexchange.com/help" class="js-gps-track" data-gps-track="site_switcher.click({ item_type:14 })">help</a>
+        <a href="https://chat.stackexchange.com?tab=site&amp;host=unix.stackexchange.com" class="js-gps-track" data-gps-track="site_switcher.click({ item_type:6 })">chat</a>
+</div>
+
+                </li>
+                <li class="related-site d-flex">
+                        <div class="L-shaped-icon-container">
+    <span class="L-shaped-icon"></span>
+</div>
+
+                        <a href="https://unix.meta.stackexchange.com"
+   class=" site-link js-gps-track d-flex gs8 gsx"
+   data-id="108"
+   data-gps-track="site.switch({ target_site:108, item_type:3 }),site_switcher.click({ item_type:4 })">
+    <div class="favicon favicon-unixmeta site-icon flex--item" title="Unix &amp; Linux Meta"></div>
+    <span class="flex--item fl1">
+        Unix &amp; Linux Meta
+    </span>
+</a>
+
+                </li>
+        </ul>
+    </div>
+
+    <div class="header" id="your-communities-header">
+        <h3>
+your communities            </h3>
+
+    </div>
+    <div class="modal-content" id="your-communities-section">
+
+            <div class="call-to-login">
+<a href="https://unix.stackexchange.com/users/signup?ssrc=site_switcher&amp;returnurl=https%3a%2f%2funix.stackexchange.com%2fquestions%2f405783%2fwhy-does-man-print-gimme-gimme-gimme-at-0030" class="login-link js-gps-track" data-gps-track="site_switcher.click({ item_type:10 })">Sign up</a> or <a href="https://unix.stackexchange.com/users/login?ssrc=site_switcher&amp;returnurl=https%3a%2f%2funix.stackexchange.com%2fquestions%2f405783%2fwhy-does-man-print-gimme-gimme-gimme-at-0030" class="login-link js-gps-track" data-gps-track="site_switcher.click({ item_type:11 })">log in</a> to customize your list.                </div>
+    </div>
+
+    <div class="header">
+        <h3><a href="https://stackexchange.com/sites">more stack exchange communities</a>
+        </h3>
+        <a href="https://stackoverflow.blog" class="fr">company blog</a>
+    </div>
+    <div class="modal-content">
+            <div class="child-content"></div>
+    </div>        
+</div>
+
+</li>
+</ol>
+
+</div>
+</header>
+
+<script>
+    StackExchange.ready(function () { StackExchange.topbar.init(); });
+    StackExchange.scrollPadding.setPaddingTop(50, 10); 
+</script>
+
+
+
+        
+
+    
+
+<div class="py24 bg-black-750 fc-black-200 sm:pt24 sm:pb24 ps-relative js-dismissable-hero">
+<div class="px12 d-flex ai-center jc-center mx-auto wmx12 sm:fd-column">
+    <div class="flex--item wmx3 fs-body2 mr64 md:mr32 sm:mr0 sm:ta-center sm:mr0 sm:ta-center">
+        <p>Unix &amp; Linux Stack Exchange is a question and answer site for users of Linux, FreeBSD and other Un*x-like operating systems. It only takes a minute to sign up.</p>
+
+        <a href="/users/signup?ssrc=hero&amp;returnurl=https%3a%2f%2funix.stackexchange.com%2fquestions%2f405783%2fwhy-does-man-print-gimme-gimme-gimme-at-0030" class="s-btn s-btn__primary">Sign up to join this community</a>
+    </div>
+    <div class="d-flex fd-column ai-center wmn3 sm:wmn-initial sm:mt32 hero-background">
+        <div class="d-flex ai-center mb24 sm:mb16">
+            <div class="flex--item mr16">
+                <img width="31" src="https://cdn.sstatic.net/Img/hero/anonymousHeroQuestions.svg?v=748bfb046b78">
+            </div>
+            <div class="flex--item">
+                Anybody can ask a question
+            </div>
+        </div>
+        <div class="d-flex ai-center mb24 sm:mb16">
+            <div class="flex--item mr16">
+                <img width="35" src="https://cdn.sstatic.net/Img/hero/anonymousHeroAnswers.svg?v=d5348b00eddc">
+            </div>
+            <div class="flex--item">
+                Anybody can answer
+            </div>
+        </div>
+        <div class="d-flex ai-center">
+            <div class="flex--item mr16">
+                <img width="24" src="https://cdn.sstatic.net/Img/hero/anonymousHeroUpvote.svg?v=af2bb70d5d1b">
+            </div>
+            <div class="flex--item wmx2">
+                The best answers are voted up and rise to the top
+            </div>
+        </div>
+    </div>
+        <div class="flex--item as-start md:ps-absolute t8 r8">
+            <button class="s-btn s-btn__muted p8 js-dismiss">
+                <svg aria-hidden="true" class="svg-icon iconClear" width="18" height="18" viewBox="0 0 18 18"><path d="M15 4.41 13.59 3 9 7.59 4.41 3 3 4.41 7.59 9 3 13.59 4.41 15 9 10.41 13.59 15 15 13.59 10.41 9 15 4.41z"/></svg>
+            </button>
+        </div>
+</div>
+</div>
+
+<script>
+StackExchange.ready(function () {
+    StackExchange.Hero.init("nso", "a");
+
+    var location = 0;
+    if ($("body").hasClass("questions-page")) {
+        location = 1;
+    } else if ($("body").hasClass("question-page")) {
+        location = 1;
+    } else if ($("body").hasClass("faq-page")) {
+        location = 5;
+    } else if ($("body").hasClass("home-page")) {
+        location = 3;
+    }
+
+    $('.js-cta-button').click(function () {
+        StackExchange.using("gps", function () {
+            StackExchange.gps.track("hero.action", { hero_action_type: 'cta', location: location }, true);
+        });
+    });
+
+    // TODO: we should review the class names and whatnot in use here. Older heroes use id selectors, the newer
+    // sticky question hero on SO has a .js-dismiss class instead, but it's apparently not used anywhere... 
+    // It's not great. Ideally we'd have a set of classes in the partials above that would correspond to 
+    // the behaviours we want here in a more clear way. 
+
+    // sticky question-page hero at the bottom of the page on SO
+    $('.js-dismiss').on('click', function () {
+        StackExchange.using("gps", function () {
+            StackExchange.gps.track("hero.action", { hero_action_type: "close", location: location }, true);
+        });
+        StackExchange.Hero.dismiss();
+        $(".js-dismissable-hero").fadeOut("fast");
+    });
+});
+</script>
+
+
+    <header class="site-header">
+        <div class="site-header--container">
+            <a class="site-header--link d-flex ai-center fs-headline1 fw-bold" href="https://unix.stackexchange.com">
+                    <img class="h-auto wmx100" src="https://cdn.sstatic.net/Sites/unix/Img/logo.svg?v=eb6eb2b9e73c" alt="Unix &amp; Linux">
+            </a>
+
+        </div>
+    </header>
+
+<div class="container">
+        
+
+
+<div id="left-sidebar" data-is-here-when="md lg" class="left-sidebar js-pinned-left-sidebar ps-relative">
+<div class="left-sidebar--sticky-container js-sticky-leftnav">
+    <nav role="navigation">
+        <ol class="nav-links">
+    <li class="">
+        <a
+           href="/"
+           class="pl8 js-gps-track nav-links--link"
+           
+           data-gps-track="top_nav.click({is_current:false, location:2, destination:8})" 
+           aria-controls="" data-controller="" data-s-popover-placement="right"
+           data-s-popover-auto-show="true" data-s-popover-hide-on-outside-click="never">
+                <div class="d-flex ai-center">
+                    <div class="flex--item truncate">
+                        Home
+                    </div>
+                </div>
+        </a>
+    </li>
+            <li>
+                <ol class="nav-links">
+                        <li class="fs-fine tt-uppercase ml8 mt16 mb4 fc-light">Public</li>
+
+    <li class=" youarehere">
+        <a id="nav-questions"
+           href="/questions"
+           class="pl8 js-gps-track nav-links--link -link__with-icon"
+           
+           data-gps-track="top_nav.click({is_current:true, location:2, destination:1})" 
+           aria-controls="" data-controller="" data-s-popover-placement="right"
+           data-s-popover-auto-show="true" data-s-popover-hide-on-outside-click="never">
+<svg aria-hidden="true" class="svg-icon iconGlobe" width="18" height="18" viewBox="0 0 18 18"><path d="M9 1C4.64 1 1 4.64 1 9c0 4.36 3.64 8 8 8 4.36 0 8-3.64 8-8 0-4.36-3.64-8-8-8zM8 15.32a6.46 6.46 0 01-4.3-2.74 6.46 6.46 0 0 1-.93-5.01L7 11.68v.8c0 .88.12 1.32 1 1.32v1.52zm5.72-2c-.2-.66-1-1.32-1.72-1.32h-1v-2c0-.44-.56-1-1-1H6V7h1c.44 0 1-.56 1-1V5h2c.88 0 1.4-.72 1.4-1.6v-.33a6.45 6.45 0 013.83 4.51 6.45 6.45 0 0 1-1.51 5.73v.01z"/></svg>                    <span class="-link--channel-name">Questions</span>
+        </a>
+    </li>
+
+    <li class="">
+        <a id="nav-tags"
+           href="/tags"
+           class=" js-gps-track nav-links--link"
+           
+           data-gps-track="top_nav.click({is_current:false, location:2, destination:2})" 
+           aria-controls="" data-controller="" data-s-popover-placement="right"
+           data-s-popover-auto-show="true" data-s-popover-hide-on-outside-click="never">
+                <div class="d-flex ai-center">
+                    <div class="flex--item truncate">
+                        Tags
+                    </div>
+                </div>
+        </a>
+    </li>
+    <li class="">
+        <a id="nav-users"
+           href="/users"
+           class=" js-gps-track nav-links--link"
+           
+           data-gps-track="top_nav.click({is_current:false, location:2, destination:3})" 
+           aria-controls="" data-controller="" data-s-popover-placement="right"
+           data-s-popover-auto-show="true" data-s-popover-hide-on-outside-click="never">
+                <div class="d-flex ai-center">
+                    <div class="flex--item truncate">
+                        Users
+                    </div>
+                </div>
+        </a>
+    </li>
+    <li class="">
+        <a id="nav-unanswered"
+           href="/unanswered"
+           class=" js-gps-track nav-links--link"
+           
+           data-gps-track="top_nav.click({is_current:false, location:2, destination:5})" 
+           aria-controls="" data-controller="" data-s-popover-placement="right"
+           data-s-popover-auto-show="true" data-s-popover-hide-on-outside-click="never">
+                <div class="d-flex ai-center">
+                    <div class="flex--item truncate">
+                        Unanswered
+                    </div>
+                </div>
+        </a>
+    </li>
+                            <li class="fs-fine tt-uppercase ml8 mt16 mb4 fc-light">Find a Job</li>
+    <li class="">
+        <a id="nav-jobs"
+           href="https://stackoverflow.com/jobs?so_medium=unix&amp;so_source=SiteNav"
+           class=" js-gps-track nav-links--link"
+           
+           data-gps-track="top_nav.click({is_current:false, location:2, destination:6})" 
+           aria-controls="" data-controller="" data-s-popover-placement="right"
+           data-s-popover-auto-show="true" data-s-popover-hide-on-outside-click="never">
+                <div class="d-flex ai-center">
+                    <div class="flex--item truncate">
+                        Jobs
+                    </div>
+                </div>
+        </a>
+    </li>
+    <li class="">
+        <a id="nav-companies"
+           href="https://stackoverflow.com/jobs/companies?so_medium=unix&amp;so_source=SiteNav"
+           class=" js-gps-track nav-links--link"
+           
+           data-gps-track="top_nav.click({is_current:false, location:2, destination:12})" 
+           aria-controls="" data-controller="" data-s-popover-placement="right"
+           data-s-popover-auto-show="true" data-s-popover-hide-on-outside-click="never">
+                <div class="d-flex ai-center">
+                    <div class="flex--item truncate">
+                        Companies
+                    </div>
+                </div>
+        </a>
+    </li>
+                </ol>
+            </li>
+                <li>
+                    <ol class="nav-links">
+                                
+
+<div class="js-freemium-cta ps-relative">
+
+<div class="fs-fine tt-uppercase ml8 mt16 mb8 fc-light">Teams</div>
+
+<div class="bt bl bb bc-black-075 p12 pb6 fc-black-600 blr-sm overflow-hidden">
+    <strong class="fc-black-750 mb6">Stack Overflow for Teams</strong>
+    – Collaborate and share knowledge with a private group.
+    
+    <img class="wmx100 mx-auto my8 h-auto d-block" width="139" height="114" src="https://cdn.sstatic.net/Img/teams/teams-illo-free-sidebar-promo.svg?v=47faa659a05e" alt="">
+
+    <a href="https://stackoverflow.com/teams/create/free?utm_source=so-owned&amp;utm_medium=side-bar&amp;utm_campaign=campaign-38&amp;utm_content=cta" 
+       class="w100 s-btn s-btn__primary s-btn__xs js-gps-track"
+       data-gps-track="teams.create.left-sidenav.click({ Action: 6 })"
+       data-ga="[&quot;teams left navigation - anonymous&quot;,&quot;left nav free cta&quot;,&quot;stackoverflow.com/teams/create/free&quot;,null,null]">Create a free Team</a>
+    <a href="https://stackoverflow.com/teams" 
+       class="w100 s-btn s-btn__muted s-btn__xs js-gps-track"
+       data-gps-track="teams.create.left-sidenav.click({ Action: 5 })"
+       data-ga="[&quot;teams left navigation - anonymous&quot;,&quot;left nav free cta&quot;,&quot;stackoverflow.com/teams&quot;,null,null]">What is Teams?</a>
+</div>
+</div>
+
+                            <li class="d-flex ai-center jc-space-between ml8 mt24 mb4 js-create-team-cta d-none">
+                                <div class="flex--item tt-uppercase fs-fine fc-light">Teams</div>
+                                <div class="flex--item">
+                                    <a href="javascript:void(0)" class="s-link p12 fc-black-500 h:fc-black-800 js-gps-track"
+                                        role="button"
+                                        aria-controls="popover-teams-create-cta"
+                                        data-controller="s-popover"
+                                        data-action="s-popover#toggle"
+                                        data-s-popover-placement="bottom-start"
+                                        data-s-popover-toggle-class="is-selected"
+                                        data-gps-track="teams.create.left-sidenav.click({ Action: ShowInfo })"
+                                        data-ga="[&quot;teams left navigation - anonymous&quot;,&quot;left nav show teams info&quot;,null,null,null]">
+                                        <svg aria-hidden="true" class="svg-icon iconInfoSm" width="14" height="14" viewBox="0 0 14 14"><path d="M7 1a6 6 0 110 12A6 6 0 017 1zm1 10V6H6v5h2zm0-6V3H6v2h2z"/></svg>
+                                    </a>
+
+                                </div>
+                            </li>
+                            <li class="ps-relative js-create-team-cta d-none">
+                                <a href="https://stackoverflow.com/teams/create/free?utm_source=so-owned&amp;utm_medium=side-bar&amp;utm_campaign=campaign-38&amp;utm_content=cta"
+                                   class="pl8 js-gps-track nav-links--link"
+                                   title="Stack Overflow for Teams is a private, secure spot for your organization's questions and answers."
+                                   data-gps-track="teams.create.left-sidenav.click({ Action: FreemiumTeamsCreateClick })"
+                                   data-ga="[&quot;teams left navigation - anonymous&quot;,&quot;left nav team click&quot;,&quot;stackoverflow.com/teams/create/free&quot;,null,null]">
+                                    <div class="d-flex ai-center">
+                                        <div class="flex--item s-avatar va-middle bg-orange-400">
+                                            <div class="s-avatar--letter mtn1">
+                                                <svg aria-hidden="true" class="svg-icon iconBriefcaseSm" width="14" height="14" viewBox="0 0 14 14"><path d="M4 3a1 1 0 011-1h4a1 1 0 011 1v1h.5c.83 0 1.5.67 1.5 1.5v5c0 .83-.67 1.5-1.5 1.5h-7A1.5 1.5 0 012 10.5v-5C2 4.67 2.67 4 3.5 4H4V3zm5 1V3H5v1h4z"/></svg>
+                                            </div>
+                                            <svg aria-hidden="true" class="native s-avatar--badge svg-icon iconShieldXSm" width="9" height="10" viewBox="0 0 9 10"><path d="M0 1.84 4.5 0 9 1.84v3.17C9 7.53 6.3 10 4.5 10 2.7 10 0 7.53 0 5.01V1.84z" fill="var(--white)"/><path d="M1 2.5 4.5 1 8 2.5v2.51C8 7.34 5.34 9 4.5 9 3.65 9 1 7.34 1 5.01V2.5zm2.98 3.02L3.2 7h2.6l-.78-1.48a.4.4 0 01.15-.38c.34-.24.73-.7.73-1.14 0-.71-.5-1.23-1.41-1.23-.92 0-1.39.52-1.39 1.23 0 .44.4.9.73 1.14.12.08.18.23.15.38z" fill="var(--black-500)"/></svg>
+                                        </div>
+                                        <div class="flex--item pl6">
+                                            Create free Team
+                                        </div>
+                                    </div>
+                                </a>
+                            </li>
+                    </ol>
+                </li>
+        </ol>
+    </nav>
+</div>
+
+
+
+    <div class="s-popover"
+         id="popover-teams-create-cta"
+         role="menu"
+         aria-hidden="true">
+        <div class="s-popover--arrow"></div>
+
+        <div class="ps-relative overflow-hidden">
+            <p class="mb2"><strong>Teams</strong></p>
+            <p class="mb12 fs-caption fc-black-400">Q&amp;A for work</p>
+            <p class="mb12 fs-caption fc-medium">Connect and share knowledge within a single location that is structured and easy to search.</p>
+            <a href="https://stackoverflow.com/teams"
+               class="js-gps-track s-btn s-btn__primary s-btn__xs"
+               data-gps-track="teams.create.left-sidenav.click({ Action: CtaClick })"
+               data-ga="[&quot;teams left navigation - anonymous&quot;,&quot;left nav cta&quot;,&quot;stackoverflow.com/teams&quot;,null,null]">
+                Learn more
+            </a>
+        </div>
+
+        <div class="ps-absolute t8 r8">
+            <svg aria-hidden="true" class="fc-orange-500 svg-spot spotPeople" width="48" height="48" viewBox="0 0 48 48"><path d="M13.5 28a4.5 4.5 0 100-9 4.5 4.5 0 0 0 0 9zM7 30a1 1 0 011-1h11a1 1 0 011 1v5h11v-5a1 1 0 011-1h12a1 1 0 011 1v10a2 2 0 01-2 2H33v5a1 1 0 01-1 1H20a1 1 0 01-1-1v-5H8a1 1 0 01-1-1V30zm25-6.5a4.5 4.5 0 109 0 4.5 4.5 0 0 0-9 0zM24.5 34a4.5 4.5 0 100-9 4.5 4.5 0 0 0 0 9z" opacity=".2"/><path d="M16.4 26.08A6 6 0 107.53 26C5.64 26.06 4 27.52 4 29.45V40a1 1 0 001 1h9a1 1 0 100-2h-4v-7a1 1 0 10-2 0v7H6v-9.55c0-.73.67-1.45 1.64-1.45H16a1 1 0 00.4-1.92zM12 18a4 4 0 110 8 4 4 0 0 1 0-8zm16.47 14a6 6 0 10-8.94 0A3.6 3.6 0 0016 35.5V46a1 1 0 001 1h14a1 1 0 001-1V35.5c0-1.94-1.64-3.42-3.53-3.5zM20 28a4 4 0 118 0 4 4 0 0 1-8 0zm-.3 6h8.6c1 0 1.7.75 1.7 1.5V45h-2v-7a1 1 0 10-2 0v7h-4v-7a1 1 0 10-2 0v7h-2v-9.5c0-.75.7-1.5 1.7-1.5zM42 22c0 1.54-.58 2.94-1.53 4A3.5 3.5 0 0144 29.45V40a1 1 0 01-1 1h-9a1 1 0 110-2h4v-7a1 1 0 112 0v7h2v-9.55A1.5 1.5 0 0040.48 28H32a1 1 0 01-.4-1.92A6 6 0 1142 22zm-2 0a4 4 0 10-8 0 4 4 0 0 0 8 0z"/><path d="M17 10a1 1 0 011-1h12a1 1 0 110 2H18a1 1 0 01-1-1zm1-5a1 1 0 100 2h12a1 1 0 100-2H18zm-4-4a1 1 0 00-1 1v12a1 1 0 001 1h5.09l4.2 4.2a1 1 0 001.46-.04l3.7-4.16H34a1 1 0 001-1V2a1 1 0 00-1-1H14zm1 12V3h18v10h-5a1 1 0 00-.75.34l-3.3 3.7-3.74-3.75a1 1 0 00-.71-.29H15z" opacity=".35"/></svg>
+        </div>
+    </div>
+
+</div>
+
+
+
+
+    <div id="content" class="">
+
+        
+<div itemprop="mainEntity" itemscope itemtype="https://schema.org/Question">
+<link itemprop="image" href="https://cdn.sstatic.net/Sites/unix/Img/apple-touch-icon.png?v=5cf7fe716a89">
+
+<div class="inner-content clearfix">
+
+    
+
+        <div id="question-header" class="d-flex sm:fd-column">
+                    <h1 itemprop="name" class="fs-headline1 ow-break-word mb8 flex--item fl1"><a href="/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030" class="question-hyperlink">Why does man print &quot;gimme gimme gimme&quot; at 00:30?</a></h1>
+            <div class="ml12 aside-cta flex--item print:d-none sm:ml0 sm:mb12 sm:order-first sm:as-end">
+                    <a href="/questions/ask" class="ws-nowrap s-btn s-btn__primary">
+    Ask Question
+</a>
+
+            </div>
+        </div>
+        <div class="d-flex fw-wrap pb8 mb16 bb bc-black-075">
+                <div class="flex--item ws-nowrap mr16 mb8" title="2017-11-20 14:19:31Z">
+                    <span class="fc-light mr2">Asked</span>
+                    <time itemprop="dateCreated" datetime="2017-11-20T14:19:31">3 years, 9 months ago</time>
+                </div>
+                <div class="flex--item ws-nowrap mr16 mb8">
+                    <span class="fc-light mr2">Active</span>
+                    <a href="?lastactivity" class="s-link s-link__inherit" title="2021-07-15 10:55:45Z">1 month ago</a>
+                </div>
+                <div class="flex--item ws-nowrap mb8" title="Viewed 399,280 times">
+                    <span class="fc-light mr2">Viewed</span>
+                    399k times
+                </div>
+        </div>
+        <div id="mainbar" role="main" aria-label="question and answers">
+
+            
+<div class="question" data-questionid="405783" data-position-on-page="0" data-score="1774"  id="question">
+<style>
+</style>
+<div class="js-zone-container zone-container-main">
+<div id="dfp-tlb" class="everyonelovesstackoverflow everyoneloves__top-leaderboard everyoneloves__leaderboard"></div>
+<div class="js-report-ad-button-container " style="width: 728px"></div>
+</div>
+
+<div class="post-layout">
+    <div class="votecell post-layout--left">
+        <div class="js-voting-container d-flex jc-center fd-column ai-stretch gs4 fc-black-200" data-post-id="405783">
+    <button class="js-vote-up-btn flex--item s-btn s-btn__unset c-pointer "
+            data-controller="s-tooltip"
+            data-s-tooltip-placement="right"
+            title="This question shows research effort; it is useful and clear"
+            aria-pressed="false"
+            aria-label="Up vote"
+            data-selected-classes="fc-theme-primary"
+            data-unselected-classes="">
+        <svg aria-hidden="true" class="svg-icon iconArrowUpLg" width="36" height="36" viewBox="0 0 36 36"><path d="M2 26h32L18 10 2 26z"/></svg>
+    </button>
+    <div class="js-vote-count flex--item d-flex fd-column ai-center fc-black-500 fs-title"
+         itemprop="upvoteCount"
+         data-value="1774">
+        1774
+    </div>
+    <button class="js-vote-down-btn flex--item s-btn s-btn__unset c-pointer "
+            data-controller="s-tooltip"
+            data-s-tooltip-placement="right"
+            title="This question does not show any research effort; it is unclear or not useful"
+            aria-pressed="false"
+            aria-label="Down vote"
+            data-selected-classes="fc-theme-primary"
+            data-unselected-classes="">
+        <svg aria-hidden="true" class="svg-icon iconArrowDownLg" width="36" height="36" viewBox="0 0 36 36"><path d="M2 10h32L18 26 2 10z"/></svg>
+    </button>
+
+    <button class="js-bookmark-btn s-btn s-btn__unset c-pointer py4 js-gps-track" 
+            data-controller="s-tooltip" data-s-tooltip-placement="right" title="Bookmark this question."
+            aria-pressed="false" aria-label="Bookmark (537)" data-selected-classes="fc-yellow-600"
+            data-gps-track="post.click({ item: 1, priv: 0, post_type: 1 })">
+        <svg aria-hidden="true" class="svg-icon iconBookmark" width="18" height="18" viewBox="0 0 18 18"><path d="M6 1a2 2 0 00-2 2v14l5-4 5 4V3a2 2 0 00-2-2H6zm3.9 3.83h2.9l-2.35 1.7.9 2.77L9 7.59l-2.35 1.7.9-2.76-2.35-1.7h2.9L9 2.06l.9 2.77z"/></svg>
+        <div class="js-bookmark-count mt4" data-value="537">537</div>
+    </button>
+
+
+
+    <a class="js-post-issue flex--item s-btn s-btn__unset c-pointer py6 mx-auto" href="/posts/405783/timeline" data-shortcut="T" data-ks-title="timeline" data-controller="s-tooltip" data-s-tooltip-placement="right" title="Show activity on this post." aria-label="Timeline"><svg aria-hidden="true" class="mln2 mr0 svg-icon iconHistory" width="19" height="18" viewBox="0 0 19 18"><path d="M3 9a8 8 0 113.73 6.77L8.2 14.3A6 6 0 105 9l3.01-.01-4 4-4-4h3L3 9zm7-4h1.01L11 9.36l3.22 2.1-.6.93L10 10V5z"/></svg></a>
+
+</div>
+
+    </div>
+
+    
+
+<div class="postcell post-layout--right">
+
+<div class="s-prose js-post-body" itemprop="text">
+            
+<p>We've noticed that some of our automatic tests fail when they run at 00:30 but work fine the rest of the day. They fail with the message</p>
+<pre><code>gimme gimme gimme
+</code></pre>
+<p>in <code>stderr</code>, which wasn't expected. Why are we getting this output?</p>
+</div>
+
+    <div class="mt24 mb12">
+        <div class="post-taglist d-flex gs4 gsy fd-column">
+            <div class="d-flex ps-relative">
+                <a href="/questions/tagged/date" class="post-tag" title="show questions tagged &#39;date&#39;" rel="tag">date</a> <a href="/questions/tagged/man" class="post-tag" title="show questions tagged &#39;man&#39;" rel="tag">man</a> 
+            </div>
+        </div>
+    </div>
+
+<div class="mb0 ">
+    <div class="mt16 d-flex gs8 gsy fw-wrap jc-end ai-start pt4 mb16">
+        <div class="flex--item mr16 fl1 w96">
+            
+
+
+<div class="js-post-menu pt2" data-post-id="405783">
+<div class="d-flex gs8 s-anchors s-anchors__muted fw-wrap">
+
+    <div class="flex--item">
+        <a href="/q/405783"
+           rel="nofollow"
+           itemprop="url"
+           class="js-share-link js-gps-track"
+           title="Short permalink to this question"
+           data-gps-track="post.click({ item: 2, priv: 0, post_type: 1 })"
+           data-controller="se-share-sheet"
+           data-se-share-sheet-title="Share a link to this question"
+           data-se-share-sheet-subtitle=""
+           data-se-share-sheet-post-type="question"
+           data-se-share-sheet-social="facebook twitter "
+           data-se-share-sheet-location="1"
+           data-se-share-sheet-license-url="https%3a%2f%2fcreativecommons.org%2flicenses%2fby-sa%2f4.0%2f"
+           data-se-share-sheet-license-name="CC BY-SA 4.0"
+           data-s-popover-placement="bottom-start">Share</a>
+    </div>
+
+
+            <div class="flex--item">
+                <a href="/posts/405783/edit" class="js-suggest-edit-post js-gps-track" data-gps-track="post.click({ item: 6, priv: 0, post_type: 1 })" title="">Improve this question</a>
+            </div>
+
+    <div class="flex--item">
+        <button type="button"
+                id="btnFollowPost-405783" class="s-btn s-btn__link js-follow-post js-follow-question js-gps-track"
+                data-gps-track="post.click({ item: 14, priv: 0, post_type: 1 })"
+                data-controller="s-tooltip " data-s-tooltip-placement="bottom"
+                data-s-popover-placement="bottom" aria-controls=""
+                title="Follow this question to receive notifications">
+            Follow
+        </button>
+    </div>
+
+
+
+
+
+</div>
+<div class="js-menu-popup-container"></div>
+</div>
+        </div>
+
+            <div class="post-signature flex--item">
+<div class="user-info ">
+<div class="user-action-time">
+    <a href="/posts/405783/revisions" title="show all edits to this post"
+                     class="js-gps-track"
+                     data-gps-track="post.click({ item: 4, priv: 0, post_type: 1 })">edited <span title="2021-07-15 10:55:45Z" class="relativetime">Jul 15 at 10:55</span></a>
+</div>
+<div class="user-gravatar32">
+    <a href="/users/377345/adminbee"><div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/96b611478f7725a9260c838a32a71cdf?s=64&amp;d=identicon&amp;r=PG&amp;f=1" alt="" width="32" height="32" class="bar-sm"></div></a>
+</div>
+<div class="user-details">
+    <a href="/users/377345/adminbee">AdminBee</a>
+    <div class="-flair">
+        <span class="reputation-score" title="reputation score 15,479" dir="ltr">15.5k</span><span title="11 gold badges" aria-hidden="true"><span class="badge1"></span><span class="badgecount">11</span></span><span class="v-visible-sr">11 gold badges</span><span title="32 silver badges" aria-hidden="true"><span class="badge2"></span><span class="badgecount">32</span></span><span class="v-visible-sr">32 silver badges</span><span title="57 bronze badges" aria-hidden="true"><span class="badge3"></span><span class="badgecount">57</span></span><span class="v-visible-sr">57 bronze badges</span>
+    </div>
+</div>
+</div>
+            </div>
+        <div class="post-signature owner flex--item">
+            <div class="user-info user-hover">
+<div class="user-action-time">
+    asked <span title="2017-11-20 14:19:31Z" class="relativetime">Nov 20 '17 at 14:19</span>
+</div>
+<div class="user-gravatar32">
+    <a href="/users/173916/jaroslav-kucera"><div class="gravatar-wrapper-32"><img src="https://i.stack.imgur.com/hzj8B.jpg?s=64&amp;g=1" alt="" width="32" height="32" class="bar-sm"></div></a>
+</div>
+<div class="user-details" itemprop="author" itemscope itemtype="http://schema.org/Person">
+    <a href="/users/173916/jaroslav-kucera">Jaroslav Kucera</a><span class="d-none" itemprop="name">Jaroslav Kucera</span>
+    <div class="-flair">
+        <span class="reputation-score" title="reputation score " dir="ltr">8,169</span><span title="4 gold badges" aria-hidden="true"><span class="badge1"></span><span class="badgecount">4</span></span><span class="v-visible-sr">4 gold badges</span><span title="11 silver badges" aria-hidden="true"><span class="badge2"></span><span class="badgecount">11</span></span><span class="v-visible-sr">11 silver badges</span><span title="27 bronze badges" aria-hidden="true"><span class="badge3"></span><span class="badgecount">27</span></span><span class="v-visible-sr">27 bronze badges</span>
+    </div>
+</div>
+</div>
+
+
+        </div>
+    </div>
+</div>
+
+</div>
+
+
+
+
+        <span class="d-none" itemprop="commentCount">6</span> 
+<div class="post-layout--right js-post-comments-component">
+    <div id="comments-405783" class="comments js-comments-container bt bc-black-075 mt12 " data-post-id="405783" data-min-length="15">
+        <ul class="comments-list js-comments-list"
+                data-remaining-comments-count="1"
+                data-canpost="false"
+                data-cansee="true"
+                data-comments-unavailable="false"
+                data-addlink-disabled="true">
+
+                    <li id="comment-725859" class="comment js-comment " data-comment-id="725859" data-comment-owner-id="117549" data-comment-score="5">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="warm">5</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">Linking in: <a href="https://unix.stackexchange.com/questions/226716/where-is-the-latest-source-code-of-man-command-for-linux" title="where is the latest source code of man command for linux">unix.stackexchange.com/questions/226716/&hellip;</a></span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/117549/jeff-schaller"
+                        title="60,216 reputation"
+                        class="comment-user">Jeff Schaller<span class="mod-flair " title="Moderator">&#9830;</span></a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-20 14:29:26Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 20 '17 at 14:29</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-725920" class="comment js-comment " data-comment-id="725920" data-comment-owner-id="3562" data-comment-score="61">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">61</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">I don&#39;t get it. Why does your test script call man where it should fail?</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/3562/joshua"
+                        title="1,623 reputation"
+                        class="comment-user">Joshua</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-20 16:20:27Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 20 '17 at 16:20</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-725956" class="comment js-comment " data-comment-id="725956" data-comment-owner-id="173916" data-comment-score="23">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="hot">23</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">@Joshua Because we wanted the &quot;manpath&quot; - &#39;man -w&#39;. See the answer.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/173916/jaroslav-kucera"
+                        title="8,169 reputation"
+                        class="comment-user owner">Jaroslav Kucera</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-20 17:48:50Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 20 '17 at 17:48</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-726292" class="comment js-comment " data-comment-id="726292" data-comment-owner-id="27616" data-comment-score="75">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">75</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">for the sake of history, why do you need to do a &#39;man -w&#39; every minutes? what are you really testing?</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/27616/olivier-dulac"
+                        title="5,327 reputation"
+                        class="comment-user">Olivier Dulac</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-21 10:12:58Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 21 '17 at 10:12</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-726350" class="comment js-comment " data-comment-id="726350" data-comment-owner-id="173916" data-comment-score="25">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="hot">25</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">@OlivierDulac It&#39;s being triggered just once in the test. We&#39;ve rearanged the order of tests and suddenly this error apeared as it was triggered at 00:30...</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/173916/jaroslav-kucera"
+                        title="8,169 reputation"
+                        class="comment-user owner">Jaroslav Kucera</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-21 11:52:34Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 21 '17 at 11:52</span></span>
+        </div>
+    </div>
+</li>
+
+        </ul>
+  </div>
+
+    <div id="comments-link-405783" data-rep=50 data-anon=true>
+                <a class="js-add-link comments-link dno" title="Use comments to ask for more information or suggest improvements. Avoid answering questions in comments."  href="#" role="button"></a>
+            <span class="js-link-separator dno">&nbsp;|&nbsp;</span>
+        <a class="js-show-link comments-link " title="Expand to show all comments on this post" href=# onclick="" role="button">Show <b>1</b> more comment</a>
+    </div>         
+</div>
+</div>
+</div>
+
+
+
+            <div id="answers">
+
+                <a name="tab-top"></a>
+                <div id="answers-header">
+                    <div class="answers-subheader d-flex ai-center mb8">
+                        <div class="flex--item fl1">
+                            <h2 class="mb0" data-answercount="3">
+                                    3 Answers
+                                <span style="display:none;" itemprop="answerCount">3</span>
+                            </h2>
+                        </div>
+                        <div class="flex--item">
+                            <div class=" d-flex s-btn-group js-filter-btn">
+    <a class="flex--item s-btn s-btn__muted s-btn__outlined" href="/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030?answertab=active#tab-top" data-nav-xhref="" title="Answers with the latest activity first" data-value="active" data-shortcut="A">
+        Active</a>
+    <a class="flex--item s-btn s-btn__muted s-btn__outlined" href="/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030?answertab=oldest#tab-top" data-nav-xhref="" title="Answers in the order they were provided" data-value="oldest" data-shortcut="O">
+        Oldest</a>
+    <a class="youarehere is-selected flex--item s-btn s-btn__muted s-btn__outlined" href="/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030?answertab=votes#tab-top" data-nav-xhref="" title="Answers with the highest score first" data-value="votes" data-shortcut="V">
+        Votes</a>
+</div>
+
+                        </div>
+                    </div>
+                </div>
+
+
+                                      
+<a name="405874"></a>
+<div id="answer-405874" class="answer" data-answerid="405874" data-score="2337" data-position-on-page="1" data-highest-scored="1" data-question-has-accepted-highest-score="0" itemprop="suggestedAnswer" itemscope itemtype="https://schema.org/Answer">
+<div class="post-layout">
+    <div class="votecell post-layout--left">
+        <div class="js-voting-container d-flex jc-center fd-column ai-stretch gs4 fc-black-200" data-post-id="405874">
+    <button class="js-vote-up-btn flex--item s-btn s-btn__unset c-pointer "
+            data-controller="s-tooltip"
+            data-s-tooltip-placement="right"
+            title="This answer is useful"
+            aria-pressed="false"
+            aria-label="Up vote"
+            data-selected-classes="fc-theme-primary"
+            data-unselected-classes="">
+        <svg aria-hidden="true" class="svg-icon iconArrowUpLg" width="36" height="36" viewBox="0 0 36 36"><path d="M2 26h32L18 10 2 26z"/></svg>
+    </button>
+    <div class="js-vote-count flex--item d-flex fd-column ai-center fc-black-500 fs-title"
+         itemprop="upvoteCount"
+         data-value="2337">
+        2337
+    </div>
+    <button class="js-vote-down-btn flex--item s-btn s-btn__unset c-pointer "
+            data-controller="s-tooltip"
+            data-s-tooltip-placement="right"
+            title="This answer is not useful"
+            aria-pressed="false"
+            aria-label="Down vote"
+            data-selected-classes="fc-theme-primary"
+            data-unselected-classes="">
+        <svg aria-hidden="true" class="svg-icon iconArrowDownLg" width="36" height="36" viewBox="0 0 36 36"><path d="M2 10h32L18 26 2 10z"/></svg>
+    </button>
+
+
+        <div class="js-accepted-answer-indicator flex--item fc-green-500 py6 mtn8 d-none" data-s-tooltip-placement="right" title="Loading when this answer was accepted&#x2026;" tabindex="0" role="note" aria-label="Accepted">
+            <div class="ta-center">
+                <svg aria-hidden="true" class="svg-icon iconCheckmarkLg" width="36" height="36" viewBox="0 0 36 36"><path d="m6 14 8 8L30 6v8L14 30l-8-8v-8z"/></svg>
+            </div>
+        </div>
+
+
+    <a class="js-post-issue flex--item s-btn s-btn__unset c-pointer py6 mx-auto" href="/posts/405874/timeline" data-shortcut="T" data-ks-title="timeline" data-controller="s-tooltip" data-s-tooltip-placement="right" title="Show activity on this post." aria-label="Timeline"><svg aria-hidden="true" class="mln2 mr0 svg-icon iconHistory" width="19" height="18" viewBox="0 0 19 18"><path d="M3 9a8 8 0 113.73 6.77L8.2 14.3A6 6 0 105 9l3.01-.01-4 4-4-4h3L3 9zm7-4h1.01L11 9.36l3.22 2.1-.6.93L10 10V5z"/></svg></a>
+
+</div>
+
+    </div>
+
+    
+
+<div class="answercell post-layout--right">
+
+<div class="s-prose js-post-body" itemprop="text">
+<blockquote>
+<p>Dear <a href="https://twitter.com/colmmacuait" rel="noreferrer">@colmmacuait</a>, I think that if you type "man" at 0001 hours it should print "gimme gimme gimme". <a href="https://twitter.com/hashtag/abba?src=hash" rel="noreferrer">#abba</a> <br>
+<sub> <a href="https://twitter.com/marnanel/status/132280557190119424" rel="noreferrer"><strong>@marnanel</strong> - 3 November 2011</a> </sub></p>
+</blockquote>
+
+<p>er, that was my fault, I suggested it. Sorry.</p>
+
+<p>Pretty much the whole story is in the commit. The maintainer of man is a good friend of mine, and one day six years ago I jokingly said to him that if you invoke man after midnight it should print "<em>gimme gimme gimme</em>", because of the Abba song called "<em>Gimme gimme gimme a man after midnight</em>":</p>
+
+<p>Well, he did actually <a href="https://git.savannah.nongnu.org/cgit/man-db.git/commit/src/man.c?id=002a6339b1fe8f83f4808022a17e1aa379756d99" rel="noreferrer">put it</a> <a href="https://git.savannah.nongnu.org/cgit/man-db.git/commit/src/man.c?id=91c495389105a4cb6214fe176f703f498e4f0d91" rel="noreferrer">in</a>. A few people were amused to discover it, and we mostly forgot about it until today.</p>
+
+<p><a href="https://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030/405874#comment726280_405874">I can't speak for Col</a>, obviously, but I didn't expect this to ever cause any problems: what sort of test would break on parsing the output of man with no page specified? I suppose I shouldn't be surprised that one turned up eventually, but it did take six years.</p>
+
+<p>(The <a href="https://git.savannah.nongnu.org/cgit/man-db.git/commit/src/man.c?id=002a6339b1fe8f83f4808022a17e1aa379756d99" rel="noreferrer">commit message</a> calls me Thomas, which is my legal first name though I don't use it online much.) </p>
+
+<p><strong>This issue has been fixed with commit <a href="https://git.savannah.gnu.org/cgit/man-db.git/commit/?id=84bde8d8a9a357bd372793d25746ac6b49480525" rel="noreferrer">84bde8</a>:</strong> Running man with <code>man -w</code> will no longer trigger this easter egg.</p>
+</div>
+<div class="mt24">
+    <div class="d-flex fw-wrap ai-start jc-end gs8 gsy">
+        <time itemprop="dateCreated" datetime="2017-11-21T00:20:50"></time>
+        <div class="flex--item mr16" style="flex: 1 1 100px;">
+            
+
+
+<div class="js-post-menu pt2" data-post-id="405874">
+<div class="d-flex gs8 s-anchors s-anchors__muted fw-wrap">
+
+    <div class="flex--item">
+        <a href="/a/405874"
+           rel="nofollow"
+           itemprop="url"
+           class="js-share-link js-gps-track"
+           title="Short permalink to this answer"
+           data-gps-track="post.click({ item: 2, priv: 0, post_type: 2 })"
+           data-controller="se-share-sheet"
+           data-se-share-sheet-title="Share a link to this answer"
+           data-se-share-sheet-subtitle=""
+           data-se-share-sheet-post-type="answer"
+           data-se-share-sheet-social="facebook twitter "
+           data-se-share-sheet-location="2"
+           data-se-share-sheet-license-url="https%3a%2f%2fcreativecommons.org%2flicenses%2fby-sa%2f3.0%2f"
+           data-se-share-sheet-license-name="CC BY-SA 3.0"
+           data-s-popover-placement="bottom-start">Share</a>
+    </div>
+
+
+            <div class="flex--item">
+                <a href="/posts/405874/edit" class="js-suggest-edit-post js-gps-track" data-gps-track="post.click({ item: 6, priv: 0, post_type: 2 })" title="">Improve this answer</a>
+            </div>
+
+    <div class="flex--item">
+        <button type="button"
+                id="btnFollowPost-405874" class="s-btn s-btn__link js-follow-post js-follow-answer js-gps-track"
+                data-gps-track="post.click({ item: 14, priv: 0, post_type: 2 })"
+                data-controller="s-tooltip " data-s-tooltip-placement="bottom"
+                data-s-popover-placement="bottom" aria-controls=""
+                title="Follow this answer to receive notifications">
+            Follow
+        </button>
+    </div>
+
+
+
+
+
+</div>
+<div class="js-menu-popup-container"></div>
+</div>
+        </div>
+        <div class="post-signature flex--item fl0">
+<div class="user-info ">
+<div class="user-action-time">
+    <a href="/posts/405874/revisions" title="show all edits to this post"
+                     class="js-gps-track"
+                     data-gps-track="post.click({ item: 4, priv: 0, post_type: 2 })">edited <span title="2017-11-22 01:50:18Z" class="relativetime">Nov 22 '17 at 1:50</span></a>
+</div>
+<div class="user-gravatar32">
+    <a href="/users/30230/pf4public"><div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/b7cd5bb98fa7b89aa2ced954c940ee30?s=64&amp;d=identicon&amp;r=PG" alt="" width="32" height="32" class="bar-sm"></div></a>
+</div>
+<div class="user-details">
+    <a href="/users/30230/pf4public">PF4Public</a>
+    <div class="-flair">
+        <span class="reputation-score" title="reputation score " dir="ltr">125</span><span title="11 bronze badges" aria-hidden="true"><span class="badge3"></span><span class="badgecount">11</span></span><span class="v-visible-sr">11 bronze badges</span>
+    </div>
+</div>
+</div>
+        </div>
+
+
+        <div class="post-signature flex--item fl0">
+            <div class="user-info user-hover">
+<div class="user-action-time">
+    answered <span title="2017-11-21 00:20:50Z" class="relativetime">Nov 21 '17 at 0:20</span>
+</div>
+<div class="user-gravatar32">
+    <a href="/users/154641/marnanel-thurman"><div class="gravatar-wrapper-32"><img src="https://lh4.googleusercontent.com/-CnB9zl2NNcM/AAAAAAAAAAI/AAAAAAAACKg/tkoP4cpSfTk/photo.jpg?sz=64" alt="" width="32" height="32" class="bar-sm"></div></a>
+</div>
+<div class="user-details" itemprop="author" itemscope itemtype="http://schema.org/Person">
+    <a href="/users/154641/marnanel-thurman">Marnanel Thurman</a><span class="d-none" itemprop="name">Marnanel Thurman</span>
+    <div class="-flair">
+        <span class="reputation-score" title="reputation score " dir="ltr">6,149</span><span title="2 gold badges" aria-hidden="true"><span class="badge1"></span><span class="badgecount">2</span></span><span class="v-visible-sr">2 gold badges</span><span title="7 silver badges" aria-hidden="true"><span class="badge2"></span><span class="badgecount">7</span></span><span class="v-visible-sr">7 silver badges</span><span title="10 bronze badges" aria-hidden="true"><span class="badge3"></span><span class="badgecount">10</span></span><span class="v-visible-sr">10 bronze badges</span>
+    </div>
+</div>
+</div>
+
+
+        </div>
+    </div>
+    
+
+</div>
+
+</div>
+
+
+
+
+        <span class="d-none" itemprop="commentCount">8</span> 
+<div class="post-layout--right js-post-comments-component">
+    <div id="comments-405874" class="comments js-comments-container bt bc-black-075 mt12 " data-post-id="405874" data-min-length="15">
+        <ul class="comments-list js-comments-list"
+                data-remaining-comments-count="3"
+                data-canpost="false"
+                data-cansee="true"
+                data-comments-unavailable="false"
+                data-addlink-disabled="true">
+
+                    <li id="comment-726280" class="comment js-comment " data-comment-id="726280" data-comment-owner-id="261570" data-comment-score="405">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">405</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">Oops!  It was never meant to affect non-error cases.  I didn&#39;t take account of this when I implemented <a href="https://git.savannah.gnu.org/cgit/man-db.git/commit/?id=e37bc92f352c97c61ef63de745e43574d27b1276" rel="nofollow noreferrer">git.savannah.gnu.org/cgit/man-db.git/commit/&hellip;</a>.  Fixed in master: <a href="https://git.savannah.gnu.org/cgit/man-db.git/commit/?id=84bde8d8a9a357bd372793d25746ac6b49480525" rel="nofollow noreferrer">git.savannah.gnu.org/cgit/man-db.git/commit/&hellip;</a></span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/261570/colin-watson"
+                        title="3,320 reputation"
+                        class="comment-user">Colin Watson</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-21 09:55:00Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 21 '17 at 9:55</span></span>
+                    <span title="this comment was edited 1 time">
+                        <svg aria-hidden="true" class="va-text-bottom o50 svg-icon iconPencilSm" width="14" height="14" viewBox="0 0 14 14"><path d="m11.1 1.71 1.13 1.12c.2.2.2.51 0 .71L11.1 4.7 9.21 2.86l1.17-1.15c.2-.2.51-.2.71 0zM2 10.12l6.37-6.43 1.88 1.88L3.88 12H2v-1.88z"/></svg>
+                    </span>
+        </div>
+    </div>
+</li>
+<li id="comment-726572" class="comment js-comment " data-comment-id="726572" data-comment-owner-id="22222" data-comment-score="3">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="cool">3</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">Comments are not for extended discussion; this conversation has been <a href="http://chat.stackexchange.com/rooms/69069/discussion-on-answer-by-marnanel-thurman-why-does-man-print-gimme-gimme-gimme">moved to chat</a>.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/22222/terdon"
+                        title="199,710 reputation"
+                        class="comment-user">terdon<span class="mod-flair " title="Moderator">&#9830;</span></a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-21 17:45:46Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 21 '17 at 17:45</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-726573" class="comment js-comment " data-comment-id="726573" data-comment-owner-id="22222" data-comment-score="13">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="warm">13</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">The comments are for asking for clarification and/or discussing the <i>technical</i> points of an answer. If you want to discuss the merits of Easter eggs, please <a href="http://chat.stackexchange.com/rooms/69069/discussion-on-answer-by-marnanel-thurman-why-does-man-print-gimme-gimme-gimme">take it to chat</a>.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/22222/terdon"
+                        title="199,710 reputation"
+                        class="comment-user">terdon<span class="mod-flair " title="Moderator">&#9830;</span></a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-21 17:46:03Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 21 '17 at 17:46</span></span>
+                    <span title="this comment was edited 1 time">
+                        <svg aria-hidden="true" class="va-text-bottom o50 svg-icon iconPencilSm" width="14" height="14" viewBox="0 0 14 14"><path d="m11.1 1.71 1.13 1.12c.2.2.2.51 0 .71L11.1 4.7 9.21 2.86l1.17-1.15c.2-.2.51-.2.71 0zM2 10.12l6.37-6.43 1.88 1.88L3.88 12H2v-1.88z"/></svg>
+                    </span>
+        </div>
+    </div>
+</li>
+<li id="comment-828797" class="comment js-comment " data-comment-id="828797" data-comment-owner-id="164309" data-comment-score="22">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="hot">22</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy"><i>Mamma mia, now I really know!</i></span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/164309/enlico"
+                        title="758 reputation"
+                        class="comment-user">Enlico</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2018-07-15 13:25:46Z, License: CC BY-SA 4.0" class="relativetime-clean">Jul 15 '18 at 13:25</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-863594" class="comment js-comment " data-comment-id="863594" data-comment-owner-id="109551" data-comment-score="7">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="warm">7</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">perhaps man needs a --seriously parameter</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/109551/patrick-taylor"
+                        title="631 reputation"
+                        class="comment-user">Patrick Taylor</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2018-10-03 06:08:56Z, License: CC BY-SA 4.0" class="relativetime-clean">Oct 3 '18 at 6:08</span></span>
+        </div>
+    </div>
+</li>
+
+        </ul>
+  </div>
+
+    <div id="comments-link-405874" data-rep=50 data-anon=true>
+                <a class="js-add-link comments-link dno" title="Use comments to ask for more information or suggest improvements. Avoid comments like &#x201C;&#x2B;1&#x201D; or &#x201C;thanks&#x201D;."  href="#" role="button"></a>
+            <span class="js-link-separator dno">&nbsp;|&nbsp;</span>
+        <a class="js-show-link comments-link " title="Expand to show all comments on this post" href=# onclick="" role="button">Show <b>3</b> more comments</a>
+    </div>         
+</div>
+</div>
+</div>
+<div class="js-zone-container zone-container-main">
+<div id="dfp-mlb" class="everyonelovesstackoverflow everyoneloves__mid-leaderboard everyoneloves__leaderboard"></div>
+<div class="js-report-ad-button-container " style="width: 728px"></div>
+</div>
+                                      
+<a name="405784"></a>
+<div id="answer-405784" class="answer accepted-answer" data-answerid="405784" data-score="460" data-position-on-page="2" data-highest-scored="0" data-question-has-accepted-highest-score="0" itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer">
+<div class="post-layout">
+    <div class="votecell post-layout--left">
+        <div class="js-voting-container d-flex jc-center fd-column ai-stretch gs4 fc-black-200" data-post-id="405784">
+    <button class="js-vote-up-btn flex--item s-btn s-btn__unset c-pointer "
+            data-controller="s-tooltip"
+            data-s-tooltip-placement="right"
+            title="This answer is useful"
+            aria-pressed="false"
+            aria-label="Up vote"
+            data-selected-classes="fc-theme-primary"
+            data-unselected-classes="">
+        <svg aria-hidden="true" class="svg-icon iconArrowUpLg" width="36" height="36" viewBox="0 0 36 36"><path d="M2 26h32L18 10 2 26z"/></svg>
+    </button>
+    <div class="js-vote-count flex--item d-flex fd-column ai-center fc-black-500 fs-title"
+         itemprop="upvoteCount"
+         data-value="460">
+        460
+    </div>
+    <button class="js-vote-down-btn flex--item s-btn s-btn__unset c-pointer "
+            data-controller="s-tooltip"
+            data-s-tooltip-placement="right"
+            title="This answer is not useful"
+            aria-pressed="false"
+            aria-label="Down vote"
+            data-selected-classes="fc-theme-primary"
+            data-unselected-classes="">
+        <svg aria-hidden="true" class="svg-icon iconArrowDownLg" width="36" height="36" viewBox="0 0 36 36"><path d="M2 10h32L18 26 2 10z"/></svg>
+    </button>
+
+
+        <div class="js-accepted-answer-indicator flex--item fc-green-500 py6 mtn8" data-s-tooltip-placement="right" title="Loading when this answer was accepted&#x2026;" tabindex="0" role="note" aria-label="Accepted">
+            <div class="ta-center">
+                <svg aria-hidden="true" class="svg-icon iconCheckmarkLg" width="36" height="36" viewBox="0 0 36 36"><path d="m6 14 8 8L30 6v8L14 30l-8-8v-8z"/></svg>
+            </div>
+        </div>
+
+
+    <a class="js-post-issue flex--item s-btn s-btn__unset c-pointer py6 mx-auto" href="/posts/405784/timeline" data-shortcut="T" data-ks-title="timeline" data-controller="s-tooltip" data-s-tooltip-placement="right" title="Show activity on this post." aria-label="Timeline"><svg aria-hidden="true" class="mln2 mr0 svg-icon iconHistory" width="19" height="18" viewBox="0 0 19 18"><path d="M3 9a8 8 0 113.73 6.77L8.2 14.3A6 6 0 105 9l3.01-.01-4 4-4-4h3L3 9zm7-4h1.01L11 9.36l3.22 2.1-.6.93L10 10V5z"/></svg></a>
+
+</div>
+
+    </div>
+
+    
+
+<div class="answercell post-layout--right">
+
+<div class="s-prose js-post-body" itemprop="text">
+<p>This is an easter egg in <code>man</code>. When you run <code>man</code> without specifying the page or with <code>-w</code>, it outputs "gimme gimme gimme" to stderr, but only at 00:30:</p>
+
+<pre><code># date +%T -s "00:30:00"
+00:30:00
+# man -w
+gimme gimme gimme
+/usr/local/share/man:/usr/share/man:/usr/man
+</code></pre>
+
+<p>The exit code is always 0.</p>
+
+<p>The correct output should always be:</p>
+
+<pre><code># man -w
+/usr/local/share/man:/usr/share/man:/usr/man
+# echo $?
+0
+# man
+What manual page do you want?
+# echo $?
+1
+</code></pre>
+
+<p>The string "gimme gimme gimme" can be found in RHEL, OpenSUSE, Fedora, Debian and probably more, so it's not really distro specific. You can <code>grep</code> your <code>man</code> binary to verify.</p>
+
+<p><a href="http://git.savannah.nongnu.org/cgit/man-db.git/tree/src/man.c#n4122" rel="noreferrer">This code is responsible for the output</a>, added by <a href="http://git.savannah.nongnu.org/cgit/man-db.git/commit/src/man.c?id=002a6339b1fe8f83f4808022a17e1aa379756d99" rel="noreferrer">this commit</a>:</p>
+
+<pre><code>src/man.c-1167- if (first_arg == argc) {
+src/man.c-1168-   /* 
+http://twitter.com/#!/marnanel/status/132280557190119424 */
+src/man.c-1169-   time_t now = time (NULL);
+src/man.c-1170-   struct tm *localnow = localtime (&amp;now);
+src/man.c-1171-   if (localnow &amp;&amp;
+src/man.c-1172-       localnow-&gt;tm_hour == 0 &amp;&amp; localnow-&gt;tm_min == 30)
+src/man.c:1173:     fprintf (stderr, "gimme gimme gimme\n");
+</code></pre>
+
+<p>I have contacted RHEL support about this issue.</p>
+
+<p>The string comes from well known <a href="https://www.youtube.com/watch?v=XEjLoHdbVeE&amp;t=1m10s" rel="noreferrer">ABBA song Gimme! Gimme! Gimme! (A Man After Midnight)</a>.</p>
+
+<hr>
+
+<p>The developer of the man-db, Colin Watson, decided that there was enough fun and the story won't get forgotten and <a href="https://git.savannah.gnu.org/cgit/man-db.git/commit/?id=b225d9e76fbb0a6a4539c0992fba88c83f0bd37e" rel="noreferrer">removed the easter egg completely</a>.</p>
+
+<p>Thank you Colin!</p>
+</div>
+<div class="mt24">
+    <div class="d-flex fw-wrap ai-start jc-end gs8 gsy">
+        <time itemprop="dateCreated" datetime="2017-11-20T14:19:31"></time>
+        <div class="flex--item mr16" style="flex: 1 1 100px;">
+            
+
+
+<div class="js-post-menu pt2" data-post-id="405784">
+<div class="d-flex gs8 s-anchors s-anchors__muted fw-wrap">
+
+    <div class="flex--item">
+        <a href="/a/405784"
+           rel="nofollow"
+           itemprop="url"
+           class="js-share-link js-gps-track"
+           title="Short permalink to this answer"
+           data-gps-track="post.click({ item: 2, priv: 0, post_type: 2 })"
+           data-controller="se-share-sheet"
+           data-se-share-sheet-title="Share a link to this answer"
+           data-se-share-sheet-subtitle=""
+           data-se-share-sheet-post-type="answer"
+           data-se-share-sheet-social="facebook twitter "
+           data-se-share-sheet-location="2"
+           data-se-share-sheet-license-url="https%3a%2f%2fcreativecommons.org%2flicenses%2fby-sa%2f3.0%2f"
+           data-se-share-sheet-license-name="CC BY-SA 3.0"
+           data-s-popover-placement="bottom-start">Share</a>
+    </div>
+
+
+            <div class="flex--item">
+                <a href="/posts/405784/edit" class="js-suggest-edit-post js-gps-track" data-gps-track="post.click({ item: 6, priv: 0, post_type: 2 })" title="">Improve this answer</a>
+            </div>
+
+    <div class="flex--item">
+        <button type="button"
+                id="btnFollowPost-405784" class="s-btn s-btn__link js-follow-post js-follow-answer js-gps-track"
+                data-gps-track="post.click({ item: 14, priv: 0, post_type: 2 })"
+                data-controller="s-tooltip " data-s-tooltip-placement="bottom"
+                data-s-popover-placement="bottom" aria-controls=""
+                title="Follow this answer to receive notifications">
+            Follow
+        </button>
+    </div>
+
+
+
+
+
+</div>
+<div class="js-menu-popup-container"></div>
+</div>
+        </div>
+        <div class="post-signature flex--item fl0">
+<div class="user-info ">
+<div class="user-action-time">
+    <a href="/posts/405784/revisions" title="show all edits to this post"
+                     class="js-gps-track"
+                     data-gps-track="post.click({ item: 4, priv: 0, post_type: 2 })">edited <span title="2017-11-22 08:06:30Z" class="relativetime">Nov 22 '17 at 8:06</span></a>
+</div>
+<div class="user-gravatar32">
+    
+</div>
+<div class="user-details">
+    
+    <div class="-flair">
+        
+    </div>
+</div>
+</div>
+        </div>
+
+
+        <div class="post-signature owner flex--item fl0">
+            <div class="user-info user-hover">
+<div class="user-action-time">
+    answered <span title="2017-11-20 14:19:31Z" class="relativetime">Nov 20 '17 at 14:19</span>
+</div>
+<div class="user-gravatar32">
+    <a href="/users/173916/jaroslav-kucera"><div class="gravatar-wrapper-32"><img src="https://i.stack.imgur.com/hzj8B.jpg?s=64&amp;g=1" alt="" width="32" height="32" class="bar-sm"></div></a>
+</div>
+<div class="user-details" itemprop="author" itemscope itemtype="http://schema.org/Person">
+    <a href="/users/173916/jaroslav-kucera">Jaroslav Kucera</a><span class="d-none" itemprop="name">Jaroslav Kucera</span>
+    <div class="-flair">
+        <span class="reputation-score" title="reputation score " dir="ltr">8,169</span><span title="4 gold badges" aria-hidden="true"><span class="badge1"></span><span class="badgecount">4</span></span><span class="v-visible-sr">4 gold badges</span><span title="11 silver badges" aria-hidden="true"><span class="badge2"></span><span class="badgecount">11</span></span><span class="v-visible-sr">11 silver badges</span><span title="27 bronze badges" aria-hidden="true"><span class="badge3"></span><span class="badgecount">27</span></span><span class="v-visible-sr">27 bronze badges</span>
+    </div>
+</div>
+</div>
+
+
+        </div>
+    </div>
+    
+
+</div>
+
+</div>
+
+
+
+
+        <span class="d-none" itemprop="commentCount">11</span> 
+<div class="post-layout--right js-post-comments-component">
+    <div id="comments-405784" class="comments js-comments-container bt bc-black-075 mt12 " data-post-id="405784" data-min-length="15">
+        <ul class="comments-list js-comments-list"
+                data-remaining-comments-count="6"
+                data-canpost="false"
+                data-cansee="true"
+                data-comments-unavailable="false"
+                data-addlink-disabled="true">
+
+                    <li id="comment-725879" class="comment js-comment " data-comment-id="725879" data-comment-owner-id="100397" data-comment-score="156">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">156</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">On platforms with <code>faketime</code> available you can try this without even needing to change the system time: <code>faketime &#39;00:30:00&#39; man</code> (Debian 8).</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/100397/roaima"
+                        title="76,784 reputation"
+                        class="comment-user">roaima</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-20 15:05:48Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 20 '17 at 15:05</span></span>
+                    <span title="this comment was edited 1 time">
+                        <svg aria-hidden="true" class="va-text-bottom o50 svg-icon iconPencilSm" width="14" height="14" viewBox="0 0 14 14"><path d="m11.1 1.71 1.13 1.12c.2.2.2.51 0 .71L11.1 4.7 9.21 2.86l1.17-1.15c.2-.2.51-.2.71 0zM2 10.12l6.37-6.43 1.88 1.88L3.88 12H2v-1.88z"/></svg>
+                    </span>
+        </div>
+    </div>
+</li>
+<li id="comment-726230" class="comment js-comment " data-comment-id="726230" data-comment-owner-id="173916" data-comment-score="5">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="warm">5</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">@rrauenza There is the buzilla ticket: <a href="https://bugzilla.redhat.com/show_bug.cgi?id=1515352" rel="nofollow noreferrer">bugzilla.redhat.com/show_bug.cgi?id=1515352</a></span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/173916/jaroslav-kucera"
+                        title="8,169 reputation"
+                        class="comment-user owner">Jaroslav Kucera</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-21 07:41:50Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 21 '17 at 7:41</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-726287" class="comment js-comment " data-comment-id="726287" data-comment-owner-id="61118" data-comment-score="41">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">41</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">The author has now tightened the easter egg to only run on <code>man</code>, not <code>man -w</code>: <a href="http://git.savannah.nongnu.org/cgit/man-db.git/commit/src/man.c?id=84bde8d8a9a357bd372793d25746ac6b49480525" rel="nofollow noreferrer">git.savannah.nongnu.org/cgit/man-db.git/commit/src/&hellip;</a> and <a href="//unix.stackexchange.com/posts/comments/726280">Colin&#39;s comment on Marnanel&#39;s confessio^Wanswer</a>.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/61118/martijn-pieters"
+                        title="101 reputation"
+                        class="comment-user">Martijn Pieters</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-21 10:09:18Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 21 '17 at 10:09</span></span>
+                    <span title="this comment was edited 2 times">
+                        <svg aria-hidden="true" class="va-text-bottom o50 svg-icon iconPencilSm" width="14" height="14" viewBox="0 0 14 14"><path d="m11.1 1.71 1.13 1.12c.2.2.2.51 0 .71L11.1 4.7 9.21 2.86l1.17-1.15c.2-.2.51-.2.71 0zM2 10.12l6.37-6.43 1.88 1.88L3.88 12H2v-1.88z"/></svg>
+                    </span>
+        </div>
+    </div>
+</li>
+<li id="comment-726644" class="comment js-comment " data-comment-id="726644" data-comment-owner-id="53656" data-comment-score="26">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="hot">26</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">Let&#39;s mention that the initial commit triggered at 12:01am. A followup commit changed that to 12:30am with the commit log message &quot;half past twelve&quot; which is again quoted from the same song.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/53656/egmont"
+                        title="4,179 reputation"
+                        class="comment-user">egmont</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-21 21:00:34Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 21 '17 at 21:00</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-728443" class="comment js-comment " data-comment-id="728443" data-comment-owner-id="261570" data-comment-score="6">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="warm">6</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">@0x90 <code>man -w</code> prints the current manual page search path, which is the sort of thing you might quite reasonably use as a building block for something else, for example if the thing you were automating involved installing or testing manual pages.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/261570/colin-watson"
+                        title="3,320 reputation"
+                        class="comment-user">Colin Watson</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-25 20:06:43Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 25 '17 at 20:06</span></span>
+        </div>
+    </div>
+</li>
+
+        </ul>
+  </div>
+
+    <div id="comments-link-405784" data-rep=50 data-anon=true>
+                <a class="js-add-link comments-link dno" title="Use comments to ask for more information or suggest improvements. Avoid comments like &#x201C;&#x2B;1&#x201D; or &#x201C;thanks&#x201D;."  href="#" role="button"></a>
+            <span class="js-link-separator dno">&nbsp;|&nbsp;</span>
+        <a class="js-show-link comments-link " title="Expand to show all comments on this post" href=# onclick="" role="button">Show <b>6</b> more comments</a>
+    </div>         
+</div>
+</div>
+</div>
+                                      
+<a name="406169"></a>
+<div id="answer-406169" class="answer" data-answerid="406169" data-score="416" data-position-on-page="3" data-highest-scored="0" data-question-has-accepted-highest-score="0" itemprop="suggestedAnswer" itemscope itemtype="https://schema.org/Answer">
+<div class="post-layout">
+    <div class="votecell post-layout--left">
+        <div class="js-voting-container d-flex jc-center fd-column ai-stretch gs4 fc-black-200" data-post-id="406169">
+    <button class="js-vote-up-btn flex--item s-btn s-btn__unset c-pointer "
+            data-controller="s-tooltip"
+            data-s-tooltip-placement="right"
+            title="This answer is useful"
+            aria-pressed="false"
+            aria-label="Up vote"
+            data-selected-classes="fc-theme-primary"
+            data-unselected-classes="">
+        <svg aria-hidden="true" class="svg-icon iconArrowUpLg" width="36" height="36" viewBox="0 0 36 36"><path d="M2 26h32L18 10 2 26z"/></svg>
+    </button>
+    <div class="js-vote-count flex--item d-flex fd-column ai-center fc-black-500 fs-title"
+         itemprop="upvoteCount"
+         data-value="416">
+        416
+    </div>
+    <button class="js-vote-down-btn flex--item s-btn s-btn__unset c-pointer "
+            data-controller="s-tooltip"
+            data-s-tooltip-placement="right"
+            title="This answer is not useful"
+            aria-pressed="false"
+            aria-label="Down vote"
+            data-selected-classes="fc-theme-primary"
+            data-unselected-classes="">
+        <svg aria-hidden="true" class="svg-icon iconArrowDownLg" width="36" height="36" viewBox="0 0 36 36"><path d="M2 10h32L18 26 2 10z"/></svg>
+    </button>
+
+
+        <div class="js-accepted-answer-indicator flex--item fc-green-500 py6 mtn8 d-none" data-s-tooltip-placement="right" title="Loading when this answer was accepted&#x2026;" tabindex="0" role="note" aria-label="Accepted">
+            <div class="ta-center">
+                <svg aria-hidden="true" class="svg-icon iconCheckmarkLg" width="36" height="36" viewBox="0 0 36 36"><path d="m6 14 8 8L30 6v8L14 30l-8-8v-8z"/></svg>
+            </div>
+        </div>
+
+
+    <a class="js-post-issue flex--item s-btn s-btn__unset c-pointer py6 mx-auto" href="/posts/406169/timeline" data-shortcut="T" data-ks-title="timeline" data-controller="s-tooltip" data-s-tooltip-placement="right" title="Show activity on this post." aria-label="Timeline"><svg aria-hidden="true" class="mln2 mr0 svg-icon iconHistory" width="19" height="18" viewBox="0 0 19 18"><path d="M3 9a8 8 0 113.73 6.77L8.2 14.3A6 6 0 105 9l3.01-.01-4 4-4-4h3L3 9zm7-4h1.01L11 9.36l3.22 2.1-.6.93L10 10V5z"/></svg></a>
+
+</div>
+
+    </div>
+
+    
+
+<div class="answercell post-layout--right">
+
+<div class="s-prose js-post-body" itemprop="text">
+<p>After some reflection, I've <a href="https://git.savannah.gnu.org/cgit/man-db.git/commit/?id=b225d9e76fbb0a6a4539c0992fba88c83f0bd37e" rel="noreferrer">removed this Easter egg</a>.  It'll be gone in the upcoming man-db 2.8.0.</p>
+
+<p>I'm glad that it made some people smile, which after all was the whole purpose of it, and my Twitter notifications and so on today suggest that most people thought it was more amusing than annoying.  Still, some people did find it annoying, and six years seems like a pretty good run for that sort of thing; it probably isn't going to get significantly better exposure than it already unexpectedly has by way of this question.  Time to put it to bed.</p>
+</div>
+<div class="mt24">
+    <div class="d-flex fw-wrap ai-start jc-end gs8 gsy">
+        <time itemprop="dateCreated" datetime="2017-11-22T01:47:58"></time>
+        <div class="flex--item mr16" style="flex: 1 1 100px;">
+            
+
+
+<div class="js-post-menu pt2" data-post-id="406169">
+<div class="d-flex gs8 s-anchors s-anchors__muted fw-wrap">
+
+    <div class="flex--item">
+        <a href="/a/406169"
+           rel="nofollow"
+           itemprop="url"
+           class="js-share-link js-gps-track"
+           title="Short permalink to this answer"
+           data-gps-track="post.click({ item: 2, priv: 0, post_type: 2 })"
+           data-controller="se-share-sheet"
+           data-se-share-sheet-title="Share a link to this answer"
+           data-se-share-sheet-subtitle=""
+           data-se-share-sheet-post-type="answer"
+           data-se-share-sheet-social="facebook twitter "
+           data-se-share-sheet-location="2"
+           data-se-share-sheet-license-url="https%3a%2f%2fcreativecommons.org%2flicenses%2fby-sa%2f3.0%2f"
+           data-se-share-sheet-license-name="CC BY-SA 3.0"
+           data-s-popover-placement="bottom-start">Share</a>
+    </div>
+
+
+            <div class="flex--item">
+                <a href="/posts/406169/edit" class="js-suggest-edit-post js-gps-track" data-gps-track="post.click({ item: 6, priv: 0, post_type: 2 })" title="">Improve this answer</a>
+            </div>
+
+    <div class="flex--item">
+        <button type="button"
+                id="btnFollowPost-406169" class="s-btn s-btn__link js-follow-post js-follow-answer js-gps-track"
+                data-gps-track="post.click({ item: 14, priv: 0, post_type: 2 })"
+                data-controller="s-tooltip " data-s-tooltip-placement="bottom"
+                data-s-popover-placement="bottom" aria-controls=""
+                title="Follow this answer to receive notifications">
+            Follow
+        </button>
+    </div>
+
+
+
+
+
+</div>
+<div class="js-menu-popup-container"></div>
+</div>
+        </div>
+
+
+        <div class="post-signature flex--item fl0">
+            <div class="user-info user-hover">
+<div class="user-action-time">
+    answered <span title="2017-11-22 01:47:58Z" class="relativetime">Nov 22 '17 at 1:47</span>
+</div>
+<div class="user-gravatar32">
+    <a href="/users/261570/colin-watson"><div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/3f81250642ce9b1fb26036fdc68629cf?s=64&amp;d=identicon&amp;r=PG" alt="" width="32" height="32" class="bar-sm"></div></a>
+</div>
+<div class="user-details" itemprop="author" itemscope itemtype="http://schema.org/Person">
+    <a href="/users/261570/colin-watson">Colin Watson</a><span class="d-none" itemprop="name">Colin Watson</span>
+    <div class="-flair">
+        <span class="reputation-score" title="reputation score " dir="ltr">3,320</span><span title="1 gold badge" aria-hidden="true"><span class="badge1"></span><span class="badgecount">1</span></span><span class="v-visible-sr">1 gold badge</span><span title="7 silver badges" aria-hidden="true"><span class="badge2"></span><span class="badgecount">7</span></span><span class="v-visible-sr">7 silver badges</span><span title="13 bronze badges" aria-hidden="true"><span class="badge3"></span><span class="badgecount">13</span></span><span class="v-visible-sr">13 bronze badges</span>
+    </div>
+</div>
+</div>
+
+
+        </div>
+    </div>
+    
+
+</div>
+
+</div>
+
+
+
+
+        <span class="d-none" itemprop="commentCount">12</span> 
+<div class="post-layout--right js-post-comments-component">
+    <div id="comments-406169" class="comments js-comments-container bt bc-black-075 mt12 " data-post-id="406169" data-min-length="15">
+        <ul class="comments-list js-comments-list"
+                data-remaining-comments-count="7"
+                data-canpost="false"
+                data-cansee="true"
+                data-comments-unavailable="false"
+                data-addlink-disabled="true">
+
+                    <li id="comment-726716" class="comment js-comment " data-comment-id="726716" data-comment-owner-id="28893" data-comment-score="142">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">142</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">I&#39;m really sad you decided that. IMO too many people have it out for easter eggs.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/28893/seth"
+                        title="1,412 reputation"
+                        class="comment-user">Seth</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-22 01:52:09Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 22 '17 at 1:52</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-726718" class="comment js-comment " data-comment-id="726718" data-comment-owner-id="261570" data-comment-score="40">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">40</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">I won&#39;t rule out adding something different in the future, albeit with more care!  It was getting a bit stale, though, and humour does require novelty.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/261570/colin-watson"
+                        title="3,320 reputation"
+                        class="comment-user">Colin Watson</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-22 01:54:52Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 22 '17 at 1:54</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-726725" class="comment js-comment " data-comment-id="726725" data-comment-owner-id="166226" data-comment-score="34">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">34</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">I have to agree with @Seth, it is sad to see something go which made most of us smile, we need more of that actually on this world.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/166226/videonauth"
+                        title="1,092 reputation"
+                        class="comment-user">Videonauth</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-22 03:00:47Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 22 '17 at 3:00</span></span>
+        </div>
+    </div>
+</li>
+<li id="comment-726743" class="comment js-comment " data-comment-id="726743" data-comment-owner-id="96454" data-comment-score="215">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">215</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">I hope this does not break any workflows <a href="https://xkcd.com/1172/" rel="nofollow noreferrer">xkcd.com/1172</a></span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/96454/lakshayg"
+                        title="101 reputation"
+                        class="comment-user">lakshayg</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-22 04:41:21Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 22 '17 at 4:41</span></span>
+                    <span title="this comment was edited 1 time">
+                        <svg aria-hidden="true" class="va-text-bottom o50 svg-icon iconPencilSm" width="14" height="14" viewBox="0 0 14 14"><path d="m11.1 1.71 1.13 1.12c.2.2.2.51 0 .71L11.1 4.7 9.21 2.86l1.17-1.15c.2-.2.51-.2.71 0zM2 10.12l6.37-6.43 1.88 1.88L3.88 12H2v-1.88z"/></svg>
+                    </span>
+        </div>
+    </div>
+</li>
+<li id="comment-726868" class="comment js-comment " data-comment-id="726868" data-comment-owner-id="108949" data-comment-score="82">
+    <div class="js-comment-actions comment-actions">
+        <div class="comment-score js-comment-edit-hide">
+                <span title="number of &#x27;useful comment&#x27; votes received"
+                        class="supernova">82</span>
+        </div>
+    </div>
+    <div class="comment-text  js-comment-text-and-form">
+        <div class="comment-body js-comment-edit-hide">
+            
+            <span class="comment-copy">@ColinWatson I think disabling this in a default flow is a good idea, so it doesn&#39;t break anyone&#39;s workflow. But at the same time, it&#39;s a shame such a masterpiece had to be removed. You could add a special flag like <code>man -abba</code> and when fired after midnight would give the easter egg.</span>
+            
+          <div class="d-inline-flex ai-center">
+&ndash;&nbsp;<a href="/users/108949/bartlomiej-skwira"
+                        title="101 reputation"
+                        class="comment-user">Bartlomiej Skwira</a>
+            </div>
+            <span class="comment-date" dir="ltr"><span title="2017-11-22 11:07:54Z, License: CC BY-SA 3.0" class="relativetime-clean">Nov 22 '17 at 11:07</span></span>
+                    <span title="this comment was edited 2 times">
+                        <svg aria-hidden="true" class="va-text-bottom o50 svg-icon iconPencilSm" width="14" height="14" viewBox="0 0 14 14"><path d="m11.1 1.71 1.13 1.12c.2.2.2.51 0 .71L11.1 4.7 9.21 2.86l1.17-1.15c.2-.2.51-.2.71 0zM2 10.12l6.37-6.43 1.88 1.88L3.88 12H2v-1.88z"/></svg>
+                    </span>
+        </div>
+    </div>
+</li>
+
+        </ul>
+  </div>
+
+    <div id="comments-link-406169" data-rep=50 data-anon=true>
+                <a class="js-add-link comments-link dno" title="Use comments to ask for more information or suggest improvements. Avoid comments like &#x201C;&#x2B;1&#x201D; or &#x201C;thanks&#x201D;."  href="#" role="button"></a>
+            <span class="js-link-separator dno">&nbsp;|&nbsp;</span>
+        <a class="js-show-link comments-link " title="Expand to show all comments on this post" href=# onclick="" role="button">Show <b>7</b> more comments</a>
+    </div>         
+</div>
+</div>
+</div>
+
+                                <aside class="s-notice s-notice__info js-post-notice mb16" role="status">
+    <div class="d-flex fd-column fw-nowrap">
+        <div class="d-flex fw-nowrap">
+                <div class="flex--item mr8">
+                    <svg aria-hidden="true" class="svg-icon iconFire" width="18" height="18" viewBox="0 0 18 18"><path opacity=".6" d="M13.18 9c-.8.33-1.46.6-1.97 1.3A9.21 9.21 0 0010 13.89a10 10 0 001.32-.8 2.53 2.53 0 0 1-.63 2.91h.78a3 3 0 001.66-.5 4.15 4.15 0 0 0 1.26-1.61c.4-.96.47-1.7.55-2.73.05-1.24-.1-2.49-.46-3.68a2 2 0 01-.4.91 2.1 2.1 0 0 1-.9.62z" fill="#FF6700"/><path d="M10.4 12.11a7.1 7.1 0 01.78-1.76c.3-.47.81-.8 1.37-1.08 0 0-.05-3.27-1.55-5.27-1.5-2-3.37-2.75-4.95-2.61 0 0 4.19 2.94 1.18 5.67-2.14 1.92-3.64 3.81-3.1 5.94a4.14 4.14 0 003.1 3 4.05 4.05 0 0 1 1.08-3.89C9.42 10.92 8 9.79 8 9.79c.67.02 1.3.28 1.81.72a2 2 0 01.58 1.6z" fill="#EF2E2E"/></svg>
+                </div>
+            <div class="flex--item wmn0 fl1 lh-lg">
+                <div class="flex--item fl1 lh-lg">
+                    <b><a href="/help/privileges/protect-questions">Highly active question</a></b>. Earn 10 reputation (not counting the <a href="https://meta.stackexchange.com/questions/141648/what-is-the-association-bonus-and-how-does-it-work">association bonus</a>) in order to answer this question. The reputation requirement helps protect this question from spam and non-answer activity.
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</aside>
+
+
+
+                        <h2 class="bottom-notice" data-loc="1">
+Not the answer you&#x27;re looking for? Browse other questions tagged <a href="/questions/tagged/date" class="post-tag" title="show questions tagged &#39;date&#39;" rel="tag">date</a> <a href="/questions/tagged/man" class="post-tag" title="show questions tagged &#39;man&#39;" rel="tag">man</a>  or <a href="/questions/ask">ask your own question</a>.                            </h2>
+            </div>
+        </div>
+        <div id="sidebar" class="show-votes" role="complementary" aria-label="sidebar">
+                
+
+            
+<div class="s-sidebarwidget s-sidebarwidget__yellow s-anchors s-anchors__grayscale mb16" data-tracker="cb=1">
+<ul class="d-block p0 m0">
+                <div class="s-sidebarwidget--header s-sidebarwidget__small-bold-text fc-light d:fc-black-900 bb bbw1">
+                    The Overflow Blog
+                </div>
+    <li class="s-sidebarwidget--item d-flex px16">
+        <div class="flex--item1 fl-shrink0">
+<svg aria-hidden="true" class="va-text-top svg-icon iconPencilSm" width="14" height="14" viewBox="0 0 14 14"><path d="m11.1 1.71 1.13 1.12c.2.2.2.51 0 .71L11.1 4.7 9.21 2.86l1.17-1.15c.2-.2.51-.2.71 0zM2 10.12l6.37-6.43 1.88 1.88L3.88 12H2v-1.88z"/></svg>            </div>
+        <div class="flex--item wmn0 ow-break-word">
+            <a href="https://stackoverflow.blog/2021/09/02/pandemic-lockdowns-accelerated-cloud-migration-by-three-to-four-years/" class="js-gps-track" data-ga="[&quot;community bulletin board&quot;,&quot;The Overflow Blog&quot;,&quot;https://stackoverflow.blog/2021/09/02/pandemic-lockdowns-accelerated-cloud-migration-by-three-to-four-years/&quot;,null,null]" data-gps-track="communitybulletin.click({ priority: 1, position: 0 })">Pandemic lockdowns accelerated cloud migration by three to four years</a>
+        </div>
+    </li>
+    <li class="s-sidebarwidget--item d-flex px16">
+        <div class="flex--item1 fl-shrink0">
+<svg aria-hidden="true" class="va-text-top svg-icon iconPencilSm" width="14" height="14" viewBox="0 0 14 14"><path d="m11.1 1.71 1.13 1.12c.2.2.2.51 0 .71L11.1 4.7 9.21 2.86l1.17-1.15c.2-.2.51-.2.71 0zM2 10.12l6.37-6.43 1.88 1.88L3.88 12H2v-1.88z"/></svg>            </div>
+        <div class="flex--item wmn0 ow-break-word">
+            <a href="https://stackoverflow.blog/2021/09/03/podcast-372-why-yes-i-do-have-a-patent-on-a-time-machine/" class="js-gps-track" data-ga="[&quot;community bulletin board&quot;,&quot;The Overflow Blog&quot;,&quot;https://stackoverflow.blog/2021/09/03/podcast-372-why-yes-i-do-have-a-patent-on-a-time-machine/&quot;,null,null]" data-gps-track="communitybulletin.click({ priority: 1, position: 1 })">Podcast 372: Why yes, I do have a patent on a time machine</a>
+        </div>
+    </li>
+                <div class="s-sidebarwidget--header s-sidebarwidget__small-bold-text fc-light d:fc-black-900 bb bbw1">
+                    Featured on Meta
+                </div>
+    <li class="s-sidebarwidget--item d-flex px16">
+        <div class="flex--item1 fl-shrink0">
+<div class="favicon favicon-stackexchangemeta" title="Meta Stack Exchange"></div>            </div>
+        <div class="flex--item wmn0 ow-break-word">
+            <a href="https://meta.stackexchange.com/questions/369013/review-queue-workflows-final-release" class="js-gps-track" data-ga="[&quot;community bulletin board&quot;,&quot;Featured on Meta&quot;,&quot;https://meta.stackexchange.com/questions/369013/review-queue-workflows-final-release&quot;,null,null]" data-gps-track="communitybulletin.click({ priority: 3, position: 2 })">Review queue workflows - Final release</a>
+        </div>
+    </li>
+    <li class="s-sidebarwidget--item d-flex px16">
+        <div class="flex--item1 fl-shrink0">
+<div class="favicon favicon-stackexchangemeta" title="Meta Stack Exchange"></div>            </div>
+        <div class="flex--item wmn0 ow-break-word">
+            <a href="https://meta.stackexchange.com/questions/369260/please-welcome-valued-associates-958-v2blast-959-spencerg" class="js-gps-track" data-ga="[&quot;community bulletin board&quot;,&quot;Featured on Meta&quot;,&quot;https://meta.stackexchange.com/questions/369260/please-welcome-valued-associates-958-v2blast-959-spencerg&quot;,null,null]" data-gps-track="communitybulletin.click({ priority: 3, position: 3 })">Please welcome Valued Associates: #958 - V2Blast &amp; #959 - SpencerG</a>
+        </div>
+    </li>
+</ul>
+</div>
+
+
+<div class="js-zone-container zone-container-sidebar">
+<div id="dfp-tsb" class="everyonelovesstackoverflow everyoneloves__top-sidebar"></div>
+<div class="js-report-ad-button-container " style="width: 300px"></div>
+</div>
+<div id="hireme"></div>                    <div class="module sidebar-linked">
+<h4 id="h-linked">Linked</h4>
+<div class="linked" data-tracker="lq=1">
+        <div class="spacer js-gps-track" data-gps-track="linkedquestion.click({ source_post_id: 405783, target_question_id: 767, position: 0 })">
+    <a href="/q/767" title="Vote score (upvotes - downvotes)">
+      <div class="answer-votes answered-accepted large">267</div>
+    </a>
+    <a href="/questions/767/what-is-the-real-difference-between-apt-get-and-aptitude-how-about-wajig?noredirect=1" class="question-hyperlink">What is the real difference between &quot;apt-get&quot; and &quot;aptitude&quot;? (How about &quot;wajig&quot;?)</a>
+  </div>
+        <div class="spacer js-gps-track" data-gps-track="linkedquestion.click({ source_post_id: 405783, target_question_id: 92185, position: 1 })">
+    <a href="/q/92185" title="Vote score (upvotes - downvotes)">
+      <div class="answer-votes answered-accepted large">317</div>
+    </a>
+    <a href="/questions/92185/whats-the-story-behind-super-cow-powers?noredirect=1" class="question-hyperlink">What&#39;s the story behind Super Cow Powers?</a>
+  </div>
+        <div class="spacer js-gps-track" data-gps-track="linkedquestion.click({ source_post_id: 405783, target_question_id: 150121, position: 2 })">
+    <a href="/q/150121" title="Vote score (upvotes - downvotes)">
+      <div class="answer-votes answered-accepted large">112</div>
+    </a>
+    <a href="/questions/150121/what-does-the-mean-after-uptime-on-htop?noredirect=1" class="question-hyperlink">What does the (!) mean after uptime on htop</a>
+  </div>
+        <div class="spacer js-gps-track" data-gps-track="linkedquestion.click({ source_post_id: 405783, target_question_id: 226716, position: 3 })">
+    <a href="/q/226716" title="Vote score (upvotes - downvotes)">
+      <div class="answer-votes answered-accepted default">23</div>
+    </a>
+    <a href="/questions/226716/where-is-the-latest-source-code-of-man-command-for-linux?noredirect=1" class="question-hyperlink">Where is the latest source code of man command for linux?</a>
+  </div>
+        <div class="spacer js-gps-track" data-gps-track="linkedquestion.click({ source_post_id: 405783, target_question_id: 508505, position: 4 })">
+    <a href="/q/508505" title="Vote score (upvotes - downvotes)">
+      <div class="answer-votes  default">17</div>
+    </a>
+    <a href="/questions/508505/what-does-the-3am-section-means-in-manpages?noredirect=1" class="question-hyperlink">What does the &quot;3am&quot; section means in manpages?</a>
+  </div>
+        <div class="spacer js-gps-track" data-gps-track="linkedquestion.click({ source_post_id: 405783, target_question_id: 224481, position: 5 })">
+    <a href="/q/224481" title="Vote score (upvotes - downvotes)">
+      <div class="answer-votes  default">16</div>
+    </a>
+    <a href="/questions/224481/why-does-oot-say-hey-in-usleep-o?noredirect=1" class="question-hyperlink">Why does oot say &quot;hey&quot; in usleep -o?</a>
+  </div>
+        <div class="spacer js-gps-track" data-gps-track="linkedquestion.click({ source_post_id: 405783, target_question_id: 520616, position: 6 })">
+    <a href="/q/520616" title="Vote score (upvotes - downvotes)">
+      <div class="answer-votes  default">4</div>
+    </a>
+    <a href="/questions/520616/why-does-abiword-tell-users-to-get-a-life?noredirect=1" class="question-hyperlink">Why does abiword tell users to get a life?</a>
+  </div>
+        <div class="spacer js-gps-track" data-gps-track="linkedquestion.click({ source_post_id: 405783, target_question_id: 493709, position: 7 })">
+    <a href="/q/493709" title="Vote score (upvotes - downvotes)">
+      <div class="answer-votes  default">1</div>
+    </a>
+    <a href="/questions/493709/does-anyone-remember-wow?noredirect=1" class="question-hyperlink">Does anyone remember &quot;wow&quot;?</a>
+  </div>
+</div>
+</div>
+
+
+                <div class="module sidebar-related">
+                    <h4 id="h-related">Related</h4>
+                    <div class="related js-gps-related-questions" data-tracker="rq=1">
+                            <div class="spacer">
+                                <a href="/q/45093" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes default">7</div>
+                                </a>
+                                <a href="/questions/45093/emacs-mode-for-man-pages" class="question-hyperlink">Emacs mode for man pages</a>
+                            </div>
+                            <div class="spacer">
+                                <a href="/q/122404" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes default">2</div>
+                                </a>
+                                <a href="/questions/122404/why-date-output-x-3-instead-x-2-days-when-i-am-doing-arithmetic-operations" class="question-hyperlink">Why date output X-3 instead X-2 days when I am doing arithmetic operations</a>
+                            </div>
+                            <div class="spacer">
+                                <a href="/q/137076" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">4</div>
+                                </a>
+                                <a href="/questions/137076/how-do-you-correctly-extract-all-command-synopses-from-manpages-in-usr-share-ma" class="question-hyperlink">How do you correctly extract all command synopses from manpages in /usr/share/man/man1?</a>
+                            </div>
+                            <div class="spacer">
+                                <a href="/q/259478" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">15</div>
+                                </a>
+                                <a href="/questions/259478/cant-install-man-pages-on-minimal-centos-docker-container" class="question-hyperlink">Can&#39;t install man pages on minimal Centos Docker container</a>
+                            </div>
+                            <div class="spacer">
+                                <a href="/q/352176" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">1</div>
+                                </a>
+                                <a href="/questions/352176/take-input-arguments-and-pass-them-to-date" class="question-hyperlink">Take input arguments and pass them to date</a>
+                            </div>
+                            <div class="spacer">
+                                <a href="/q/594081" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">4</div>
+                                </a>
+                                <a href="/questions/594081/man-html-and-man-gxditview-exit-with-errors" class="question-hyperlink">`man --html` and `man --gxditview` exit with errors?</a>
+                            </div>
+                            <div class="spacer">
+                                <a href="/q/616913" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes default">1</div>
+                                </a>
+                                <a href="/questions/616913/create-custom-profile-to-run-man-using-firejail" class="question-hyperlink">create custom profile to run man using firejail</a>
+                            </div>
+                            <div class="spacer">
+                                <a href="/q/638994" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes default">5</div>
+                                </a>
+                                <a href="/questions/638994/why-a-text-editor-shows-different-from-cat-command" class="question-hyperlink">Why a text editor shows different from cat command</a>
+                            </div>
+                    </div>
+                </div>
+
+            <div id="hot-network-questions" class="module tex2jax_ignore">
+<h4>
+    <a href="https://stackexchange.com/questions?tab=hot"
+       class="js-gps-track s-link s-link__inherit" 
+       data-gps-track="posts_hot_network.click({ item_type:1, location:11 })">
+        Hot Network Questions
+    </a>
+</h4>
+<ul>
+        <li >
+            <div class="favicon favicon-money" title="Personal Finance &amp; Money Stack Exchange"></div><a href="https://money.stackexchange.com/questions/144632/is-there-a-price-point-beyond-which-it-no-longer-makes-sense-to-buy-an-apartment" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:93 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Is there a price point beyond which it no longer makes sense to buy an apartment or house?
+            </a>
+
+        </li>
+        <li >
+            <div class="favicon favicon-scifi" title="Science Fiction &amp; Fantasy Stack Exchange"></div><a href="https://scifi.stackexchange.com/questions/253331/christian-novel-about-astronauts-returning-from-mars-to-the-rapture" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:186 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Christian novel about astronauts returning from Mars to the rapture
+            </a>
+
+        </li>
+        <li >
+            <div class="favicon favicon-scifi" title="Science Fiction &amp; Fantasy Stack Exchange"></div><a href="https://scifi.stackexchange.com/questions/253326/does-any-faction-in-the-world-of-warhammer-40k-take-prisoners-of-war" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:186 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Does any faction in the world of Warhammer 40K take prisoners of war?
+            </a>
+
+        </li>
+        <li >
+            <div class="favicon favicon-academia" title="Academia Stack Exchange"></div><a href="https://academia.stackexchange.com/questions/175120/my-interview-went-well-but-at-the-end-the-interviewer-said-all-the-best-for-you" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:415 }); posts_hot_network.click({ item_type:2, location:11 })">
+                My interview went well but at the end the interviewer said &quot;All the best for your future endeavours&quot;. What does it mean?
+            </a>
+
+        </li>
+        <li >
+            <div class="favicon favicon-dba" title="Database Administrators Stack Exchange"></div><a href="https://dba.stackexchange.com/questions/298979/is-there-a-performance-or-storage-space-advantage-to-lowering-time-timestamp-pre" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:182 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Is there a performance or storage space advantage to lowering time/timestamp precision in PostgreSQL?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-physics" title="Physics Stack Exchange"></div><a href="https://physics.stackexchange.com/questions/662672/why-dont-electrons-tunnel-out-of-atoms" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:151 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Why don&#x27;t electrons tunnel out of atoms?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-puzzling" title="Puzzling Stack Exchange"></div><a href="https://puzzling.stackexchange.com/questions/111507/re-introducing-kpk-puzzle" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:559 }); posts_hot_network.click({ item_type:2, location:11 })">
+                (Re-)Introducing KPK Puzzle!
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-stackoverflow" title="Stack Overflow"></div><a href="https://stackoverflow.com/questions/69021225/resource-linking-fails-on-lstar" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:1 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Resource linking fails on lStar
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-unix" title="Unix &amp; Linux Stack Exchange"></div><a href="https://unix.stackexchange.com/questions/667288/checkbashisms-whats-wrong-with-type" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:106 }); posts_hot_network.click({ item_type:2, location:11 })">
+                checkbashisms: what&#x27;s wrong with `type&#x27;?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-workplace" title="The Workplace Stack Exchange"></div><a href="https://workplace.stackexchange.com/questions/178043/leaving-company-should-i-write-personalized-farewell-emails" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:423 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Leaving company, should I write personalized farewell emails?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-bicycles" title="Bicycles Stack Exchange"></div><a href="https://bicycles.stackexchange.com/questions/80639/shifter-cable-ruptured-near-the-inner-end-in-st-r7020-usual-defect" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:126 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Shifter cable ruptured near the inner end in ST-R7020 - usual defect?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-codegolf" title="Code Golf Stack Exchange"></div><a href="https://codegolf.stackexchange.com/questions/233942/eulers-numerus-idoneus" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:200 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Euler&#x27;s numerus idoneus
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-stats" title="Cross Validated"></div><a href="https://stats.stackexchange.com/questions/543361/what-if-there-is-no-true-data-generating-process" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:65 }); posts_hot_network.click({ item_type:2, location:11 })">
+                What if there is no true data-generating process?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-or" title="Operations Research Stack Exchange"></div><a href="https://or.stackexchange.com/questions/6859/are-short-sell-allowed-in-conic-formulation-of-markowitz-optimization" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:700 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Are short-sell allowed in conic formulation of Markowitz optimization?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-scicomp" title="Computational Science Stack Exchange"></div><a href="https://scicomp.stackexchange.com/questions/40011/how-to-solve-a-second-order-differential-equation-diffusion-with-boundary-cond" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:363 }); posts_hot_network.click({ item_type:2, location:11 })">
+                How to solve a second order differential equation (diffusion) with boundary conditions using Python
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-latin" title="Latin Language Stack Exchange"></div><a href="https://latin.stackexchange.com/questions/16768/how-good-is-the-new-version-of-google-translate" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:644 }); posts_hot_network.click({ item_type:2, location:11 })">
+                How good is the new version of Google Translate?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-christianity" title="Christianity Stack Exchange"></div><a href="https://christianity.stackexchange.com/questions/84764/how-do-churches-that-have-indefinitely-suspended-in-person-services-understand-h" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:304 }); posts_hot_network.click({ item_type:2, location:11 })">
+                How do churches that have indefinitely suspended in-person services understand Hebrews 10:25?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-fitness" title="Physical Fitness Stack Exchange"></div><a href="https://fitness.stackexchange.com/questions/44280/rollerskating-or-rollerblading-and-falling-into-water-drowning-dangers" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:216 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Rollerskating or rollerblading and falling into water, drowning dangers
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-diy" title="Home Improvement Stack Exchange"></div><a href="https://diy.stackexchange.com/questions/234062/what-do-you-use-to-mud-the-joins-between-cement-boards-on-walls" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:73 }); posts_hot_network.click({ item_type:2, location:11 })">
+                What do you use to mud the joins between cement boards on walls?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-english" title="English Language &amp; Usage Stack Exchange"></div><a href="https://english.stackexchange.com/questions/574215/name-for-gap-in-a-line-caused-by-everyone-stopping-and-then-having-the-front-of" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:97 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Name for gap in a line caused by everyone stopping, and then having the front of the line start moving again?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-codereview" title="Code Review Stack Exchange"></div><a href="https://codereview.stackexchange.com/questions/267644/first-attempt-at-chess-in-python" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:196 }); posts_hot_network.click({ item_type:2, location:11 })">
+                First attempt at chess in Python
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-math" title="Mathematics Stack Exchange"></div><a href="https://math.stackexchange.com/questions/4240656/expressing-sequence-as-a-set" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:69 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Expressing Sequence as a set
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-chess" title="Chess Stack Exchange"></div><a href="https://chess.stackexchange.com/questions/36896/is-it-legal-to-take-a-piece-to-the-bathroom-during-a-tournament" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:435 }); posts_hot_network.click({ item_type:2, location:11 })">
+                Is it legal to take a piece to the bathroom during a tournament?
+            </a>
+
+        </li>
+        <li class="dno js-hidden">
+            <div class="favicon favicon-tex" title="TeX - LaTeX Stack Exchange"></div><a href="https://tex.stackexchange.com/questions/613884/tikz-rotating-a-pic-of-nodes" class="js-gps-track question-hyperlink mb0" data-gps-track="site.switch({ item_type:11, target_site:85 }); posts_hot_network.click({ item_type:2, location:11 })">
+                TikZ: rotating a pic of nodes
+            </a>
+
+        </li>
+</ul>
+
+    <a href="#" 
+       class="show-more js-show-more js-gps-track" 
+       data-gps-track="posts_hot_network.click({ item_type:3, location:11 })">
+        more hot questions
+    </a>
+</div>
+
+                        <div id="feed-link" class="js-feed-link">
+    <a href="/feeds/question/405783" title="Feed of this question and its answers">
+        <svg aria-hidden="true" class="fc-orange-400 svg-icon iconRss" width="18" height="18" viewBox="0 0 18 18"><path d="M1 3c0-1.1.9-2 2-2h12c1.09 0 2 .91 2 2v12c0 1.09-.91 2-2 2H3c-1.09 0-2-.91-2-2V3zm14.5 12C15.5 8.1 9.9 2.5 3 2.5V5a10 10 0 0110 10h2.5zm-5 0A7.5 7.5 0 003 7.5V10a5 5 0 015 5h2.5zm-5 0A2.5 2.5 0 003 12.5V15h2.5z"/></svg>
+        Question feed
+    </a>
+</div>
+<aside class="s-modal js-feed-link-modal" tabindex="-1" role="dialog" aria-labelledby="feed-modal-title" aria-describedby="feed-modal-description" aria-hidden="true">
+    <div class="s-modal--dialog js-modal-dialog wmx4" role="document"  data-controller="se-draggable">
+        <h1 class="s-modal--header fw-bold js-first-tabbable" id="feed-modal-title" data-se-draggable-target="handle" tabindex="0">
+            Subscribe to RSS
+        </h1>
+        <div class="d-flex gs4 gsy fd-column">
+            <div class="flex--item">
+                <label class="d-block s-label c-default" for="feed-url">
+                    Question feed
+                    <p class="s-description mt2" id="feed-modal-description">To subscribe to this RSS feed, copy and paste this URL into your RSS reader.</p>
+                </label>
+            </div>
+            <div class="d-flex ps-relative">
+                <input class="s-input" type="text" name="feed-url" id="feed-url" readonly="readonly" value="https://unix.stackexchange.com/feeds/question/405783" />
+                <svg aria-hidden="true" class="s-input-icon fc-orange-400 svg-icon iconRss" width="18" height="18" viewBox="0 0 18 18"><path d="M1 3c0-1.1.9-2 2-2h12c1.09 0 2 .91 2 2v12c0 1.09-.91 2-2 2H3c-1.09 0-2-.91-2-2V3zm14.5 12C15.5 8.1 9.9 2.5 3 2.5V5a10 10 0 0110 10h2.5zm-5 0A7.5 7.5 0 003 7.5V10a5 5 0 015 5h2.5zm-5 0A2.5 2.5 0 003 12.5V15h2.5z"/></svg>
+            </div>
+        </div>
+        <a class="s-modal--close s-btn s-btn__muted js-modal-close js-last-tabbable" href="#" aria-label="Close">
+            <svg aria-hidden="true" class="svg-icon iconClearSm" width="14" height="14" viewBox="0 0 14 14"><path d="M12 3.41 10.59 2 7 5.59 3.41 2 2 3.41 5.59 7 2 10.59 3.41 12 7 8.41 10.59 12 12 10.59 8.41 7 12 3.41z"/></svg>
+        </a>
+    </div>
+</aside>
+
+        </div>
+</div>
+<script>StackExchange.ready(function(){$.get('/posts/405783/ivc/e5f8');});</script>
+<noscript><div><img src="/posts/405783/ivc/e5f8" class="dno" alt="" width="0" height="0"></div></noscript><div style="display:none" id="js-codeblock-lang"></div></div>
+
+
+    </div>
+</div>
+
+    
+<script>;try{(function(a){function b(a){return'string'==typeof a?document.getElementById(a):a}function c(a){return a=b(a),!!a&&'none'===getComputedStyle(a).display}function d(a){return!c(a)}function e(a){return!!a}function f(a){return /^\s*$/.test(b(a).innerHTML)}function g(a){var b=a.style;b.height=b.maxHeight=b.minHeight='auto',b.display='none'}function h(a){var b=a.style;b.height=b.maxHeight=b.minHeight='auto',b.display='none',[].forEach.call(a.children,h)}function i(a){var b=a.style;b.height=b.maxHeight=b.minHeight='auto',b.removeProperty('display')}function j(a,b){var c;return function(){return a&&(c=a.call(b||this,arguments),a=null),c}}function k(a){var b=document.createElement('script');b.src=a,document.body.appendChild(b)}function l(a){return m([],a)}function m(a,b){return a.push=function(a){return b(),delete this.push,this.push(a)},a}function n(){try{return!new Function('return async()=>{};')}catch(a){return!0}}function o(){return'undefined'!=typeof googletag&&!!googletag.apiReady}function p(){o()||(googletag={cmd:l(B)})}function q(){var a=document.createElement('div');a.className='adsbox',a.id='clc-abd',a.style.position='absolute',a.style.pointerEvents='none',a.innerHTML='&nbsp;',document.body.appendChild(a)}function r(){return Object.keys(F.ids).filter(function(a){return'clc-cpa'!=a})}function s(a){var b=a.split('_')[0],c=F.ids[b],d=F.slots[c];'function'==typeof d&&(d=d(b));return{path:'/'+C+'/'+E+'/'+c+'/'+D,sizes:d,zone:c}}function t(a){try{Array.isArray(clc.dfp.slotsRenderedEvents)||(clc.dfp.slotsRenderedEvents=[]),clc.dfp.slotsRenderedEvents.push(a);var b=a.slot.getSlotElementId(),c=[];b||c.push('id=0');var d=document.getElementById(b);if(!b||d?d.hasAttribute('data-clc-stalled')&&c.push('st=1'):c.push('el=0'),0!==c.length)return void G(c.join('&'));var e=s(b),f=e.zone;if(clc.collapse&&clc.collapse[f]&&a.isEmpty)return h(d),void d.setAttribute('data-clc-ready','true');if(-1!==y.dh.indexOf(a.lineItemId))h(d);else if(a.lineItemId){d.setAttribute('data-clc-prefilled','true');var j=d.parentElement;if(j.classList.contains('js-zone-container')){g(j);var k=j.querySelectorAll('.js-report-ad-button-container'),l=k[0];switch(l.style.height='24px',b){case'dfp-tlb':case'dfp-tag':{j.classList.add('mb8');break}case'dfp-mlb':case'dfp-smlb':case'dfp-bmlb':{j.classList.add('my8');break}case'dfp-isb':{j.classList.add('mt24');break}case'dfp-m-aq':{j.classList.add('my12'),j.classList.add('mx-auto');break}default:}i(j),i(d)}else i(d);if('dfp-msb'==b){var m=document.getElementById('hireme');h(m)}}d.setAttribute('data-clc-ready','true')}catch(a){var n=document.querySelector('#dfp-tsb, #dfp-isb, #clc-tsb');n&&n.setAttribute('data-clc-ready','true'),G('e=1')}}function u(a,b){'dfp-isb'===a&&b.setTargeting('Sidebar',['Inline']),'dfp-tsb'===a&&b.setTargeting('Sidebar',['Right']);var c=s(a),d=c.path,e=c.sizes,f=c.zone,g=googletag.defineSlot(d,e,a);g.addService(b),!1;var h=a.split('_');if('clc-cpa'==h[0]&&h[1]){var i=h[1];g.setTargeting('talent-company-id',i)}}function v(b){var c=a.dfp&&a.dfp.targeting||{};'SystemDefault'===c.ProductVariant&&(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?c.ProductVariant='Dark':c.ProductVariant='Light'),Object.keys(c).forEach(function(a){b.setTargeting(a,c[a])})}function w(a){var g=a.map(b).filter(e);return{eligible:g.filter(f).filter(d),ineligible:g.filter(c)}}function x(b){void 0===b&&(b=r());var c=['dfp-mlb','dfp-smlb'];if(!o())return p(),void googletag.cmd.push(function(){return x(b)});var d=w(b),e=d.eligible,f=d.ineligible;if(e.forEach(function(a){g(a)}),f.forEach(h),0!==e.length){y.abd&&q();var i=googletag.pubads().getSlots(),j=i.filter(function(a){return 0<=b.indexOf(a.getSlotElementId())});googletag.destroySlots(j);var k=googletag.pubads();y.sf&&(k.setForceSafeFrame(!0),k.setSafeFrameConfig({allowOverlayExpansion:!0,allowPushExpansion:!0,sandbox:!0})),'undefined'!=typeof y.targeting_consent&&(k.setRequestNonPersonalizedAds(y.targeting_consent?0:1),!y.targeting_consent&&k.setPrivacySettings({limitedAds:!0})),y.ll||k.enableSingleRequest(),a.sreEvent||(k.addEventListener('slotRenderEnded',t),a.sreEvent=!0),v(k);var l=e.filter(function(a){return!y.ll||0>c.indexOf(a.id)}),m=e.filter(function(a){return!!y.ll&&0<=c.indexOf(a.id)});l.forEach(function(a){u(a.id,k),a.setAttribute('data-dfp-zone','true')}),googletag.enableServices(),l.forEach(function(a){googletag.display(a.id)}),y.ll&&(k.enableLazyLoad({fetchMarginPercent:0,renderMarginPercent:0}),m.forEach(function(a){u(a.id,k),a.setAttribute('data-clc-prefilled','true')}),m.forEach(function(a){googletag.display(a.id)}))}}var y=function(a){for(var b=[],c=1;c<arguments.length;c++)b[c-1]=arguments[c];for(var d,e=0,f=b;e<f.length;e++)for(var g in d=f[e],d)a[g]=d[g];return a}({"lib":"https://cdn.sstatic.net/clc/clc.min.js?v=7375b71ba68b","style":"https://cdn.sstatic.net/clc/styles/clc.min.css?v=d2cbe7302363","u":"https://clc.stackoverflow.com/markup.js","wa":true,"kt":2000,"tto":true,"h":"clc.stackoverflow.com","allowed":"^(((talent\\.)?stackoverflow)|(blog\\.codinghorror)|(serverfault|askubuntu)|([^\\.]+\\.stackexchange))\\.com$","wv":true,"al":false,"dh":[5171832659],"abd":true},a.options||{}),z=j(function(){var a=y.lib;n()&&(a=a.replace(/(\.min)?\.js(\?v=[0-9a-fA-F]+)?$/,'.ie$1.js$2')),k(a)}),A=a.cmd||[];Array.isArray(A)&&(0<A.length?z():m(A,z));var B=j(function(){y.targeting_consent||'undefined'==typeof y.targeting_consent?k('https://securepubads.g.doubleclick.net/tag/js/gpt.js'):k('https://pagead2.googlesyndication.com/tag/js/gpt.js')}),C='248424177',D=/^\/tags\//.test(location.pathname)||/^\/questions\/tagged\//.test(location.pathname)?'tag-pages':/^\/$/.test(location.pathname)||/^\/home/.test(location.pathname)?'home-page':'question-pages',E=location.hostname;var F={slots:{lb:[[728,90]],mlb:[[728,90]],smlb:[[728,90]],bmlb:[[728,90]],sb:function(a){return'dfp-tsb'===a?[[300,250],[300,600]]:[[300,250]]},"tag-sponsorship":[[730,135]],"mobile-below-question":[[320,50],[300,250]],msb:[[300,250],[300,600]],"talent-conversion-tracking":[[1,1]]},ids:{"dfp-tlb":'lb',"dfp-mlb":'mlb',"dfp-smlb":'smlb',"dfp-bmlb":'bmlb',"dfp-tsb":'sb',"dfp-isb":'sb',"dfp-tag":'tag-sponsorship',"dfp-msb":'msb',"dfp-m-aq":'mobile-below-question',"clc-tlb":'lb',"clc-mlb":'mlb',"clc-tsb":'sb',"clc-cpa":'talent-conversion-tracking'}},G=function(a){new Image().src='https://'+y.h+'/stalled.gif?'+a};(function(){var b=y.al;b&&A.push(function(){return a.load()})})(),p(),a.dfp={load:x},a.options=y,a.cmd=A})(this.clc=this.clc||{})}catch(a){window.console.error(a)}</script><script>
+var clc = clc || {};
+clc.collapse = { sb: !0, 'tag-sponsorship': !0, lb: !0, mlb: !0, smlb: !0, bmlb: !0, 'mobile-below-question': !0 };
+clc.options = clc.options || {};
+clc.options.sf = !1;
+clc.options.hb = !1;
+clc.options.ll = !0;
+clc.options.targeting_consent = !0;
+clc.options.performance_consent = !0;
+    clc.cmd = clc.cmd || [];
+    clc.cmd.push(function () { window.clc_request='A5OZjyT5btkIAAAAABcxBgALAAAAAgAAAAABCgAAAHxkYXRlfG1hbnwAQRUsKuC3B3yXaw'; clc.load(); });
+    clc.dfp = clc.dfp || {};
+    clc.dfp.targeting = {Registered:['false'],'ron-tag':['date','man'],Community:['true'],NumberOfAnswers:['3']};
+    clc.dfp.targeting.TargetingConsent = ['true'];
+
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('dfptestads')) {
+        const dfptestads = urlParams.get('dfptestads');
+        clc.dfp.targeting.DfpTestAds = dfptestads;
+    }
+    
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function () { clc.dfp.load(); });
+    StackExchange.ready(function () { googletag.cmd.push(function () { StackExchange.ads.init(googletag, '/ads/report-ad', 'Report this ad') }) });
+</script>
+
+        <footer id="footer" class="site-footer js-footer" role="contentinfo">
+    <div class="site-footer--container">
+        <nav class="site-footer--nav">
+                <div class="site-footer--col site-footer--col__visible js-footer-col" data-name="default">
+                    <h5 class="-title"><a href="/">Unix &amp; Linux</a></h5>
+                    <ul class="-list js-primary-footer-links">
+                                <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 2 })" href="/tour">Tour</a></li>
+                            <li class="-item"><a href="/help" class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 3 })">Help</a></li>
+                                <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 5 })" href="https://chat.stackexchange.com?tab=site&host=unix.stackexchange.com">Chat</a></li>
+                        <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 13 })" href="/contact">Contact</a></li>
+                            <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 14 })" href="https://unix.meta.stackexchange.com">Feedback</a></li>
+                            <li class="-item"><a onclick='StackExchange.switchMobile("on")' class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 12 })">Mobile</a></li>
+                    </ul>
+                </div>
+            <div class="site-footer--col site-footer--col__visible js-footer-col" data-name="default">
+                <h5 class="-title"><a class="js-gps-track" data-gps-track="footer.click({ location: 2, link: 1 })" href="https://stackoverflow.com/company">Company</a></h5>
+                <ul class="-list">
+                        <li class="-item"><a href="https://stackoverflow.com" class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 15})">Stack Overflow</a></li>
+                        <li class="-item"><a href="https://stackoverflow.com/teams" class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 29 })">For Teams</a></li>
+                        <li class="-item"><a href="https://stackoverflow.com/advertising" class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 21 })">Advertise With Us</a></li>
+                        <li class="-item"><a href="https://stackoverflow.com/talent" class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 20 })">Hire a Developer</a></li>
+                        <li class="-item"><a href="https://stackoverflow.com/jobs" class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 17})">Developer Jobs</a></li>
+                            <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 1 })" href="https://stackoverflow.com/company">About</a></li>
+                    <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 27 })" href="https://stackoverflow.com/company/press">Press</a></li>
+                    <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 7 })" href="https://stackoverflow.com/legal">Legal</a></li>
+                    <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 8 })" href="https://stackoverflow.com/legal/privacy-policy">Privacy Policy</a></li>
+                    <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 37 })" href="https://stackoverflow.com/legal/terms-of-service">Terms of Service</a></li>
+                        <li class="-item" id="consent-footer-link"><a class="js-gps-track -link js-cookie-settings" data-gps-track="footer.click({ location: 2, link: 38 })" href="#" data-consent-popup-loader="footer">Cookie Settings</a></li>
+                    <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link: 39 })" href="https://stackoverflow.com/legal/cookie-policy">Cookie Policy</a></li>
+                </ul>
+            </div>
+            <div class="site-footer--col site-footer--categories-nav site-footer--col__visible">
+                <a href="#" class="site-footer--back js-footer-back"><svg aria-hidden="true" class="svg-icon iconArrowLeftAlt" width="18" height="18" viewBox="0 0 18 18"><path d="M10.58 16 12 14.59 6.4 9 12 3.41 10.57 2l-7 7 7 7z"/></svg></a>
+                <div>
+                    <h5 class="-title"><a href="https://stackexchange.com" data-gps-track="footer.click({ location: 2, link: 30 })">Stack Exchange<br> Network</a></h5>
+                    <ul class="-list">
+                        <li class="-item"><a href="#" class="-link _expandable js-footer-category-trigger js-gps-track" data-gps-track="footer.click({ location: 2, link: 24 })" data-target="Technology">Technology</a></li>
+                        <li class="-item"><a href="#" class="-link _expandable js-footer-category-trigger js-gps-track" data-gps-track="footer.click({ location: 2, link: 24 })" data-target="Life / Arts">Life / Arts</a></li>
+                        <li class="-item"><a href="#" class="-link _expandable js-footer-category-trigger js-gps-track" data-gps-track="footer.click({ location: 2, link: 24 })" data-target="Culture / Recreation">Culture / Recreation</a></li>
+                        <li class="-item"><a href="#" class="-link _expandable js-footer-category-trigger js-gps-track" data-gps-track="footer.click({ location: 2, link: 24 })" data-target="Science">Science</a></li>
+                        <li class="-item"><a href="#" class="-link _expandable js-footer-category-trigger js-gps-track" data-gps-track="footer.click({ location: 2, link: 24 })" data-target="Other">Other</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="site-footer--categories">
+                    <div class="site-footer--col site-footer--category js-footer-col" data-name="Technology">
+    <ul class="-list">
+            <li class="-item"><a href="https://stackoverflow.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="professional and enthusiast programmers">Stack Overflow</a></li>
+            <li class="-item"><a href="https://serverfault.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="system and network administrators">Server Fault</a></li>
+            <li class="-item"><a href="https://superuser.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="computer enthusiasts and power users">Super User</a></li>
+            <li class="-item"><a href="https://webapps.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="power users of web applications">Web Applications</a></li>
+            <li class="-item"><a href="https://askubuntu.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="Ubuntu users and developers">Ask Ubuntu</a></li>
+            <li class="-item"><a href="https://webmasters.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="pro webmasters">Webmasters</a></li>
+            <li class="-item"><a href="https://gamedev.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="professional and independent game developers">Game Development</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Technology"><ul class="-list">
+            <li class="-item"><a href="https://tex.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="users of TeX, LaTeX, ConTeXt, and related typesetting systems">TeX - LaTeX</a></li>
+            <li class="-item"><a href="https://softwareengineering.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="professionals, academics, and students working within the systems development life cycle">Software Engineering</a></li>
+            <li class="-item"><a href="https://unix.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="users of Linux, FreeBSD and other Un*x-like operating systems">Unix &amp; Linux</a></li>
+            <li class="-item"><a href="https://apple.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="power users of Apple hardware and software">Ask Different (Apple)</a></li>
+            <li class="-item"><a href="https://wordpress.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="WordPress developers and administrators">WordPress Development</a></li>
+            <li class="-item"><a href="https://gis.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="cartographers, geographers and GIS professionals">Geographic Information Systems</a></li>
+            <li class="-item"><a href="https://electronics.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="electronics and electrical engineering professionals, students, and enthusiasts">Electrical Engineering</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Technology"><ul class="-list">
+            <li class="-item"><a href="https://android.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="enthusiasts and power users of the Android operating system">Android Enthusiasts</a></li>
+            <li class="-item"><a href="https://security.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="information security professionals">Information Security</a></li>
+            <li class="-item"><a href="https://dba.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="database professionals who wish to improve their database skills and learn from others in the community">Database Administrators</a></li>
+            <li class="-item"><a href="https://drupal.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="Drupal developers and administrators">Drupal Answers</a></li>
+            <li class="-item"><a href="https://sharepoint.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="SharePoint enthusiasts">SharePoint</a></li>
+            <li class="-item"><a href="https://ux.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="user experience researchers and experts">User Experience</a></li>
+            <li class="-item"><a href="https://mathematica.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="users of Wolfram Mathematica">Mathematica</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Technology"><ul class="-list">
+            <li class="-item"><a href="https://salesforce.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="Salesforce administrators, implementation experts, developers and anybody in-between">Salesforce</a></li>
+            <li class="-item"><a href="https://expressionengine.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="administrators, end users, developers and designers for ExpressionEngine&#xAE; CMS">ExpressionEngine&#xAE; Answers</a></li>
+            <li class="-item"><a href="https://pt.stackoverflow.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="programadores profissionais e entusiastas">Stack Overflow em Portugu&#xEA;s</a></li>
+            <li class="-item"><a href="https://blender.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="people who use Blender to create 3D graphics, animations, or games">Blender</a></li>
+            <li class="-item"><a href="https://networkengineering.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="network engineers">Network Engineering</a></li>
+            <li class="-item"><a href="https://crypto.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="software developers, mathematicians and others interested in cryptography">Cryptography</a></li>
+            <li class="-item"><a href="https://codereview.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="peer programmer code reviews">Code Review</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Technology"><ul class="-list">
+            <li class="-item"><a href="https://magento.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="users of the Magento e-Commerce platform">Magento</a></li>
+            <li class="-item"><a href="https://softwarerecs.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="people seeking specific software recommendations">Software Recommendations</a></li>
+            <li class="-item"><a href="https://dsp.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="practitioners of the art and science of signal, image and video processing">Signal Processing</a></li>
+            <li class="-item"><a href="https://emacs.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="those using, extending or developing Emacs">Emacs</a></li>
+            <li class="-item"><a href="https://raspberrypi.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="users and developers of hardware and software for Raspberry Pi">Raspberry Pi</a></li>
+            <li class="-item"><a href="https://ru.stackoverflow.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="&#x43F;&#x440;&#x43E;&#x433;&#x440;&#x430;&#x43C;&#x43C;&#x438;&#x441;&#x442;&#x43E;&#x432;">Stack Overflow &#x43D;&#x430; &#x440;&#x443;&#x441;&#x441;&#x43A;&#x43E;&#x43C;</a></li>
+            <li class="-item"><a href="https://codegolf.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="programming puzzle enthusiasts and code golfers">Code Golf</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Technology"><ul class="-list">
+            <li class="-item"><a href="https://es.stackoverflow.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="programadores y profesionales de la inform&#xE1;tica">Stack Overflow en espa&#xF1;ol</a></li>
+            <li class="-item"><a href="https://ethereum.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="users of Ethereum, the decentralized application platform and smart contract enabled blockchain">Ethereum</a></li>
+            <li class="-item"><a href="https://datascience.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="Data science professionals, Machine Learning specialists, and those interested in learning more about the field">Data Science</a></li>
+            <li class="-item"><a href="https://arduino.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="developers of open-source hardware and software that is compatible with Arduino">Arduino</a></li>
+            <li class="-item"><a href="https://bitcoin.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="Bitcoin crypto-currency enthusiasts">Bitcoin</a></li>
+            <li class="-item"><a href="https://sqa.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="software quality control experts, automation engineers, and software testers">Software Quality Assurance &amp; Testing</a></li>
+            <li class="-item"><a href="https://sound.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="sound engineers, producers, editors, and enthusiasts">Sound Design</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Technology"><ul class="-list">
+            <li class="-item"><a href="https://windowsphone.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="enthusiasts and power users of Windows Phone OS">Windows Phone</a></li>
+            <li class="-item">
+                <a href="https://stackexchange.com/sites#technology" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 26 })">
+                    <strong>
+                        more (29)
+                    </strong>
+                </a>
+            </li>
+    </ul>
+</div>
+<div class="site-footer--col site-footer--category js-footer-col" data-name="Life / Arts">
+    <ul class="-list">
+            <li class="-item"><a href="https://photo.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="professional, enthusiast and amateur photographers">Photography</a></li>
+            <li class="-item"><a href="https://scifi.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="science fiction and fantasy enthusiasts">Science Fiction &amp; Fantasy</a></li>
+            <li class="-item"><a href="https://graphicdesign.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="Graphic Design professionals, students, and enthusiasts">Graphic Design</a></li>
+            <li class="-item"><a href="https://movies.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="movie and TV enthusiasts">Movies &amp; TV</a></li>
+            <li class="-item"><a href="https://music.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="musicians, students, and enthusiasts">Music: Practice &amp; Theory</a></li>
+            <li class="-item"><a href="https://worldbuilding.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="writers/artists using science, geography and culture to construct imaginary worlds and settings">Worldbuilding</a></li>
+            <li class="-item"><a href="https://video.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="engineers, producers, editors, and enthusiasts spanning the fields of video, and media creation">Video Production</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Life / Arts"><ul class="-list">
+            <li class="-item"><a href="https://cooking.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="professional and amateur chefs">Seasoned Advice (cooking)</a></li>
+            <li class="-item"><a href="https://diy.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="contractors and serious DIYers">Home Improvement</a></li>
+            <li class="-item"><a href="https://money.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="people who want to be financially literate">Personal Finance &amp; Money</a></li>
+            <li class="-item"><a href="https://academia.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="academics and those enrolled in higher education">Academia</a></li>
+            <li class="-item"><a href="https://law.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="legal professionals, students, and others with experience or interest in law">Law</a></li>
+            <li class="-item"><a href="https://fitness.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="physical fitness professionals, athletes, trainers, and those providing health-related needs">Physical Fitness</a></li>
+            <li class="-item"><a href="https://gardening.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="gardeners and landscapers">Gardening &amp; Landscaping</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Life / Arts"><ul class="-list">
+            <li class="-item"><a href="https://parenting.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="parents, grandparents, nannies and others with a parenting role">Parenting</a></li>
+            <li class="-item">
+                <a href="https://stackexchange.com/sites#lifearts" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 26 })">
+                    <strong>
+                        more (10)
+                    </strong>
+                </a>
+            </li>
+    </ul>
+</div>
+<div class="site-footer--col site-footer--category js-footer-col" data-name="Culture / Recreation">
+    <ul class="-list">
+            <li class="-item"><a href="https://english.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="linguists, etymologists, and serious English language enthusiasts">English Language &amp; Usage</a></li>
+            <li class="-item"><a href="https://skeptics.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="scientific skepticism">Skeptics</a></li>
+            <li class="-item"><a href="https://judaism.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="those who base their lives on Jewish law and tradition and anyone interested in learning more">Mi Yodeya (Judaism)</a></li>
+            <li class="-item"><a href="https://travel.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="road warriors and seasoned travelers">Travel</a></li>
+            <li class="-item"><a href="https://christianity.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="committed Christians, experts in Christianity and those interested in learning more">Christianity</a></li>
+            <li class="-item"><a href="https://ell.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="speakers of other languages learning English">English Language Learners</a></li>
+            <li class="-item"><a href="https://japanese.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="students, teachers, and linguists wanting to discuss the finer points of the Japanese language">Japanese Language</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Culture / Recreation"><ul class="-list">
+            <li class="-item"><a href="https://chinese.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="students, teachers, and linguists wanting to discuss the finer points of the Chinese language">Chinese Language</a></li>
+            <li class="-item"><a href="https://french.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="students, teachers, and linguists wanting to discuss the finer points of the French language">French Language</a></li>
+            <li class="-item"><a href="https://german.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="speakers of German wanting to discuss the finer points of the language and translation">German Language</a></li>
+            <li class="-item"><a href="https://hermeneutics.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="professors, theologians, and those interested in exegetical analysis of biblical texts">Biblical Hermeneutics</a></li>
+            <li class="-item"><a href="https://history.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="historians and history buffs">History</a></li>
+            <li class="-item"><a href="https://spanish.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="linguists, teachers, students and Spanish language enthusiasts in general wanting to discuss the finer points of the language">Spanish Language</a></li>
+            <li class="-item"><a href="https://islam.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="Muslims, experts in Islam, and those interested in learning more about Islam">Islam</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Culture / Recreation"><ul class="-list">
+            <li class="-item"><a href="https://rus.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="&#x43B;&#x438;&#x43D;&#x433;&#x432;&#x438;&#x441;&#x442;&#x43E;&#x432; &#x438; &#x44D;&#x43D;&#x442;&#x443;&#x437;&#x438;&#x430;&#x441;&#x442;&#x43E;&#x432; &#x440;&#x443;&#x441;&#x441;&#x43A;&#x43E;&#x433;&#x43E; &#x44F;&#x437;&#x44B;&#x43A;&#x430;">&#x420;&#x443;&#x441;&#x441;&#x43A;&#x438;&#x439; &#x44F;&#x437;&#x44B;&#x43A;</a></li>
+            <li class="-item"><a href="https://russian.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="students, teachers, and linguists wanting to discuss the finer points of the Russian language">Russian Language</a></li>
+            <li class="-item"><a href="https://gaming.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="passionate videogamers on all platforms">Arqade (gaming)</a></li>
+            <li class="-item"><a href="https://bicycles.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="people who build and repair bicycles, people who train cycling, or commute on bicycles">Bicycles</a></li>
+            <li class="-item"><a href="https://rpg.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="gamemasters and players of tabletop, paper-and-pencil role-playing games">Role-playing Games</a></li>
+            <li class="-item"><a href="https://anime.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="anime and manga fans">Anime &amp; Manga</a></li>
+            <li class="-item"><a href="https://puzzling.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="those who create, solve, and study puzzles">Puzzling</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Culture / Recreation"><ul class="-list">
+            <li class="-item"><a href="https://mechanics.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="mechanics and DIY enthusiast owners of cars, trucks, and motorcycles">Motor Vehicle Maintenance &amp; Repair</a></li>
+            <li class="-item"><a href="https://boardgames.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="people who like playing board games, designing board games or modifying the rules of existing board games">Board &amp; Card Games</a></li>
+            <li class="-item"><a href="https://bricks.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="LEGO&#xAE; and building block enthusiasts">Bricks</a></li>
+            <li class="-item"><a href="https://homebrew.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="dedicated home brewers and serious enthusiasts">Homebrewing</a></li>
+            <li class="-item"><a href="https://martialarts.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="students and teachers of all martial arts">Martial Arts</a></li>
+            <li class="-item"><a href="https://outdoors.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="people who love being outdoors enjoying nature and wilderness, and learning about the required skills and equipment">The Great Outdoors</a></li>
+            <li class="-item"><a href="https://poker.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="serious players and enthusiasts of poker">Poker</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Culture / Recreation"><ul class="-list">
+            <li class="-item"><a href="https://chess.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="serious players and enthusiasts of chess">Chess</a></li>
+            <li class="-item"><a href="https://sports.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="participants in team and individual sport activities">Sports</a></li>
+            <li class="-item">
+                <a href="https://stackexchange.com/sites#culturerecreation" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 26 })">
+                    <strong>
+                        more (16)
+                    </strong>
+                </a>
+            </li>
+    </ul>
+</div>
+<div class="site-footer--col site-footer--category js-footer-col" data-name="Science">
+    <ul class="-list">
+            <li class="-item"><a href="https://mathoverflow.net" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="professional mathematicians">MathOverflow</a></li>
+            <li class="-item"><a href="https://math.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="people studying math at any level and professionals in related fields">Mathematics</a></li>
+            <li class="-item"><a href="https://stats.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="people interested in statistics, machine learning, data analysis, data mining, and data visualization">Cross Validated (stats)</a></li>
+            <li class="-item"><a href="https://cstheory.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="theoretical computer scientists and researchers in related fields">Theoretical Computer Science</a></li>
+            <li class="-item"><a href="https://physics.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="active researchers, academics and students of physics">Physics</a></li>
+            <li class="-item"><a href="https://chemistry.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="scientists, academics, teachers, and students in the field of chemistry">Chemistry</a></li>
+            <li class="-item"><a href="https://biology.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="biology researchers, academics, and students">Biology</a></li>
+                </ul></div><div class="site-footer--col site-footer--category js-footer-col" data-name="Science"><ul class="-list">
+            <li class="-item"><a href="https://cs.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="students, researchers and practitioners of computer science">Computer Science</a></li>
+            <li class="-item"><a href="https://philosophy.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="those interested in the study of the fundamental nature of knowledge, reality, and existence">Philosophy</a></li>
+            <li class="-item"><a href="https://linguistics.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="professional linguists and others with an interest in linguistic research and theory">Linguistics</a></li>
+            <li class="-item"><a href="https://psychology.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="practitioners, researchers, and students in cognitive science, psychology, neuroscience, and psychiatry">Psychology &amp; Neuroscience</a></li>
+            <li class="-item"><a href="https://scicomp.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="scientists using computers to solve scientific problems">Computational Science</a></li>
+            <li class="-item">
+                <a href="https://stackexchange.com/sites#science" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 26 })">
+                    <strong>
+                        more (10)
+                    </strong>
+                </a>
+            </li>
+    </ul>
+</div>
+<div class="site-footer--col site-footer--category js-footer-col" data-name="Other">
+    <ul class="-list">
+            <li class="-item"><a href="https://meta.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="meta-discussion of the Stack Exchange family of Q&amp;A websites">Meta Stack Exchange</a></li>
+            <li class="-item"><a href="https://stackapps.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="apps, scripts, and development with the Stack Exchange API">Stack Apps</a></li>
+            <li class="-item"><a href="https://api.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="programmatic interaction with Stack Exchange sites">API</a></li>
+            <li class="-item"><a href="https://data.stackexchange.com" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 25 })" title="querying Stack Exchange data using SQL">Data</a></li>
+    </ul>
+</div>
+
+            </div>
+        </nav>
+        <div class="site-footer--copyright fs-fine">
+            <ul class="-list">
+                <li class="-item"><a class="js-gps-track -link" data-gps-track="footer.click({ location: 2, link:4 })" href="https://stackoverflow.blog?blb=1">Blog</a></li>
+                <li class="-item"><a href="https://www.facebook.com/officialstackoverflow/" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 31 })">Facebook</a></li>
+                <li class="-item"><a href="https://twitter.com/stackoverflow" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 32 })">Twitter</a></li>
+                <li class="-item"><a href="https://linkedin.com/company/stack-overflow" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 33 })">LinkedIn</a></li>
+                <li class="-item"><a href="https://www.instagram.com/thestackoverflow" class="-link js-gps-track" data-gps-track="footer.click({ location: 2, link: 36 })">Instagram</a></li>
+            </ul>
+
+            <p class="mt-auto mb24">
+site design / logo &#169; 2021 Stack Exchange Inc; user contributions licensed under <a href="https://stackoverflow.com/help/licensing">cc by-sa</a>.                    <span id="svnrev">rev&nbsp;2021.9.2.40142</span>
+            </p>
+        </div>
+    </div>
+
+        <div class="site-footer--extra ai-center">
+            Linux is a registered trademark of Linus Torvalds. UNIX is a registered trademark of The Open Group. <br>This site is not affiliated with Linus Torvalds or The Open Group in any way.
+        </div>
+</footer>
+
+        <script>StackExchange.ready(function () { StackExchange.responsiveness.addSwitcher(); })</script>
+<noscript>
+    <div id="noscript-warning">Unix &amp; Linux Stack Exchange works best with JavaScript enabled
+        <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=17440561&amp;cv=3.6.0&amp;cj=1" alt="">
+    </div>
+</noscript>
+
+        <script>
+(function(i, s, o, g, r, a, m) {
+            i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function() { (i[r].q = i[r].q || []).push(arguments) }, i[r].l = 1 * new Date(); a = s.createElement(o),
+            m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m);
+        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+
+        StackExchange.ready(function () {
+
+            StackExchange.ga.init({
+                autoLink: ["stackoverflow.blog","info.stackoverflowsolutions.com","stackoverflowsolutions.com"],
+                sendTitles: true,
+                tracker: window.ga,
+                trackingCodes: [
+                    'UA-108242619-5'
+                ],
+                    checkDimension: 'dimension42'
+            });
+
+
+
+                StackExchange.ga.setDimension('dimension2', '|date|man|');
+
+
+                StackExchange.ga.setDimension('dimension3', 'Questions/Show');
+
+
+            StackExchange.ga.trackPageView();
+        });
+        
+        var _comscore = _comscore || [];
+        _comscore.push({ c1: "2", c2: "17440561" });
+        (function() {
+            var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+            s.src = "https://sb.scorecardresearch.com/cs/17440561/beacon.js";
+            el.parentNode.insertBefore(s, el);
+        })();
+            </script>
+
+    
+<div id="onetrust-consent-sdk" class="d-none"></div>
+<div id="onetrust-banner-sdk" data-controller="s-modal"></div>
+<div id="ot-pc-content" class="d-none"></div>
+<div id="onetrust-style" class="d-none">&nbsp;</div>
+<div class="d-none js-consent-banner-version" data-consent-banner-version="baseline"></div>
+
+
+</body>
+</html>

--- a/tests/laodeai_fixture/wikihow.html
+++ b/tests/laodeai_fixture/wikihow.html
@@ -1,0 +1,2527 @@
+
+<!DOCTYPE html>
+<html class="client-nojs" lang="en" dir="ltr">
+<head>
+<meta charset="utf-8"/>
+<title>3 Ways to Stop Ringing in Ears - wikiHow</title>
+<script>document.documentElement.className = document.documentElement.className.replace( /(^|\s)client-nojs(\s|$)/, "$1client-js$2" );</script>
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Stop-Ringing-in-Ears","wgTitle":"Stop Ringing in Ears","wgCurRevisionId":29839671,"wgRevisionId":29839671,"wgArticleId":543713,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Tinnitus","Ear Health","Health"],"wgBreakFrames":false,"wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgMonthNamesShort":["","Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"wgRelevantPageName":"Stop-Ringing-in-Ears","wgRelevantArticleId":543713,"wgRequestId":"a6a165c8696eb473dcc1676e","wgCSPNonce":false,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgUserType":"anon","wgWikihowSiteRev":"tmCgL","wgFBAppId":"157545333433","wgGoogleAppId":"475770217963-cj49phca8tqki2ggs0ttcaerhs8339eh.apps.googleusercontent.com","wgCDNbase":"https://www.wikihow.com","wgProMembership":0,"wgHasEmail":0,"wgIsUserReviewEligible":"expert","wgNumReviews":"34","wgMFMode":"stable","wgMFLazyLoadImages":false,"wgMFLazyLoadReferences":false,"wgMFIsPageContentModelEditable":true,"wgMFEnableFontChanger":true,"wgMFDisplayWikibaseDescriptions":{"search":false,"nearby":false,"watchlist":false,"tagline":false},"wgMinervaFeatures":{"amc":false,"beta":false,"mobileOptionsLink":true,"categories":false,"backToTop":false,"shareButton":false,"toggling":true,"pageIssues":false,"talkAtTop":false},"wgMinervaDownloadNamespaces":[0],"wgMinervaMenuData":[]});mw.loader.state({"user.styles":"ready","user":"ready","user.options":"ready","user.tokens":"loading","ext.cite.styles":"ready","skins.minerva.base.styles":"ready","skins.minerva.content.styles.images":"ready","mediawiki.hlist":"ready","mediawiki.ui.icon":"ready","mediawiki.ui.button":"ready","skins.minerva.icons.images":"ready","ext.wikihow.trusted_sources.styles":"ready","ext.wikihow.slider_styles":"ready","ext.wikihow.expertadvicesection.styles":"ready","ext.wikihow.green_box":"ready","ext.wikihow.social_footer_styles":"ready"});mw.loader.implement("user.tokens@0tffind",function($,jQuery,require,module){/*@nomin*/mw.user.tokens.set({"editToken":"+\\","patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});
+});RLPAGEMODULES=["mediawiki.page.startup","skins.minerva.scripts","ext.wikihow.common_top","ext.wikihow.common_bottom","mobile.wikihow.mmf","ext.wikihow.article_courses_banner","ext.wikihow.membershipmanager","ext.wikihow.trusted_sources.scripts","zzz.mobile.wikihow.styles_late_load","zzz.mobile.wikihow.scripts_late_load","mobile.wikihow.tabsonmobile","mobile.wikihow","mobile.wikihow.stable.styles","mobile.wikihow.socialproof","ext.wikihow.slider","mobile.wikihow.qa_widget","mobile.wikihow.userreview","ext.wikihow.green_box.scripts","ext.wikihow.social_footer","ext.wikihow.Disclaimer","ext.eventLogging","mobile.site","mobile.init"];mw.loader.load(RLPAGEMODULES);});</script>
+<link rel="preload" href="/load.php?debug=false&lang=en&modules=ext.cite.styles%7Cext.wikihow.expertadvicesection.styles%7Cext.wikihow.green_box%2Cslider_styles%2Csocial_footer_styles%7Cext.wikihow.trusted_sources.styles%7Cmediawiki.hlist%7Cmediawiki.ui.button%2Cicon%7Cskins.minerva.base.styles%7Cskins.minerva.content.styles.images%7Cskins.minerva.icons.images&only=styles&siterev=tmCgL&skin=wh" as="style" onload="this.onload=null;this.rel='stylesheet'"/><link rel="stylesheet" href="/load.php?debug=false&amp;lang=en&amp;modules=ext.cite.styles%7Cext.wikihow.expertadvicesection.styles%7Cext.wikihow.green_box%2Cslider_styles%2Csocial_footer_styles%7Cext.wikihow.trusted_sources.styles%7Cmediawiki.hlist%7Cmediawiki.ui.button%2Cicon%7Cskins.minerva.base.styles%7Cskins.minerva.content.styles.images%7Cskins.minerva.icons.images&amp;only=styles&amp;siterev=tmCgL&amp;skin=wh"/>
+<meta name="ResourceLoaderDynamicStyles" content=""/>
+<meta name="generator" content="MediaWiki 1.33.0-alpha"/>
+<meta name="robots" content="index,follow"/><!--default-->
+<meta name="google-site-verification" content="Jb3uMWyKPQ3B9lzp5hZvJjITDKG8xI8mnEpWifGXUb0"/>
+<meta name="description" content="Ringing, buzzing, or roaring in the ears is often used to describe tinnitus, which can be extremely annoying and occur without any reason. Tinnitus may signify underlying nerve damage or an issue with your circulatory system, or there may..."/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+<meta name="viewport" content="initial-scale=1.0, user-scalable=yes, minimum-scale=0.25, maximum-scale=5.0, width=device-width"/>
+<meta name="theme-color" content="#eaecf0"/>
+<link rel="amphtml" href="https://www.wikihow.com/Stop-Ringing-in-Ears?amp=1"/>
+<link rel="alternate" type="application/x-wiki" title="Edit" href="/index.php?title=Stop-Ringing-in-Ears&amp;action=edit"/>
+<link rel="edit" title="Edit" href="/index.php?title=Stop-Ringing-in-Ears&amp;action=edit"/>
+<link rel="apple-touch-icon" href="https://www.wikihow.com/skins/WikiHow/wH-initials_152x152.png"/>
+<link rel="shortcut icon" href="/favicon.ico"/>
+<link rel="search" type="application/opensearchdescription+xml" href="/opensearch_desc.php" title="wikiHow (en)"/>
+<link rel="EditURI" type="application/rsd+xml" href="https://www.wikihow.com/api.php?action=rsd"/>
+<link rel="canonical" href="https://www.wikihow.com/Stop-Ringing-in-Ears"/>
+<script>window.WH=window.WH||{timeStart:+(new Date()),lang:{}};
+if(/.+@.+/.test(window.location.hash)){window.location.hash='';}</script>
+<script>window.WH.proMembership=0;</script>
+<script>window.WH.jsFastRender=0;</script>
+<script>retinaAvailable = false;</script>
+<style>html,body,div,span,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,del,ins,em,img,small,strike,strong,sub,sup,tt,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,input,textarea,button,select,audio,video{margin:0;padding:0;border:0;font:inherit;font-size:100%;vertical-align:baseline}table,caption,tbody,tfoot,thead,tr,th,td{margin:0;padding:0;font:inherit;font-size:100%;vertical-align:baseline}button{border:none;background-color:transparent}body{line-height:1;-webkit-tap-highlight-color:transparent}input{line-height:normal}ol,ul{list-style:none}table{border-collapse:collapse}strong,b{font-weight:bold}i,em{font-style:italic}html,body{height:100%}body{background-color:#f3f3f3;color:#545454;font-family:"Helvetica","Nimbus Sans L","Arial","Liberation Sans",sans-serif;line-height:1.4;font-size:16px;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}h1,h2,h3,h4{color:#222}.hidden,a.hide,img[src=""],#mw-mf-page-left,.stable #ca-talk,.client-nojs #ca-watch.cta,.client-nojs #ca-edit,.client-nojs #ca-upload,#ca-talk.selected,.template_top,.section>.section_text>h3 .edit-page,#tips h3,h4.steps_text .edit-page,h5.steps_text .edit-page,h6.steps_text .edit-page,#article_rating_mobile,#uci_section,.trvote_box,.section.video,#hp_navigation,#mcta_root,#method_toc,.amazon_info,#servedtime,.tabbed_content,#sp_h2.tabbed_content,#social_proof_mobile.tabbed_content,#uci_section.tabbed_content,.tabbed_content .edit-page,.m-video-helpful-wrap,.m-video-wm,#gdpr_dismiss,#gdpr_close,#intro .green_box,.header #actions,#actionbar,.pswp,#mw-mf-last-modified,.page_stats,#end_options,#footer_newsletter{display:none}a,a:active,a:visited,a.new{color:#307530;text-decoration:none;word-wrap:break-word}a:active,a:hover{color:#439B05;text-decoration:underline}a.new{color:#B30000}a[title^='User']{color:#307530}a.external{background-image:none}.clearall{clear:both;height:0}#section_0.title_sm{font-size:1.3em}#section_0.title_md{font-size:1.5em}#section_0.title_lg{font-size:1.6em}#section_0 span.ja_how_to{color:#7b9965}#mw-mf-viewport{position:relative;height:100%}#mw-mf-page-center{padding:0;min-height:100%;width:100%;position:relative;z-index:3;background-color:#f3f3f3;transition:all 0.5s ease 0s}#mw-mf-page-center.footerad{padding:0 0 180px}.footerad #footer{bottom:110px}.header_container{background-color:#93B874;position:fixed;border:0;z-index:10;top:0;width:100%}#header_container_small{display:none}#wh-progress-bar{position:absolute;left:0;bottom:0;width:0px;height:2px;background-color:#475347;transition:width 1s linear;-webkit-transition:width 1s linear;-moz-transition:width 1s linear;-o-transition:width 1s linear}.header{height:40px;display:table;white-space:nowrap;margin:0 auto;width:100%;border-top:none}.header > *{width:3em;display:table-cell;vertical-align:middle}.header > h1,.header > form,.header > ul{width:auto}.header h1{text-align:center;font-weight:bold}.header #mw-mf-main-menu-button,.header #secondary-button{text-indent:-9999px;background-repeat:no-repeat}.header #mw-mf-main-menu-button{background-position:40% 40%}.header #secondary-button{background-position:60% 40%}.header #secondary-button.user-button{text-indent:0;text-align:center}.header #secondary-button.user-button:hover{text-decoration:none}.header #secondary-button.user-button span{display:inline-block;width:24px;height:24px;font-weight:bold;color:#fff;line-height:24px;background:#c91f2c;border-radius:2px}.header .search{border:none;padding:0;background-color:transparent}#hs,#hs_query{width:72px;position:static}#hs + a{padding-left:0 !important}.hs_active .search{padding-right:50px}#hs_query,#hs_close,#hs_submit{display:block;position:absolute;top:0;right:0;height:39px;margin:1px 0 0;padding:0;background-color:transparent;background-repeat:no-repeat;border:none}#hs_query{border:solid 5px #93B874;border-radius:10px;padding:0 5px;-webkit-appearance:none;background:#FFF url(/extensions/wikihow/mobile/images/search_gray.svg) right 4px center / 20px no-repeat;box-sizing:border-box;color:transparent;font-size:16px;transition:width 100ms ease-in-out;outline:none}.hs_notif #hs_query{margin-right:40px}.hs_active.hs_notif #hs_query{margin-right:0}.hs_active #hs_query:valid{background-image:none}#hs_close{width:0;background:url(/extensions/wikihow/mobile/images/close.svg) center / 15px no-repeat}#hs_submit{display:none;position:absolute;background-size:20px;background-position:right 9px center;width:40px}@media only screen and (max-width:599px){#hs_query,#hs_submit{background-image:url(/extensions/wikihow/mobile/images/search_gray.svg)}.hs_active #hs_query{color:#545454;width:100%;padding-left:34px;padding-right:34px;background-position:left 6px bottom 50%}.hs_active #hs_query:valid ~ #hs_submit{display:block;right:auto;left:0}.hs_active #hs_close{width:40px}#hs_query::-webkit-input-placeholder{opacity:0}.hs_active #hs_query::-webkit-input-placeholder{opacity:1}}@media only screen and (min-width:600px){#hs_query{background-color:#B3CE9C;color:#fff;width:30%;padding-left:10px;padding-right:34px}#hs_query,#hs_submit{background-image:url(/extensions/wikihow/mobile/images/mag_white.png)}#hs_query:valid ~ #hs_submit{display:block}#hs_query::-webkit-input-placeholder{color:#E3F8D1}}.content{margin:0 5px;word-wrap:break-word}.full_width .content{margin:0}.content img{max-width:100%;width:100%;height:auto}.content video{max-width:100%;width:100%;height:auto}.content h1,.content h2,.content h3,.content h4,.content h5,.content h6{line-height:1.3;padding:0.5em 0}.content p{margin-bottom:.7em}.content .thumb{margin:15px 0;border:1px solid #ccc;border-radius:5px;background:#f9f9f9;text-align:center}.content ol ol,.content ul ol,.content ol ul,.content ul ul,dl{margin-left:1em}.pre-content h1,.content h1{font-size:1.8em}h2{font-size:1.5em}h3{font-size:1.2em;font-weight:bold}h4,dl dt{font-weight:bold}sup{vertical-align:super;line-height:normal}sub{vertical-align:sub}sub,sup{font-size:0.83em}pre{white-space:pre-wrap;overflow-wrap:break-word}#content_wrapper{padding-top:40px;background-color:#f3f3f3}.pre-content{background-color:#FFF;border-bottom:none;margin:0}.section-heading .indicator{display:none}#section_0{border-bottom:none;color:#222;font-size:26px;font-weight:bold;line-height:1.2em;padding:12px 15px 0}#section_0.special_title{font-size:18px;margin-bottom:.5em;padding:15px 20px}#section_0 a{color:#222;text-decoration:none}.ns-0.action-view #section_0{padding:0 15px}#intro{background-color:#FFF;margin:0 -5px; padding:7px 15px 3px}body.action-view #content>#intro{padding-top:7px}#intro p{line-height:20px}#intro .mwimg{margin:-7px -15px 5px -15px}#intro .mwimg img{border-radius:0}.section{margin-top:1em;position:relative}.section h2,.steps h3{background-color:#FFF;width:100%;border-radius:4px 4px 0 0;font-weight:bold;font-size:1em;box-sizing:border-box;padding:0;border-bottom:1px solid #f3f3f3}.section h2 span.mw-headline{display:inline-block;padding:.8em;color:#222}.steps.sample h3 span.mw-headline{color:#222;padding-top:1em}.steps h3 span.mw-headline{display:inline-block;padding:0 1em 1em}h4.steps_text{position:relative;padding-left:25px;border:1px solid #f3f3f3;border-width:1px 0}.section>.section_text>h3{background-position:3px center}.step_num{font-size:30px;color:#545454;padding:0 15px 0 0;float:left;font-weight:bold;line-height:39px}.stepanchor{display:block;position:relative;top:-110px;visibility:hidden}.steps_list_2 li{margin-bottom:1em;font-size:16px;line-height:normal;list-style:none;background-color:#FFF;border-radius:4px;padding:20px;clear:both}#content_wrapper{margin:0}.steps_list_2 li li{border:none;margin:0;list-style:disc;padding:0 }.steps_list_2 .mwimg.largeimage{margin:-20px -20px 10px}.mwimg{border-bottom:1px solid rgba(0,0,0,0.1);line-height:0;margin-bottom:1em;position:relative;text-align:center}#quick_summary_section .mwimg{margin-bottom:0}.mwimg a img{border-top-left-radius:3px;border-top-right-radius:3px}.steps_list_2 li:first-child .mwimg a img{border-radius:0}.steps_list_2 .mwimg.underwidth{margin-left:auto;margin-right:auto}.mwimg.techicon{display:inline;border:none}.mwimg.techicon img{width:auto;height:30px !important;position:relative;min-height:0;min-width:0}.mwimg.techicon .content-spacer{width:auto;height:30px !important;padding-top:0 !important;display:inline}.content img.whvgif{width:100%;max-width:760px !important}.caption{position:absolute;width:96%;bottom:0;left:0;background-color:#444;opacity:0.7;text-align:left;font-size:12px;line-height:normal;padding:5px 2%;color:#fff}.mwimg.tright{float:right}.steps_list_2 li li .mwimg.largeimage{margin:5px 0}.section_text,.steps_text{padding:15px;background-color:#FFF;border-radius:0 0 4px 4px;font-size:16px}.steps.sample .section_text{background-color:#FFF}.sample p{padding:.9em;margin:0}#quicksummary{padding-bottom:0;margin-bottom:-15px}#video.section_text{padding:0}#quick_summary_section.section_text{padding-bottom:0}#video .embedvideocontainer{width:100%}.content .steps_list_2 ul,.content .steps_list_2 ol{margin:8px 0 0 30px}.steps .section_text{background-color:inherit;padding:0;border:none}h3 .altblock{padding:1rem 1rem 0;font-weight:normal}#ingredients li,#thingsyoullneed li{clear:both;list-style:none;margin-bottom:1.1em;line-height:20px}#thingsyoullneed li > ul{margin-top:10px;margin-left:27px}.checkmark{border:1px solid #a3a3a3;width:.9em;height:.9em;border-radius:4px;float:left;margin-right:.5em}.section:not(.steps) h3{position:relative;color:#222;font-weight:normal;font-size:1rem}.section:not(.steps) h3 .altblock{position:absolute;margin-top:.1em;height:1em;width:1em;background-color:#93b874;padding:0}.section:not(.steps) h3 .mw-headline{display:inline-block;width:auto;padding-left:1.6em}.content ul{list-style:disc inside}.section h2.android,.section h3.android,.tool div.android{top:0}#ca-edit.enabled{background-size:10px 10px;width:20px;height:20px;margin-right:4px}#page-actions:not(.page-actions-menu__list){font-size:inherit;float:right;border:none;padding:10px 0 0 0;margin:0;width:auto}#page-actions li{cursor:pointer;vertical-align:top;height:30px;width:40px;text-indent:-9999px;background-position:50% 0;background-repeat:no-repeat}#page-actions li input{opacity:0}#page-actions li input,#page-actions li a{display:block;width:100%;height:100%;margin:0 0 8px}#page-actions li#ca-edit{width:27px;height:15px;margin-right:0;background-size:14px;background-position:top left}.content .edit-page{display:none}.stable .content p,.stable .content li,.stable .content dl{line-height:25px}.stable .content .stu_test_font p,.stable .content .stu_test_font li,.stable .content .stu_test_font dl{line-height:35px;font-size:18px}#header_logo{display:table-cell;vertical-align:middle;background:center / 115px no-repeat url(/extensions/wikihow/mobile/images/wikihow_logo_230.png);width:auto;height:38px;padding:0 14px}.header #mw-mf-main-menu-button{width:72px;border-right:none;background:url(/extensions/wikihow/mobile/images/main_menu_button.svg) left 15px bottom 50% / 18px no-repeat}.header #mw-mf-main-menu-button,.header #secondary-button{height:auto}.header #secondary-button.user-button{padding-top:.35em}.header > *:nth-child(3){border-left:none}.wh_search .cse_q{border:none}.breadcrumbs li{display:inline-block;padding-right:.3em}.breadcrumbs li:after{content:' \20\00BB'}.breadcrumbs li:last-child:after{content:''}#breadcrumb{font-size:.7em;padding:1em 0 .7em 15px;text-transform:uppercase}#breadcrumb li{display:none;line-height:1em;padding-right:.5em}#breadcrumb li:after{color:#307530;font-size:1.25em;white-space:pre}#breadcrumb li:nth-last-child(2),#breadcrumb li:last-child{display:inline-block;font-weight:bold} .button,button,.panel .button,.panel button,.buttonBar .button,.buttonBar button,.buttonBar input[type="submit"],.mw-ui-button,input[type="submit"]{border-radius:4px;text-align:center;color:#FFF;padding:8px 11px;font-size:1.1em;margin-right:10px;cursor:pointer;background-image:none;background-color:#97ba78;border:1px solid #97ba78;-webkit-appearance:none;-moz-appearance:none} #wh_ad_middle_related{float:left}#wh_ad_tips,#pagebottom{margin-top:12px}.al_method{text-align:center;font-size:12px;color:#999}#references_first ins{margin-top:10px}.method_ad{margin:17px 0 0 -16px;display:block}.wh_ad1_full{margin-left:-16px}.embedvideocontainer{position:relative;width:99%;height:0;padding-bottom:56.25%}.embedvideo{position:absolute;top:0;left:0;width:100%;height:100%}body.action-view #fa_container p{width:100%;font-size:16px !important;line-height:16px !important}#ab_notice{margin-top:10px;display:none;background-color:#f1c4c8;color:black;padding:10px}#ab_notice_img{background:url(/skins/owl/images/face_sad_black.svg) center no-repeat;width:50px;height:50px;background-size:contain;display:table-cell;vertical-align:middle}#ab_notice_msg{padding-left:15px;display:table-cell;vertical-align:middle}.related_box p{width:100%;font-size:16px;line-height:16px}.content #intro ul,.content .section_text ul{list-style:disc outside;padding-left:24px}.content .section_text .steps_list_2 ul,.content .ingredients ul,.content .thingsyoullneed ul{padding-left:0}.content #intro li,.content .section_text ul li{margin-bottom:5px}.content .section_text.expert_advice_section ul li{margin-bottom:12px;font-size:14px;line-height:22px;list-style:none}.content .section_text.expert_advice_section ul{padding-left:16px}.content .expert_advice_section p{margin-bottom:10px;color:#5f5f5f;font-size:14px;line-height:23px}.content .section_text .steps_list_2 ul li,.content .ingredients ul li,.content .thingsyoullneed ul li{margin-bottom:0}.content .ingredients ul ul{margin:20px 0 0 26px}#social_proof_anchor{margin-top:-115px;display:block;position:absolute}.related-article{float:left;position:relative;width:100%;margin-bottom:2%}.related-image-link{display:block;vertical-align:top}.related-image-link img{border:none;width:100%}.related-image-link video{display:block;border:none;width:100%;height:auto}.related-title{background-color:rgba(50,50,50,.5);padding:2% 4%;width:92%;min-height:32px;position:absolute;bottom:0;cursor:pointer;color:#fff;font-weight:bold}#relatedwikihows .related-title-text p,#qa_related_box .related-title-text p{font-size:12px;line-height:15px;margin:0}.related-image-link{text-decoration:none}#relatedwikihows{padding:2%}.content-spacer{position:relative}.content-fill{position:absolute;top:0;left:0;bottom:0;right:0;width:1px;min-width:100%;height:1px;min-height:100%;color:#fff }.loader{position:absolute;display:block;height:10px;top:50%;left:50%;transform:translateX(-50%) translateY(-50%);transform-origin:50% 50%;white-space:nowrap}.loader-dot{animation:loader-dots 1s infinite}.loader-dot{position:relative;display:inline-block;height:10px;width:10px;margin:2px;border-radius:100%;background-color:rgba(137,172,108,1);will-change:transform}.loader-dot:nth-child(1){animation-delay:0s}.loader-dot:nth-child(2){animation-delay:.3s}.loader-dot:nth-child(3){animation-delay:.5s}@keyframes loader-dots{0%,100%{transform:scale(1);background-color:rgba(137,172,108,1)}50%{transform:scale(.7);background-color:rgba(137,172,108,0.9)}}#mobile_tab_container{position:relative;border:1px solid #E6EEE0;border-width:1px 0;clear:both;background:#f7faf6;margin:5px -15px 15px;box-shadow:0 6px 6px -6px rgba(84,84,84,.3)}#mobile_tab_container a,#mobile_tab_container a:visited{color:#707070}.mobile_tab{position:relative;margin:0 1em 0 1.3em;padding:.7em 0 .8em;font-weight:bold;font-size:.8em;display:inline-block}.mobile_tab.video{margin-left:0}.mobile_tab a{padding:.2em 0}.mobile_tab.video a{padding-right:1.9em;background:right 0 bottom 57% / 18px no-repeat; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cpath fill='%23fff' stroke='%23a3a3a3' d='M14.13 3a2.66 2.66 0 00-1.06-1.1 3.84 3.84 0 00-2.16-.4H4.1a3.88 3.88 0 00-2.17.4A2.69 2.69 0 00.88 3 4.47 4.47 0 00.5 5.34v4.32A4.5 4.5 0 00.88 12a2.69 2.69 0 001 1.14 3.88 3.88 0 002.17.4h6.81a3.84 3.84 0 002.16-.4A2.66 2.66 0 0014.13 12a4.53 4.53 0 00.37-2.3V5.34A4.51 4.51 0 0014.13 3z'/%3E%3Cpath fill='%23a3a3a3' d='M10.76 7.84a.78.78 0 01-.31.34l-4.74 2.53a.68.68 0 01-.93-.34.76.76 0 01-.08-.37V5a.73.73 0 01.7-.75.65.65 0 01.31.08l4.74 2.53a.78.78 0 01.31.98z'/%3E%3C/svg%3E")}#mobile_tab_line{position:absolute;bottom:0;background-color:#6d9d6c;height:4px;width:90%;margin-left:5%;border-radius:4px 4px 0 0}.summarysection.mwimg,.summarysection .mwimg{margin:-16px -15px 0}.content .m-video{max-width:100%;width:100%;height:auto}.summary-video{position:relative;overflow:hidden}.video-poster-image{position:absolute;z-index:1}.video-poster-image img{object-fit:cover}.green_tips_box_inline{background-color:#fff5d9;color:#000;margin:0;width:75%;display:inline}.img-loading-hide{visibility:hidden}.img-loading-alt{color:#000}#gdpr{width:100%;margin:0 auto;position:fixed;bottom:0;max-height:70px;z-index:10000;text-align:center;background-color:#475347;color:#FFF;padding:9px 5px;display:none}.gdpr_button,button.gdpr_button{background-color:#b6e684;border:1px solid #b6e684;color:#000;display:inline-block;font-size:0.8em;font-weight:bold;padding:5px 10px 6px 10px;-moz-border-radius:4px;-webkit-border-radius:4px;border-radius:4px;text-decoration:none;vertical-align:super;margin-left:5px;margin-right:0}#gdpr_text{font-size:0.9em;display:inline-block;max-width:73%;text-align:left;vertical-align:middle}#gdpr_text a{color:#EEE;text-decoration:underline}#gdpr_text_inner{padding-right:3px}#gdpr_accept_wrap{display:inline-block}#gdpr_cp_link{font-size:13px;color:#FFF;text-decoration:underline;display:inline-block}.mw-mf-display-toggle > a{color:#AFAFAF;font-size:1em}.mw-mf-display-toggle{bottom:0;margin:3em 0 10px 13px;color:#AFAFAF;font-size:.75em}.geo-group-eu .mw-mf-display-toggle{padding-left:0;background:none}.gdpr_only{visibility:hidden}.no_gdpr{visibility:visible}.geo-group-eu .gdpr_only{visibility:visible}.geo-group-eu .no_gdpr{visibility:hidden}#mw-mf-page-left{position:fixed !important;overflow-y:scroll;height:100%}body.navigation-enabled #mw-mf-page-left{display:block}a.related-title,a.related-title:active,a.related-title:visited{color:#FFF}.noarticletext div{border:none !important;padding:0;margin-bottom:0.75em}.references li{position:relative;list-style-position:outside}.references li span{margin-left:3px;word-break:break-word}.references li > a{float:left;margin-top:-2px}.sourcesandcitations{word-break:break-all}.sourcesandcitations .section_text{padding-left:30px} #aiinfo:target ~ .aidata,#social_proof_mobile:target ~ .aidata{display:block}.aidata,#aiinfo:target,#social_proof_mobile:target ~ #aiinfo{display:none}.section.articleinfo{margin-top:0;padding-top:0}.articleinfo #articleinfo{margin-top:-5px;border-radius:0 0 4px 4px;border-top:none;position:relative}#articleinfo #info_link{width:100%;display:block}#articleinfo #info_link,.collapse_link{ background:url(/extensions/wikihow/mobile/images/show_sources.svg) right .5em center / 20px no-repeat} #social_proof_mobile + .articleinfo #articleinfo,#summary_wrapper + .articleinfo #articleinfo{ padding:15px;border-top:1px solid #f3f3f3;border-radius:0 0 4px 4px;margin-top:-5px;position:relative;z-index:1}#summary_close{display:none}#references_second{padding-top:0;border-top:0;margin-top:-10px;border-top-left-radius:0;border-top-right-radius:0} .article_byline{color:#222;font-size:12px;overflow:auto}#intro .article_byline p{line-height:1rem;margin:0}#recipe_byline{line-height:24px; }#coauthor_byline{margin-bottom:.75rem}#byline_info{line-height:1rem}#coauthor_byline p,#coauthor_byline p a{color:#595959}.last_updated_highlighted{font-weight:bold}#coauthor_byline p:last-child{padding-top:.1em}.coauthor_link{font-weight:bold;padding-right:.5em}.coauthor_checkstar{padding-right:1.2em;background:right center / .9em no-repeat; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 41.1 40.6'%3E%3Cpath fill='%23307530' d='M41.1 21.4c.1-1.6-1.5-3.1-3.9-4 2-1.7 2.9-3.7 2.3-5.2-.6-1.4-2.6-2.1-5-1.9.9-2.3.9-4.3-.2-5.4-1.2-1.1-3.3-.8-5.4.4-.1-2.5-1-4.4-2.5-4.8-1.6-.5-3.4.8-4.9 3C20.3 1.2 18.6-.2 17 .1c-1.6.3-2.7 2.1-3 4.6-2-1.5-4.1-1.9-5.4-1-1.4.9-1.6 2.9-.9 5.2-2.4-.4-4.4 0-5.2 1.4-.8 1.4 0 3.4 1.7 5.3-2.5.7-4.2 2-4.2 3.6-.1 1.6 1.5 3.2 3.9 4C2 25 1 27 1.7 28.5c.6 1.5 2.6 2.1 5 1.9-.9 2.3-.9 4.3.2 5.4 1.2 1 3.3.8 5.4-.4.1 2.5 1 4.3 2.5 4.8 1.6.5 3.4-.8 4.9-3 1.2 2.3 2.9 3.7 4.5 3.4 1.6-.3 2.7-2.1 3-4.6 2 1.5 4.1 1.9 5.4 1 1.3-.9 1.5-3 .8-5.3 2.4.4 4.4 0 5.2-1.4.8-1.4 0-3.4-1.7-5.3 2.5-.7 4.2-2 4.2-3.6z'/%3E%3Cpath fill='%23FFF' d='M30.2 16.5L19.1 27.6c-.2.2-.6.3-.9 0l-7.3-5.9c-.6-.6-.6-.9 0-1.5l2-2c.8-.8 1-.6 1.6 0l3.6 2.8c.2.2.6.2.8-.1l7.9-8.1c.6-.6.9-.7 1.5 0l2 2c.6.8.7.9-.1 1.7z'/%3E%3C/svg%3E")}.coauthor_avatar_badge{height:19px;width:19px;position:absolute;margin:37px 0 0 37px;z-index:1; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 41.1 40.6'%3E%3Cpath fill='%235b734c' d='M41.1 21.4c.1-1.6-1.5-3.1-3.9-4 2-1.7 2.9-3.7 2.3-5.2-.6-1.4-2.6-2.1-5-1.9.9-2.3.9-4.3-.2-5.4-1.2-1.1-3.3-.8-5.4.4-.1-2.5-1-4.4-2.5-4.8-1.6-.5-3.4.8-4.9 3C20.3 1.2 18.6-.2 17 .1c-1.6.3-2.7 2.1-3 4.6-2-1.5-4.1-1.9-5.4-1-1.4.9-1.6 2.9-.9 5.2-2.4-.4-4.4 0-5.2 1.4-.8 1.4 0 3.4 1.7 5.3-2.5.7-4.2 2-4.2 3.6-.1 1.6 1.5 3.2 3.9 4C2 25 1 27 1.7 28.5c.6 1.5 2.6 2.1 5 1.9-.9 2.3-.9 4.3.2 5.4 1.2 1 3.3.8 5.4-.4.1 2.5 1 4.3 2.5 4.8 1.6.5 3.4-.8 4.9-3 1.2 2.3 2.9 3.7 4.5 3.4 1.6-.3 2.7-2.1 3-4.6 2 1.5 4.1 1.9 5.4 1 1.3-.9 1.5-3 .8-5.3 2.4.4 4.4 0 5.2-1.4.8-1.4 0-3.4-1.7-5.3 2.5-.7 4.2-2 4.2-3.6z'/%3E%3Cpath fill='%23FFF' d='M30.2 16.5L19.1 27.6c-.2.2-.6.3-.9 0l-7.3-5.9c-.6-.6-.6-.9 0-1.5l2-2c.8-.8 1-.6 1.6 0l3.6 2.8c.2.2.6.2.8-.1l7.9-8.1c.6-.6.9-.7 1.5 0l2 2c.6.8.7.9-.1 1.7z'/%3E%3C/svg%3E")}.coauthor_circle_i{padding-left:1.2em;background:left 1px / .9em no-repeat; background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle fill='%23307530' cx='50' cy='50' r='50'/%3E%3Crect fill='%23FFF' x='42' y='39' width='16' height='42' rx='4'/%3E%3Ccircle fill='%23FFF' cx='50' cy='26' r='9'/%3E%3C/g%3E%3C/svg%3E")}#coauthor_image{float:left;margin:3px 10px 0 0;border-radius:16%;width:50px;height:50px;max-width:50px;overflow:hidden}.article_byline .sp_star_section_upper{margin-bottom:-4px;min-width:115px}.byline_extra{white-space:nowrap}.byline_references{background:left center no-repeat; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9.12 11.86'%3E%3Cg opacity='.8'%3E%3Cpath fill='%23595959' d='M8.66,2.74H1.82a.92.92,0,0,1,0-1.83H8.66A.46.46,0,0,0,9.12.46.46.46,0,0,0,8.66,0H1.82A1.83,1.83,0,0,0,0,1.82V10a1.84,1.84,0,0,0,1.82,1.83H8.66a.47.47,0,0,0,.46-.46h0V3.19a.46.46,0,0,0-.46-.45Zm-6.84,8.2A.91.91,0,0,1,.91,10V3.39a1.74,1.74,0,0,0,.91.26H8.21V11Zm7.3-9.12a.45.45,0,0,1-.45.46H1.82a.46.46,0,0,1,0-.91H8.66a.46.46,0,0,1,.46.45Z'/%3E%3C/g%3E%3C/svg%3E");padding-left:1.2em}#coauthor_byline p > *{margin-right:.5em}.success_stories{padding-right:.3em}.ss_pipe{color:#e9e7e3}.byline_success{white-space:nowrap;background:left center / 1em no-repeat; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16.276 15.081'%3E%3Cg transform='translate(-44.1 -201.134)'%3E%3Cpath d='M57.213 209.537v6.107a.572.572 0 01-.571.571h-8.858a.572.572 0 01-.571-.571v-6.107a.572.572 0 01.571-.571.585.585 0 01.14.023.508.508 0 01.315.2.6.6 0 01.117.35v3.508h6.119a.571.571 0 110 1.142h-6.12v.886h7.716v-5.536a.571.571 0 011.142 0z' fill='%2397ba78'/%3E%3Cpath d='M52.213 201.134l-.606 1.224a2.5 2.5 0 00-1.876 2.471.541.541 0 01-.07.268.563.563 0 01-.769.233 2.322 2.322 0 00-1.177-.291H47.7a2.5 2.5 0 00-2.459 2.552 2.538 2.538 0 001.97 2.517l.711-1.119a.508.508 0 01.315.2l-1.026 2.075a3.708 3.708 0 01.5-7.366 4.032 4.032 0 01.979.128 3.617 3.617 0 013.523-2.892z' fill='%2397ba78'/%3E%3Cpath d='M52.259 201.134l.606 1.224a2.5 2.5 0 011.876 2.471.541.541 0 00.07.268.563.563 0 00.769.233 2.322 2.322 0 011.177-.291h.012a2.5 2.5 0 012.459 2.552 2.538 2.538 0 01-1.97 2.517l-.711-1.119a.509.509 0 00-.315.2l1.026 2.075a3.708 3.708 0 00-.5-7.366 4.032 4.032 0 00-.979.128 3.617 3.617 0 00-3.52-2.892z' fill='%2397ba78'/%3E%3Cpath d='M48.146 205.709a2.253 2.253 0 00-2.209 2.274.564.564 0 001.126 0 1.091 1.091 0 011.069-1.113h.014a.581.581 0 000-1.161z' fill='%2397ba78'/%3E%3Cpath d='M51.064 202.568a2.763 2.763 0 012.347 0l-1.042-1.434H52.1z' fill='%2397ba78'/%3E%3C/g%3E%3C/svg%3E");padding-left:1.2em}#coauthor_byline p a.eat_tag{font-weight:600;padding-left:1.3em;background:left center / 1em no-repeat; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 7.154 7.154'%3E%3Cg transform='translate(-58.981 -26.634)' opacity='.8'%3E%3Cpath d='M64.456 29.509l-2.2 2.2a.125.125 0 01-.177 0l-1.446-1.169c-.119-.119-.119-.179 0-.3l.4-.4c.158-.159.2-.119.317 0l.713.554a.105.105 0 00.148-.006l.01-.013 1.565-1.6c.119-.119.178-.137.3 0l.4.4c.108.156.128.175-.03.334z' fill='%23595959'/%3E%3Crect width='6.554' height='6.554' rx='1.689' transform='translate(59.281 26.934)' fill='none' stroke='%23595959' stroke-miterlimit='10' stroke-width='.6'/%3E%3C/g%3E%3C/svg%3E")}.eat_tag:hover{text-decoration:none}.sp_expert_text{line-height:52px;text-align:left;margin-left:65px}.sp_expert_text > div{line-height:normal;display:inline-block;vertical-align:middle;margin:0 auto;color:#222}.sp_expert_name,.sp_expert_team{font-size:16px;font-weight:bold}.sp_expert_blurb{font-weight:normal}.sp_coauthor_label{font-size:.85em;font-weight:bold;color:#545454}.ar_avatar{width:50px;height:50px;overflow:hidden;position:absolute;border-radius:16%;margin-top:2px;box-sizing:border-box}.expert_initials{background:#97ba78;color:#475346;text-align:center;font-size:22px;font-weight:bold;line-height:50px}.sp_top_icon_bg{margin:0;position:absolute;width:50px;height:50px;background-color:#ADC996;border-radius:16%}.sp_top_icon_bg > div{background-repeat:no-repeat}#trust_banner{width:100%;position:relative;z-index:1;box-sizing:border-box;background-color:#e4ecdc;padding:.5em 15px;font-size:12px;line-height:1em;top:40px}#trust_banner > div{max-width:728px;margin:0 auto}#trust_banner a{color:#417505;padding-left:1.5em;font-weight:normal; background:url(/skins/owl/images/sp_expert_icon_white.svg) left center / 1.1em no-repeat}#trust_banner span{display:none}.sp_star_section_upper{display:inline-block}.sp_star_container{position:relative;width:21px;height:20px;float:left;border-right:2px solid transparent;background:url(/skins/owl/images/sp_helpful_icon_star_empty.optimized.svg) 0 0 / cover no-repeat}.sp_helpful_icon_star{width:100%;height:100%;position:absolute;background:url(/skins/owl/images/sp_helpful_icon_star.optimized.svg) 0 0 / cover no-repeat}.pretty_star,.sp_helpful_box .recipe_star{ background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 26.028 24.652'%3E%3Cpath fill='%2393B874' d='M13.014 0l4.022 8.115 8.992 1.301-6.507 6.316 1.536 8.919-8.043-4.211-8.043 4.211 1.536-8.919L0 9.416l8.992-1.301L13.014 0z'/%3E%3C/svg%3E")}.recipe_star{ background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 26.028 24.652'%3E%3Cpath fill='%23fecf4f' d='M13.014 0l4.022 8.115 8.992 1.301-6.507 6.316 1.536 8.919-8.043-4.211-8.043 4.211 1.536-8.919L0 9.416l8.992-1.301L13.014 0z'/%3E%3C/svg%3E")} @media only screen and (min-width:500px) and (min-aspect-ratio:13/9){.content .sticking .edit-page{margin-right:50px}}@media only screen and (min-width:768px){.mwimg{border-bottom:none}.related-article{width:48%;margin-right:2%}}@media only screen and (max-width:320px){#gdpr_text{max-width:72%}#gdpr{padding:5px 0 6px;max-height:70px}.gdpr_button,button.gdpr_button{font-size:0.7em;max-width:45px}}@media only screen and (max-width:300px){#gdpr_text{font-size:0.8em;max-width:78%}.gdpr_button,button.gdpr_button{margin-left:3px;padding:4px 8px 5px}}@media only screen and (min-width:450px){#gdpr_text{max-width:80%}.gdpr_button,button.gdpr_button{margin-left:10px}}@media only screen and (min-width:600px){#gdpr{padding:13px 5px 14px}#gdpr_text{max-width:88%}.gdpr_button{margin-left:10px;padding:1px 6px}}@media only screen and (device-width:375px) and (device-height:812px) and (-webkit-device-pixel-ratio:3){#gdpr{padding-bottom:15px}}.skin-minervawh .content .section-heading{margin-bottom:0}.content ol{list-style:decimal inside}.content .in-block.steps_text{display:block}.mw-mf-cleanup{display:block;padding:10px 15px 10px 44px;background:url(/extensions/wikihow/MobileFrontendWikihow/images/wikihow/icon-notification.svg) 10px center / 24px no-repeat;margin-bottom:4px}.overlay-issues .cleanup > li .issue-notice{padding-top:50px}  #sidebar #jpt_sidebox{padding:0;background-color:#f6f5f4}#jpt_header{padding:16px;font-weight:bold}.jpt_container{border-bottom:1px solid #ecebe8;padding:5px 16px;background-color:#fff;display:block;width:268px;height:61px}.jpt_container:last-child{border-bottom:none}.jpt_container:hover{text-decoration:none}.jpt_container img{vertical-align:middle;margin:5px 10px 5px 13px;width:50px;height:50px}.jpt_count{font-size:22px;color:#ecebe8;font-weight:bold;vertical-align:middle}.jpt_container:hover .jpt_count{color:#93b874}.jpt_title{font-size:14px;display:inline-block;width:182px;color:#686868;vertical-align:middle}#footer_ccpa,#footer_ccpa_optout{display:none}.reference.trusted{background:url(/skins/owl/images/sp_expert_icon_white.svg) no-repeat right 2px/12px;padding-right:14px;display:inline-block}.reference{position:relative} .bolded{font-weight:bold;font-size:14px}.steps_text.healthintro{margin-bottom:0;border-bottom-right-radius:0;border-bottom-left-radius:0}.healtharticle{margin-bottom:25px}#contribute_footer_inner{margin:0 auto;color:#545454;max-width:728px;padding:15px 20px;position:relative;font-size:14px;text-align:left}#contribute_close{position:absolute;right:10px;top:5px;z-index:1}#contribute_footer_inner a{color:#545454;font-weight:bold}#contribute_footer_inner a.button{color:#668051;border:1px solid #668051;background-color:#fff;border-radius:7px;text-align:center;display:inline-block;padding:5px 20px;font-weight:bold}a.pdf_link{color:#545454;border-radius:4px}.small_pdf_link{display:inline-flex;font-size:12px;margin:-5px 0 10px;padding:.35em;border:1px solid #e7e7e7;background-color:#f6f6f6}.pdf_link > img{width:15px;margin-right:5px}.large_pdf_link{display:none}.pdf_link.pdf_link_hidden{display:none !important}a.pdf_link.disabled{pointer-events:none;opacity:.2}a.pdf_link:hover,a.pdf_link:active{text-decoration:none}.pdf_link > div{display:inline-block;font-size:10px;color:#FFF;background:#FFCF5A;border-radius:2px;margin-left:.75em;padding:0 .5em;height:16px;line-height:17px}.test_list_article .steps .section_text{background-color:#FFF;border-radius:4px;padding-bottom:20px}.test_list_article .steps .section_text ul{margin:0 20px 0 20px}.test_list_article li b{font-weight:normal }.test_list_method .steps .altblock{background:#93b874;color:#FFF;text-align:center;padding:0;border-radius:4px 0 0 0;font-size:0;width:3.5rem;height:3.5rem;display:table;position:absolute}.test_list_method .steps .altblock > div{display:table-cell;vertical-align:middle}.test_list_method .steps .altblock > div > span{font-size:21px;font-weight:bold}.test_list_method .steps h3 span.mw-headline{display:table-cell;vertical-align:middle;padding:0 0 0 4.5rem;width:100%;height:3.45rem}.test_list_method .method_of_count,.test_list_method .step_num{display:none}.test_list_method .step,.test_list_method li{font-size:18px;line-height:26px}.test_list_method #mf-section-0 p{font-size:18px;line-height:26px} #sd_container{border:none}#sd_container{padding:15px;background-color:#FFF;-moz-border-radius:4px;-webkit-border-radius:4px;border-radius:4px;display:-ms-flexbox;display:-webkit-flex;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-justify-content:space-around;-ms-flex-pack:distribute;justify-content:space-around;-webkit-align-items:stretch;-ms-flex-align:stretch;align-items:stretch}.sd_content{width:125px;margin:auto}.sd_thumb{position:relative;text-align:center;width:100%;max-width:200px;margin:6px}.sd_thumb img{border:1px solid #BBB;width:100%;height:auto} .qa_user_hover{display:none} .qa_answers{position:relative}.qa_obscured_prompt{display:block;position:absolute;left:0;top:3.75em;right:0;bottom:0;background-color:rgba(255,255,255,0.5);z-index:2}.qa_unlocked .qa_obscured_prompt{display:none}.sd_obscured_link{position:absolute;left:0;top:0;bottom:0;right:0;cursor:pointer}.qa_obscured_answer_overlay,.sd_obscured_thumb_overlay{position:absolute;background-color:#F7FAF5;box-shadow:1px 1px 6px rgba(0,0,0,0.41);border-radius:5px;padding:10px 15px;z-index:1;box-sizing:border-box;display:table}.qa_obscured_answer_overlay{left:1em;top:0.5em;text-shadow:none;color:initial;min-height:72px;max-width:85%}.sd_obscured_thumb_overlay{font-size:smaller}.qa_obscured_answer_overlay:hover,.sd_obscured_link:hover .sd_obscured_thumb_overlay{background-color:#F2F6EB}.qa_obscured_answer_overlay a,.sd_obscured_thumb_overlay a{font-weight:bold}.qa_obscured_answer_overlay a:hover,.sd_obscured_link:hover .sd_obscured_thumb_overlay a{text-decoration:none}.qa_obscured_answer_overlay_img,.sd_obscured_thumb_overlay_img{position:absolute;border:none !important}.qa_obscured_answer_overlay_img{width:37px !important}.sd_obscured_thumb_overlay_img{width:24px !important}.qa_obscured_answer_overlay p,.sd_obscured_thumb_overlay p{display:table-cell;vertical-align:middle;text-align:left;padding:0 0 0 52px;margin:0}#sd_container .sd_thumb .sd_obscured_thumb_overlay p{line-height:18px}.sd_obscured_thumb_overlay p{padding:0 0 0 32px}.qa_obscured_answer_overlay p strong,.sd_obscured_thumb_overlay p strong{color:#307530}.qa_answer.qa_obscured_answer{margin:1em 0 0 0;color:transparent;text-shadow:0 0 5px rgba(0,0,0,0.5)}.sd_obscured_prompt{padding-top:25%}.qa_obscured_cta{position:absolute;right:0;top:0;bottom:0;font-size:0.7em;font-weight:normal;text-align:right;background-color:#FDF5D1;padding:13px;border-top-right-radius:4px;max-width:62%}.qa_obscured_cta_pitch{display:block;font-weight:bold}.qa_obscured_cta_link{display:inline-block;font-weight:bold}@media only screen and (max-width:727px){.qa_obscured_cta{display:none}}#eu_cp_save{display:none}.menuitem.top_cat{padding-left:25px;font-size:14px;line-height:22px}#promopair_container{display:none}#housebottom_ad{display:none}.house-promo{display:none}#left_sidebox{display:none}@media only screen and (max-width:727px){.sample_initial_location{display:none}}#footer_links li{word-break:break-word}.m-video-intro-over{position:absolute;top:0;z-index:3;width:100%;visibility:hidden;background:rgba(0,0,0,.3);height:100%}.section.summary_with_video h2{background-color:#93b874;color:#fff;border-radius:4px 4px 0 0;border-bottom:0}.summary_with_video h2 span.mw-headline{color:#FFF}.m-video-play-count-triangle{width:0;height:0;border-top:11px solid rgba(145,182,115,1);border-bottom:11px solid rgba(145,182,115,1);border-left:20px solid #fff;display:inline-block;position:absolute;top:19px;left:20px;background-image:none}.m-video-intro-over .m-video-play{border:none;width:74px;height:60px;padding-left:47px;line-height:60px;color:#fff;font-size:18px;top:0;bottom:0;font-weight:bold;margin:auto;position:absolute;left:0;right:0;text-align:left;cursor:default;user-select:none}.m-video-intro-over .m-video-play-text{background-color:#91b673;border-radius:10px;padding-right:21px;padding-left:47px;margin-left:-47px;display:inline-block;white-space:nowrap}.m-video::-webkit-media-controls-overlay-play-button{display:none}.m-video-controls{position:absolute;left:0;right:0;top:0;bottom:0}.m-video-intro-text:nth-child(1){font-size:2em}.m-video-intro-text.m-video-intro-text-long{font-size:1.5em}.m-video-intro-text.m-video-intro-text-very-long{font-size:1em}#m-video-intro-time-v2{bottom:-11px;font-size:1.2em;height:48px;width:43px;line-height:2.65em}.embedvideo_gdpr_message{font-size:12px;font-weight:normal;line-height:14px;padding-left:5px;display:none}.embedvideo_gdpr_label{background:url(/skins/owl/images/sp_icon_info.png); background:url(/skins/owl/images/sp_icon_info.svg);background-size:14px;background-repeat:no-repeat;height:14px;padding-left:8px;margin-bottom:2px;vertical-align:bottom;cursor:pointer;overflow:hidden;display:inline-block}#show_embedvideo_gdpr_block{display:none}#show_embedvideo_gdpr_block:checked ~ .embedvideo_gdpr_message{display:block}#show_embedvideo_gdpr_block:checked ~ .edit-page{background-position-y:calc(75% - 9px)}.geo-group-eu .gdpr_only{visibility:visible}.geo-group-eu .no_gdpr{visibility:hidden}.video .mw-headline{display:inline}.header .search{display:table-cell}.header .search .cse_q{width:25px;height:25px;padding-right:25px}.header .search .cse_q:focus{position:absolute;left:5px;top:5px;right:5px;width:auto}.header .search .cse_sa{background-color:transparent;background-image:url(/extensions/wikihow/mobile/images/gray_mag.png); background-image:url(/extensions/wikihow/mobile/images/gray_mag.svg);background-size:25px 25px;background-repeat:no-repeat;background-position:center center;width:25px;height:25px;border:none;margin:0;padding:0;cursor:pointer;right:10px}#mw-mf-viewport{background-color:#E9E7E3}#mw-mf-viewport.menuopen{overflow:auto}#sidebar{display:none}.section.bss_share_container{margin-top:0;text-align:center}.bss_share_title.section-heading{border:0}.bss_share_container .section_text{padding-top:0px}.bss_share_button.button.secondary{display:inline-block;font-weight:bold;color:#97ba78;border:1px #97ba78 solid;background-color:#fff;margin-right:0}@media only screen and (min-width:768px){.sp_num_votes{margin-top:2px}.section .bss_share_button.button.secondary{width:75%}}</style>
+<script>WH.mediumScreenMinWidth=728;WH.largeScreenMinWidth=975;WH.shared=function(){function p(a){null==q&&(q=new IntersectionObserver(function(a,c){a.forEach(function(a){a.isIntersecting&&(g[a.target.id].load(),q.unobserve(a.target))})},{rootMargin:z}));q.observe(a)}function A(a){u.push(a)}function B(a,b){var c=null,d=0,e=function(){d=0;c=null;a.apply()};return function(){var f=J(),g=b-(f-d);0>=g||g>b?(c&&(clearTimeout(c),c=null),d=f,a.apply()):c||(c=setTimeout(e,g))}}function v(){console.log("updateVisibility");var a=!1,b=window.innerHeight||document.documentElement.clientHeight,c;for(c in g){var d=g[c];if(!d.isLoaded){a=d;var e=a.element.getBoundingClientRect(),f={top:e.top,bottom:e.bottom};0==a.lastTop-e.top&&window.scrollY!=a.lastY&&(f.top-=window.scrollY,f.bottom-=window.scrollY);a.lastTop=e.top;a.lastY=window.scrollY;a=f;e=b;f=52;var h=2*e;f-=h;e+=h;(0==a.top&&0==a.bottom?0:a.top>=f&&a.top<=e||a.bottom>=f&&a.bottom<=e||a.top<=f&&a.bottom>=e)&&d.load();a=!0}}!a&&g.length&&(window.
+removeEventListener("scroll",l),l=null)}function w(a){if(a&&a.element){var b=!0;a.element.className||(b=!1);-1==a.element.className.indexOf("content-fill")&&(b=!1);if(b&&document.addEventListener&&a.finishedLoadingEvent){a.loaderRemoved=!1;b=document.createElement("div");b.className="loader";for(var c=0;3>c;c++){var d=document.createElement("div");d.className="loader-dot";b.appendChild(d)}var e=document.createElement("div");e.className="loading-container";e.appendChild(b);a.element.parentElement.insertAdjacentElement("afterbegin",e);a.element.addEventListener(a.finishedLoadingEvent,function(){a.loadedCallback&&a.loadedCallback();0==a.loaderRemoved&&(this.parentElement.removeChild(e),a.loaderRemoved=!0,"undefined"!==typeof a.element.classList&&a.element.classList.remove("img-loading-hide"));a.alt&&(a.element.alt=a.alt,"undefined"!==typeof a.element.classList&&a.element.classList.remove("img-loading-alt"))});a.errorEvent&&a.element.addEventListener(a.errorEvent,function(){a.alt&&(a.
+element.alt=a.alt)})}else a.alt&&(a.element.alt=a.alt),"undefined"!==typeof a.element.classList&&a.element.classList.remove("img-loading-hide")}}function x(a){if(!a)return"";if(!h)return a;var b=a.split(".").pop();"jpg"!==b&&"png"!==b||!a.match(/images(_[a-z]{2})?\/thumb\//)||a.match(/(\.[a-zA-Z]+){2}$/)||(a+=".webp");return a}function K(a){this.isLoaded=!1;this.element=a;k||(this.lastY=window.scrollY,this.lastTop=a.getBoundingClientRect().top);this.src=a.getAttribute("data-src");this.load=function(){this.element.setAttribute("src",this.src);this.isLoaded=!0}}function C(a){this.isLoaded=!1;this.element=a;k||m||(this.lastTop=a.getBoundingClientRect().top,this.lastY=window.scrollY);this.alt=a.alt;a.alt="";this.finishedLoadingEvent="load";this.errorEvent="error";if(n){var b=a.getAttribute("data-srclarge");null!=b&&(this.src=b)}this.src||(this.src=a.getAttribute("data-src"));this.src=x(this.src);a&&void 0!==a.classList&&a.classList.add("img-loading-hide");this.load=function(){this.element.
+setAttribute("src",this.src);this.isLoaded=!0;w(this)}}function L(a){this.isLoaded=!1;this.element=a;k||(this.lastTop=a.getBoundingClientRect().top,this.lastY=window.scrollY);this.finishedLoadingEvent="loadeddata";this.isPlaying=!1;this.src="https://www.wikihow.com/video"+this.element.getAttribute("data-src");this.poster=this.element.getAttribute("data-poster");(this.poster=x(this.poster))&&"jpg"==this.poster.split(".").pop()&&h&&(this.poster+=".webp");this.noAutoplay=this.element.getAttribute("data-noautoplay");this.play=function(){this.element.play();this.isPlaying=!0};this.pause=function(){this.element.pause();this.isPlaying=!1};this.load=function(){this.element.setAttribute("poster",this.poster);!D||this.noAutoplay||!n&&!0!==window.wgIsMainPage?this.finishedLoadingEvent=null:(this.element.setAttribute("src",this.src),this.play());this.isLoaded=!0;this.noAutoplay||w(this)}}function r(a){var b=document.getElementById(a);if(b)if(h||E){a=!1;var c=null,d=b.nodeName.toLowerCase();if(
+"img"===d)c=new C(b),m?(d=c,d.element.classList.remove("img-loading-hide"),d.element.classList.add("img-loading-alt"),d.element.setAttribute("loading","lazy"),d.load()):k?p(c.element):a=!0;else if("video"===d)c=new L(b),k?p(c.element):a=!0;else if("iframe"===d)c=new K(b),k?p(c.element):a=!0;else if("picture"===d)if(d=b.getElementsByTagName("img")[0],m){t?(d.width=d.dataset.width,d.height=d.dataset.height):(d.width=d.dataset.widthlarge,d.height=d.dataset.heightlarge);d.src=d.dataset.src;d=b.getElementsByTagName("source");for(var e=0;e<d.length;e++){var f=d[e];f.srcset=f.dataset.srcset}}else c=document.createElement("div"),c.className="content-spacer",b.appendChild(c),d.id="picture_"+M++,d.classList.add("content-fill"),c.appendChild(d),c=new C(d),useObserver?p(c.element):a=!0,b=d;else return;c&&(g[c.element.id]=c);d=b.getAttribute("data-width")||b.getAttribute("width");e=b.getAttribute("data-height")||b.getAttribute("height");0<d&&(b.parentElement.style.paddingTop=e/d*100+"%");F?c.load()
+:a&&(v(),l=B(v,500),window.addEventListener("scroll",l))}else G.push(a)}var u=[],g={},G=[],l,F=!1,J=Date.now||function(){return(new Date).getTime()},h=!1,E=!1,y=window.innerWidth||document.documentElement.clientWidth,t=y<WH.mediumScreenMinWidth,H=!t&&y<WH.largeScreenMinWidth,I=!t&&!H,n=I,z="0px 0px 100% 0px",M=1,m="loading"in HTMLImageElement.prototype,k="IntersectionObserver"in window,q=null;(function(a){var b=new Image;b.onload=function(){a(0<b.width&&0<b.height)};b.onerror=function(){a(!1)};b.src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA"})(function(a){h=a;E=!0;G.forEach(function(a){r(a)})});1==WH.jsFastRender&&(m=!1,z="0px 0px 0px 0px");window.onresize=function(){u.forEach&&u.forEach(function(a){a()})};A(v);var D=function(){var a=window.document.createElement("video");a.setAttribute("muted","");a.setAttribute("playsinline","");a.setAttribute("webkit-playsinline","");a.muted=!0;a.playsinline=!0;a.webkitPlaysinline=!0;a.setAttribute("height","0"
+);a.setAttribute("width","0");a.style.position="fixed";a.style.top=0;a.style.width=0;a.style.height=0;a.style.opacity=0;try{var b=a.play();b&&b.catch&&b.then(function(){}).catch(function(){})}catch(c){}return!a.paused}();window.addEventListener?window.addEventListener("scroll",l):F=!0;return{isDesktopSize:n,isSmallSize:t,isMedSize:H,isLargeSize:I,viewportWidth:y,getScreenSize:function(){var a=document;var b=a.documentElement,c=a.body,d=c&&c.clientWidth,e=0;!b||!b.clientWidth||"CSS1Compat"!==a.compatMode&&d?d&&(e=c.clientWidth):e=b.clientWidth;a=e;return 0==a||a>=WH.largeScreenMinWidth?"large":a>=WH.mediumScreenMinWidth?"medium":"small"},throttle:B,TOP_MENU_HEIGHT:52,autoPlayVideo:D,webpSupport:h,addScrollLoadItem:r,addLazyImage:function(a){var b=document.getElementById(a);if(!n&&h&&m)c=b.getAttribute("data-src-large"),n&&c||(c=b.getAttribute("data-src")),b.setAttribute("src",c);else{var c=b.getAttribute("data-src-nowebp");c||(c=b.getAttribute("data-src"),5<c.length&&".webp"==c.substr(c
+.length-5)&&(c=c.substr(0,c.length-5)));b.setAttribute("data-src",c);b.setAttribute("class","content-fill");r(a)}},addScrollLoadItemByElement:function(a){var b=a.id;b||(b="id-"+Math.random().toString(36).substr(2,16));a.id=b;r(b)},videoRoot:"https://www.wikihow.com/video",setupLoader:w,addResizeFunction:A,loadAllImages:function(){for(var a in g){var b=g[a];b.isLoaded||b.load()}},loadAllEmbed:function(){for(var a in g){var b=g[a];b.isLoaded||"iframe"==b.element.nodeName.toLowerCase()&&b.load()}},addLoadedCallback:function(a,b){g[a].loadedCallback=b},showVideoPlay:function(a){a=a.element.parentElement.getElementsByClassName("m-video-intro-over");"undefined"!==typeof a&&(a=a[0]);a&&(a.style.visibility="visible")},getCompressedImageSrc:x}}();</script>
+<script>WH.gdpr=(function(){var acceptCookieName='gdpr_accept';function hasAcceptCookie(){var hasCookie=document.cookie.indexOf('gdpr_accept=');if(hasCookie>=0){return true;}return false;}function hasCookiePolicyPageOptOut(){var hasCookie=document.cookie.indexOf('gdpr_cpp_opt_out=1');if(hasCookie>=0){return true;}return false;}function hasEUQueryParam(){var url=window.location.href;if(url.indexOf('?EUtest=')!=-1){return true;}else if(url.indexOf('&EUtest=')!=-1){return true;}return false;}function isEULocation(){var value="; "+document.cookie;var parts=value.split("; vi=");var res=null;if(parts.length==2){res=parts.pop().split(";").shift();}if(hasEUQueryParam()){res="EU";}if(res=="EU"){return true;}return false;}function popupClosed(){createCookie("gdpr_accept",1,365);createCookie("gdpr_decline","",-1);gdpr.style.display="none";}function createCookie(name,value,days){var expires="; expires="+new Date(2147483647*1000).toUTCString();if(days){var date=new Date();date.setTime(date.getTime()+(days*
+24*60*60*1000));expires="; expires="+date.toGMTString();}document.cookie=name+"="+value+expires+"; path=/";}function declinePage(){var decline=document.getElementById('gdpr_decline');if(decline){decline.style.display="block";decline.addEventListener("click",function(){var cookies=document.cookie.split(";");for(var i=0;i<cookies.length;i++){createCookie(cookies[i].split("=")[0],"",-1);}createCookie("gdpr_decline",1,1);var declineConfirm=document.getElementById('gdpr_decline_confirm');if(declineConfirm){declineConfirm.style.display='block';}});}var declineOk=document.getElementById('gdpr_decline_confirm_dismiss');if(declineOk){declineOk.addEventListener("click",function(){var declineConfirm=document.getElementById('gdpr_decline_confirm');if(declineConfirm){declineConfirm.style.display='none';}});}}function cookiePage(){var cookie_policy=document.getElementById('eu_cookie_policy');if(!cookie_policy){return;}var eu_cp_save=document.getElementById('eu_cp_save');var checkbox=document.
+getElementById('eu_cookie_message_check');checkbox.addEventListener("click",function(){if(hasCookiePolicyPageOptOut()){if(this.checked==true){eu_cp_save.className='';}else{eu_cp_save.className='active';}}else{if(this.checked==true){eu_cp_save.className='active';}else{eu_cp_save.className='';}}});if(hasCookiePolicyPageOptOut()){checkbox.checked=!0;}else{checkbox.checked=!1;}cookie_policy.style.display="block";eu_cp_save.addEventListener("click",function(){var checkbox=document.getElementById('eu_cookie_message_check');if(checkbox.checked==true){createCookie('gdpr_cpp_opt_out',1,1);WH.event('gdpr_cookie_page_opt_out',{});}else{createCookie('gdpr_cpp_opt_out',0,1);WH.event('gdpr_cookie_page_opt_in',{});}eu_cp_save.className='';});WH.eventView('gdpr_cookie_page_opt_out');WH.eventView('gdpr_cookie_page_opt_in');}function pageLoaded(){if(!isEULocation()){return;}if(hasEUQueryParam()){var viValue='EU';createCookie('vi',viValue,1);}declinePage();document.body.className+=' '+'geo-group-eu'
+;var sidebarShare=document.getElementById('sidebar_share');if(sidebarShare){sidebarShare.remove();}cookiePage();}function initialize(){var isEU=isEULocation();var gdpr=document.getElementById('gdpr');if(gdpr&&isEU&&!hasAcceptCookie()){gdpr.style.display="block";}else if(gdpr){gdpr.parentNode.removeChild(gdpr);}var accept=document.getElementById('gdpr_accept');if(accept){WH.eventView('gdpr_banner_ok_click',{},'#gdpr_accept','click');WH.eventView('gdpr_banner_policy_click',{},'#gdpr_cp_link','click');WH.eventView('gdpr_banner_settings_click',{},'#gdpr_text_inner a','click');accept.addEventListener("click",function(){popupClosed()},true);}var close=document.getElementById('gdpr_close');if(close){close.addEventListener("click",function(){popupClosed()},true);}return;}return{'initialize':initialize,'pageLoaded':pageLoaded,'hasAcceptCookie':hasAcceptCookie,'hasCookiePolicyPageOptOut':hasCookiePolicyPageOptOut,'isEULocation':isEULocation};})();document.addEventListener('DOMContentLoaded',
+function(){WH.gdpr.pageLoaded();},false);</script>
+<style>.switch.large{display:none} .switch{position:relative;width:40px;height:20px;top:-5px;float:right;margin-right:0px}.switch .toggle_text{margin-left:-60px;font-size:12.4px;font-weight:bold} .switch input{opacity:0;width:0;height:0} .toggle_slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background-color:#ccc;-webkit-transition:.4s;transition:.4s}.toggle_slider::before{position:absolute;content:"";height:20px;width:20px;left:1px;bottom:4px;background-color:white;-webkit-transition:.4s;transition:.4s;top:0px}input:checked + .toggle_slider{background-color:#93B874}input:focus + .toggle_slider{box-shadow:0 0 1px #93B874}input:checked + .toggle_slider::before{-webkit-transform:translateX(18px);-ms-transform:translateX(18px);transform:translateX(18px)} .toggle_slider.round{border-radius:34px}.toggle_slider.round::before{border-radius:50%}div.articleShareIcons{display:none}div.articleShareIcons a{padding:2px}#pinterestShareRound{text-decoration:none}#pinterestShareRound > img{cursor:pointer}#rewardedweb{display:none}.related-title:hover,.related-title:visited:hover,.related-title:active:hover{background-color:white;color:#2483ef;text-decoration:none}#relatedwikihows.section_text .related-image-link{max-height:183px;overflow:hidden}.w_label:before{display:none}#intro .wh_ad_inner{line-height:0}#intro_ad_1.gam-sml{height:100px;margin-left:-15px}@media only screen and (min-width:321px){#intro_ad_1.gam-sml{margin:0 auto}}.steps .wh_ad_inner{margin-top:20px}#intro_ad_1.full-width{margin-left:-15px}#intro_ad_1.gam-lrg{height:100px;margin-left:0px;text-align:center}.dfp_small{margin:auto;max-height:250px;max-width:300px;height:250px;width:300px;margin-bottom:12px}.dfp_small_inner{text-align:center;max-height:250px;max-width:300px;height:250px;width:300px;overflow:auto}#tips > .wh_ad_inner > div > ins{margin-top:22px}.oo-ui-buttonElement-button:hover{text-decoration:none}.ur_author{margin-top:5px;color:#c3c3c3;font-weight:normal;font-style:normal;display:inline-block;height:36px;vertical-align:bottom}.ur_rating{margin-top:5px}.section.sample h3 span.mw-headline{padding-top:1em}#sample_loading{display:none}.sd_thumb{text-align:center;width:200px;margin:6px}.sd_content .sd_thumb img{border:1px solid #BBB;width:100%;height:auto}#sd_container{padding:15px;background-color:#FFF;-moz-border-radius:4px;-webkit-border-radius:4px;border-radius:4px;display:-ms-flexbox;display:-webkit-flex;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-justify-content:space-around;-ms-flex-pack:distribute;justify-content:space-around;-webkit-align-items:stretch;-ms-flex-align:stretch;align-items:stretch}.noscroll{overflow:hidden}.oo-ui-processDialog-content .oo-ui-window-head{background-image:url(/extensions/wikihow/MobileFrontendWikihow/images/dialog-header.svg);background-size:cover}#footer_newsletter{display:block;grid-column:3 / 3;grid-row:2 / span 4;min-height:166px}#footer_newsletter #footer_subscribe_icon{display:inline-block;width:25px;height:25px; background:url(/skins/owl/images/newsletter_footer.svg) no-repeat;position:relative;top:2px}#footer_newsletter #footer_subscribe_title{display:inline-block;font-weight:bold;font-size:18px;color:#444f45}#footer_newsletter #footer_subscribe_confirm_text{display:none;margin:5px 0 10px 0;font-weight:bold;font-size:14px}#footer_newsletter #footer_subscribe_text{margin:5px 0 10px 0;font-weight:bold;font-size:12px}#footer_newsletter #footer_subscribe_email{box-sizing:border-box;background:white;margin-bottom:10px;padding:5px 10px;border-radius:5px;border:1px solid #ffffff;font-size:16px;width:180px}#footer_newsletter #footer_subscribe_email.error{border:1px red solid}#footer_newsletter #footer_subscribe_notice{margin:4px auto;font-size:12px;width:180px;line-height:13px}#footer_newsletter a#footer_subscribe_button{display:block;background:#444f45;font-weight:bold;color:#FFF;margin:0 auto;padding:2px .7em;box-sizing:border-box;border-radius:5px;width:182px;border:none}.related-wh{display:block;margin-bottom:2%;overflow:hidden}.related-wh-title{background-color:rgba(50,50,50,0.5);padding:2% 4%;width:92%;min-height:32px;position:absolute;bottom:0;cursor:pointer;color:#fff;font-weight:bold}.related-wh-howto{font-size:12px}.medium_a{display:none} #watchtheserelatedvideos{display:grid;grid-template-columns:1fr;grid-gap:10px}#watchtheserelatedvideos a{display:block;position:relative;color:#444f45;border:1px solid #dfdfdf;border-radius:7px;text-decoration:none}#watchtheserelatedvideos .play_button{position:absolute;width:64px;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1}#watchtheserelatedvideos img{display:block}#watchtheserelatedvideos img:not(.play_button){border-top-left-radius:7px;border-top-right-radius:7px}#watchtheserelatedvideos .related-expert-title{left:0;z-index:2;padding:5px;font-size:16px;font-weight:bold}#watchtheserelatedvideos .related-expert-title .related-wh-howto{font-weight:normal}@media only screen and (min-width:728px){.switch.small{display:none}.switch.large{display:block}.switch{top:0px;margin-right:-295px}.medium_a{display:block}.related-wh{float:left;width:48%;margin-right:2%}.sd_thumb{width:200px}div.articleShareIcons{display:block;position:relative;float:right;top:0px}.gdpr_button,button.gdpr_button{vertical-align:baseline;margin-bottom:0;margin:0 auto}#gdpr_text{position:relative}#gdpr_cp_link{position:absolute;width:155px;right:-230px;top:2px}#gdpr_text_inner{padding-right:0}#gdpr_accept_wrap{width:70px}#housebottom_ad_1{display:block;padding-top:25px}.house-promo{display:block}#hausead-img-wrap{display:block;position:relative}#intro_ad_1.full-width{margin-left:0}.test_list_article .steps .section_text ul{margin:0 26px 0 26px}.test_list_article .section_text{background-color:#FFF;border-radius:0 0 4px 4px;font-size:16px}.test_list_method .steps .altblock{height:60px}.test_list_method .steps h3 span.mw-headline{height:58px}.test_list_method .steps .wh_ad_inner.al_grey{display:block}.menu{font-size:1rem;position:absolute;border:1px solid #91af79;margin:0;padding:10px 0;top:71px;z-index:1000;background-color:#f9f9f9;display:none;right:0}.menu a{display:block;padding:0 20px 0 15px;line-height:26px;color:#669933}#AdminOptions.menu a{color:#363}.menu a:hover{color:white;background-color:#91af79;text-decoration:none}#AdminOptions.menu a:hover{color:white}.admin_arrow{width:0;height:0;border-left:3px solid transparent;border-right:3px solid transparent;border-top:5px solid #AAAAAA;display:inline-block;margin-left:3px;margin-bottom:1px}.menu a.admin_tab_hide{display:none} #actionbar{position:relative;height:35px;margin-top:-10px;z-index:2} .is-authenticated #actionbar{display:block}ul#tabs{position:absolute;top:0px;left:2px;margin:0px;padding:0px}ul#tabs li{float:left;list-style:none;padding:0px;margin:0px;padding-right:15px;line-height:2em}ul#tabs li a{font-size:13px;font-weight:500}ul#tabs li a.on{color:#454545;font-weight:bold}.mobile_tab:first-child{margin-left:2.3em}#AdminOptions{position:absolute;top:30px;font-size:1em;border:1px solid #91af79;color:#363;margin:0;background-color:#f9f9f9;width:100%;width:-moz-max-content;width:-webkit-max-content;width:-o-max-content}ul#AdminOptions li{padding-left:0px}#content_wrapper{margin:1em auto;max-width:1050px;padding:40px 1em 1em}#content_inner{width:100%;max-width:728px;margin:0 auto;position:relative}.full_width #content_wrapper,.full_width #content_inner{max-width:initial;padding-left:0;padding-right:0}.stable .content p,.stable .content li,.stable .content dl{line-height:25px}.stable .content .steps_list_2 ul,.stable .content .steps_list_2 ol{margin-left:55px;margin-top:5px;padding:0}#trust_banner{border-radius:4px 4px 0 0;font-size:14px}#trust_banner span{display:inline}#breadcrumb{padding:1.1em 0 0.8em 26px;color:#307530}div.articleShareIcons{margin-right:10px;margin-top:-25px}.article_byline{color:#545454;font-size:.85em}.article_byline#recipe_byline{padding-top:0}.article_byline p{font-size:.9em;line-height:1.2rem}.coauthor_checkstar{background-position:right 1px}#byline_info{line-height:1.2rem}.byline_success{background-position:left 40%}#mobile_tab_container{display:none}#section_0{padding:26px 26px 0;line-height:normal}#section_0.special_title{font-size:35px}.ns-0.action-view #section_0{padding:0 26px}#intro{font-size:1em;margin:0;border-radius:0 0 4px 4px;padding:7px 26px}#intro p{line-height:25px}#intro .mwimg{margin:10px 0px}#intro .mwimg img{border-radius:3px}.mw-mf-cleanup{display:none}#method_toc{display:block;position:static;font-size:12px;font-weight:bold;line-height:1.65em;color:#222222;float:right;background-color:#f6f8f7;border-radius:6px;width:260px;padding:8px 15px 15px 15px;margin:2px 0 10px 10px;clear:right}#method_toc .hidden,#method_toc a.hidden,#method_toc #toc_showless{display:none}#method_toc span{margin-right:.75em}#method_toc .sp_method_toc{margin:3px -26px;border:0 26px;padding:10px 26px;border:0;color:#222222;background-color:#f6f8f7;font-size:12px;font-weight:bold;line-height:1.65em}#method_toc .header_toc{width:100%;padding-bottom:5px;color:#444;line-height:normal}#method_toc.en_toc .method_toc_item a{background-repeat:no-repeat;background-size:17px}#method_toc.en_toc .toc_method a > span{background-color:#94b778;width:15px;height:15px;display:inline-block;text-align:center;line-height:15px;border-radius:5px;color:#fff;margin-right:5px;font-size:11px;position:absolute;left:0;top:1px}#method_toc.en_toc a{display:block;font-weight:bold;font-size:12.4px;color:#307530;line-height:18px;margin:3px 0;background-image:none;padding-left:20px;position:relative}#method_toc.en_toc .header_toc{font-size:14px;display:none}#method_toc.en_toc #qa_toc{background-image:none}#method_toc.en_toc #qa_toc a{ background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%238effff;opacity:0%7D.cls-2%7Bfill:%23fff%7D.cls-3,.cls-4%7Bfill:none;stroke:%23a3a3a3%7D.cls-4%7Bfill:%23a3a3a3;stroke-linecap:round;stroke-linejoin:round;stroke-width:.25px%7D%3C/style%3E%3C/defs%3E%3Cpath class='cls-1' d='M0 0h15v15H0z'/%3E%3Ccircle class='cls-2' cx='7.5' cy='7.5' r='7'/%3E%3Ccircle class='cls-3' cx='7.5' cy='7.5' r='6.56'/%3E%3Cpath class='cls-4' d='M5.66 3.42A3.16 3.16 0 0 1 7.39 3a3.76 3.76 0 0 1 2.25.64 2.24 2.24 0 0 1 .89 1.92 2.16 2.16 0 0 1-.39 1.31 4.42 4.42 0 0 1-.87.82L8.85 8a1.32 1.32 0 0 0-.46.63 2.82 2.82 0 0 0-.08.71H6.69a5.07 5.07 0 0 1 .19-1.4 2.55 2.55 0 0 1 .8-.94l.44-.34a1.4 1.4 0 0 0 .34-.35 1.21 1.21 0 0 0 .24-.73 1.43 1.43 0 0 0-.26-.82 1.12 1.12 0 0 0-1-.38 1.11 1.11 0 0 0-1 .46 1.81 1.81 0 0 0-.28 1H4.47a2.79 2.79 0 0 1 1.19-2.42z'/%3E%3Crect class='cls-4' x='6.65' y='10.15' width='1.79' height='1.73' rx='.44'/%3E%3C/svg%3E")}#method_toc.en_toc #rwh_toc a{ background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%238effff;opacity:0%7D.cls-2,.cls-3%7Bfill:%23fff%7D.cls-2,.cls-3,.cls-4,.cls-5%7Bstroke:%23a3a3a3%7D.cls-2,.cls-5%7Bstroke-width:.75px%7D.cls-4,.cls-5%7Bfill:none%7D.cls-5%7Bstroke-linecap:round;stroke-linejoin:round%7D%3C/style%3E%3C/defs%3E%3Cpath class='cls-1' d='M0 0h15v15H0z'/%3E%3Cpath class='cls-2' d='M13.49 3.66v9.1a1.87 1.87 0 0 1-2 1.74H5.38a1.87 1.87 0 0 1-2-1.74V2.44a1.87 1.87 0 0 1 2-1.74H10z'/%3E%3Cpath class='cls-3' d='M11.59 3.45v8.11a1.87 1.87 0 0 1-2 1.74H3.48a1.87 1.87 0 0 1-2-1.74V2.24a1.87 1.87 0 0 1 2-1.74H8z'/%3E%3Cpath class='cls-4' d='M11.59 3.45H8.66A.58.58 0 0 1 8 2.91V.5'/%3E%3Cpath class='cls-5' d='M3.41 3.45h2.91M3.41 5.43h6.28M3.41 7.42h6.28M3.41 9.4h6.28M3.41 11.38h6.28'/%3E%3C/svg%3E")}#method_toc.en_toc #toc_ref a{ background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%238effff;opacity:0%7D.cls-2%7Bfill:none;stroke:%23a3a3a3;stroke-linecap:round;stroke-linejoin:round%7D.cls-3%7Bfill:%23fff%7D%3C/style%3E%3C/defs%3E%3Cpath class='cls-1' d='M0 0h15v15H0z'/%3E%3Cpath class='cls-2' d='M4.19 2.82h8.15'/%3E%3Cpath class='cls-3' d='M12.34 4.23V14H4.46a1.8 1.8 0 0 1-1.8-1.8V2.61a1.56 1.56 0 0 0 1.49 1.62z'/%3E%3Cpath class='cls-2' d='M12.34 4.23V14H4.46a1.8 1.8 0 0 1-1.8-1.8V2.61a1.56 1.56 0 0 0 1.49 1.62zM2.66 2.61A1.55 1.55 0 0 1 4.15 1h8.19'/%3E%3C/svg%3E")}#method_toc.en_toc #summary_toc a{ background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%238effff;opacity:0%7D.cls-2,.cls-4%7Bfill:none;stroke:%2393b874;stroke-linecap:round;stroke-linejoin:round%7D.cls-3%7Bfill:%23fff%7D.cls-4%7Bstroke-width:.75px%7D%3C/style%3E%3C/defs%3E%3Cpath class='cls-1' d='M0 0h15v15H0z'/%3E%3Cpath class='cls-2' d='M3.06 2.82H14'/%3E%3Cpath class='cls-3' d='M14 4.23V14H3.42C2.09 14 1 13.2 1 12.2V2.61a1.84 1.84 0 0 0 2 1.62z'/%3E%3Cpath class='cls-2' d='M14 4.23V14H3.42C2.09 14 1 13.2 1 12.2V2.61a1.84 1.84 0 0 0 2 1.62zM1 2.61A1.84 1.84 0 0 1 3 1h11'/%3E%3Cpath class='cls-4' d='M3.06 7.03h7.48M3.06 9.03h7.48M3.06 11.03h7.48'/%3E%3C/svg%3E")}#method_toc.en_toc #tips_toc a{ background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%238effff;opacity:0%7D.cls-2%7Bfill:%23fff%7D.cls-3%7Bfill:none;stroke:%23a3a3a3%7D.cls-4%7Bfill:%23a3a3a3%7D%3C/style%3E%3C/defs%3E%3Cpath class='cls-1' d='M0 0h15v15H0z'/%3E%3Cg id='Ellipse_443-3' data-name='Ellipse 443-3'%3E%3Ccircle class='cls-2' cx='7.5' cy='7.5' r='7'/%3E%3Ccircle class='cls-3' cx='7.5' cy='7.5' r='6.56'/%3E%3C/g%3E%3Cpath class='cls-4' d='M7.56 2.63a1 1 0 0 1 1 1v1.53l-.5 4.48h-1l-.53-4.48V3.67a1 1 0 0 1 1.03-1.04z'/%3E%3Crect class='cls-4' x='6.57' y='10.13' width='1.97' height='1.91' rx='.95'/%3E%3C/svg%3E")}#method_toc.en_toc #summaryvideo_toc a{ background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15.5 15'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%23fff;%7D.cls-1,.cls-4%7Bstroke:%2393b875;%7D.cls-2,.cls-4%7Bfill:none;%7D.cls-2%7Bopacity:0.61;%7D.cls-3%7Bfill:%2393b874;%7D%3C/style%3E%3C/defs%3E%3Cg id='Layer_2' data-name='Layer 2'%3E%3Cg id='TOC'%3E%3Cpath class='cls-1' d='M.54,5.25H13.89A1.11,1.11,0,0,1,15,6.36v7a1.11,1.11,0,0,1-1.11,1.11H1.65A1.11,1.11,0,0,1,.54,13.39V5.25A0,0,0,0,1,.54,5.25Z'/%3E%3Crect class='cls-2' width='15' height='15'/%3E%3Cpath class='cls-3' d='M2.13,7.44H.75c-.29,0-.53-.17-.53-.37V5.2h3Z'/%3E%3Cpolygon class='cls-3' points='5.82 5.2 4.77 7.44 3.25 7.44 4.3 5.2 5.82 5.2'/%3E%3Cpolygon class='cls-3' points='8.99 5.2 7.93 7.44 5.88 7.44 6.94 5.2 8.99 5.2'/%3E%3Cpolygon class='cls-3' points='11.63 5.2 10.57 7.44 9.05 7.44 10.1 5.2 11.63 5.2'/%3E%3Cpath class='cls-3' d='M14.47,7.44H11.69L12.75,5.2H15V7.07C15,7.27,14.76,7.44,14.47,7.44Z'/%3E%3Cpath class='cls-3' d='M3.16,4.69.05,5,0,3.36c0-.2.19-.41.48-.46l1.37-.24Z'/%3E%3Cpolygon class='cls-3' points='4.26 4.5 2.96 2.47 4.46 2.21 5.78 4.23 4.26 4.5'/%3E%3Cpolygon class='cls-3' points='6.88 4.04 5.57 2.01 7.6 1.65 8.92 3.68 6.88 4.04'/%3E%3Cpolygon class='cls-3' points='10.02 3.49 8.71 1.46 10.22 1.2 11.53 3.22 10.02 3.49'/%3E%3Cpath class='cls-3' d='M14.65.79l.23,1.84L12.64,3,11.33,1,14.09.52C14.38.47,14.63.59,14.65.79Z'/%3E%3Cline class='cls-4' x1='0.66' y1='7.74' x2='14.63' y2='7.74'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");color:#307431}#method_toc.en_toc #summaryvideo_toc a span{font-size:7px;color:#307431;background-color:#bbd1ab;padding:1px 4px 0 4px;border-radius:6px;display:inline-block;margin-top:1px;vertical-align:text-top;line-height:14px;margin-left:4px}#method_toc.en_toc #othervideo_toc a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_video.svg)}#method_toc.en_toc #need_toc a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_need.svg)}#method_toc.en_toc #ea_toc a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_expert.svg)}#method_toc.en_toc #ingredients_toc a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_ingredients.svg);background-position:0px 4px;background-size:15px}#method_toc.en_toc .toc_sample a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_sample_new.svg);padding-left:21px}#method_toc.en_toc .toc_questionmethod a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_video.svg);padding-left:21px}#method_toc.en_toc .toc_method.toc_tech a span{display:none}#method_toc.en_toc .toc_android a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_android.svg)}#method_toc.en_toc .toc_desktop a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_desktop.svg)}#method_toc.en_toc .toc_iphone a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_iphone.svg)}#method_toc.en_toc .toc_mac a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_mac.svg)}#method_toc.en_toc .toc_mobile a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_mobile.svg)}#method_toc.en_toc .toc_windows a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_windows.svg)}#method_toc.en_toc #final_toc a{background-image:url(/extensions/wikihow/wikihowtoc/images/toc_final.svg)}#method_toc.en_toc #steps_toc a{background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 17 17'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%2394b778%7D.cls-2%7Bfill:%23fff%7D%3C/style%3E%3C/defs%3E%3Crect id='Rectangle_1284' data-name='Rectangle 1284' class='cls-1' width='17' height='17' rx='5'/%3E%3Crect id='Rectangle_1284-2' data-name='Rectangle 1284' class='cls-2' x='3.2' y='9.99' width='3.5' height='3.5' rx='1.03'/%3E%3Crect id='Rectangle_1284-3' data-name='Rectangle 1284' class='cls-2' x='3.2' y='3.51' width='3.5' height='3.5' rx='1.03'/%3E%3Cpath class='cls-2' d='M7.95 4.71h5.85v1.75H7.95zM7.95 11.19h5.85v1.75H7.95z'/%3E%3C/svg%3E");background-size:14px}#method_toc .toc_hidden,#method_toc .toc_ignore{display:none}#method_toc.intl_toc{margin:3px -26px 12px;padding:10px 26px;border-radius:0;width:100%;float:none}#method_toc.intl_toc a,#method_toc.intl_toc .toc_method,#method_toc.intl_toc #toc_showless,#method_toc.intl_toc #toc_showmore,#method_toc.intl_toc .toc_pre{ background-image:url(data:image/gif;base64,R0lGODlhCgAKAIAAAJa6eQAAACH/C1hNUCBEYXRhWE1QPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4gPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4wLWMwNjEgNjQuMTQwOTQ5LCAyMDEwLzEyLzA3LTEwOjU3OjAxICAgICAgICAiPiA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPiA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ1M1LjEgTWFjaW50b3NoIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjIxMjNDN0VGMjdBRjExRTNBNkUwQTY5OUIxODI0MUQ5IiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjIxMjNDN0YwMjdBRjExRTNBNkUwQTY5OUIxODI0MUQ5Ij4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6MjEyM0M3RUQyN0FGMTFFM0E2RTBBNjk5QjE4MjQxRDkiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6MjEyM0M3RUUyN0FGMTFFM0E2RTBBNjk5QjE4MjQxRDkiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz4B//79/Pv6+fj39vX08/Lx8O/u7ezr6uno5+bl5OPi4eDf3t3c29rZ2NfW1dTT0tHQz87NzMvKycjHxsXEw8LBwL++vby7urm4t7a1tLOysbCvrq2sq6qpqKempaSjoqGgn56dnJuamZiXlpWUk5KRkI+OjYyLiomIh4aFhIOCgYB/fn18e3p5eHd2dXRzcnFwb25tbGtqaWhnZmVkY2JhYF9eXVxbWllYV1ZVVFNSUVBPTk1MS0pJSEdGRURDQkFAPz49PDs6OTg3NjU0MzIxMC8uLSwrKikoJyYlJCMiISAfHh0cGxoZGBcWFRQTEhEQDw4NDAsKCQgHBgUEAwIBAAAh+QQAAAAAACwAAAAACgAKAAACCISPqcvtD2MrADs=);background-repeat:no-repeat;background-position-x:left}#method_toc.intl_toc a{ background-position:0 3px;padding-left:15px;display:inline-block;font-size:12px;margin:0 5px 0 0}#method_toc.intl_toc .method_toc_item{display:inline;background:none;padding-left:0}#method_toc.intl_toc .method_toc_item a{line-height:17px}#method_toc.intl_toc .header_toc{margin-right:.75em;border-bottom:none;display:inline;font-size:12px}#method_toc.intl_toc .toc_nav{display:none}#method_toc.intl_toc span.summaryvideo_icon{background:url(/skins/owl/images/video_play_icon.png) 0 0 contain no-repeat; background-image:url(/skins/owl/images/video_play_icon.svg);width:14px;height:12px;margin:0 0 -1px 2px;display:inline-block}.toc_header{color:#444;border-bottom:1px solid #d8d8d4;font-size:12px;text-transform:uppercase}#section_0.title_lg,#section_0.title_md,#section_0.title_sm{font-size:35px}h2 .altblock,h3 .altblock{position:absolute;background-color:#93b874;top:0;left:0;height:60px;width:60px;font-size:12px;font-weight:bold;line-height:1em;text-align:center;padding:0;color:#fff;border-radius:4px 0 0 0;box-sizing:border-box;display:table}h2 .altblock > div,h3 .altblock > div{width:100%;height:auto;display:table-cell;vertical-align:middle;padding-top:.2em}div.section.steps h3 .altblock span{font-size:21px;padding-top:2.5px;display:block;line-height:20px}div.section.steps h3 .altblock span.method_of_count{display:none}.section{margin-top:2.2em; }.section.stuck{padding-top:58px}.section h2,.section h3{font-size:1.25em;position:relative}.section h2 span.mw-headline,.section h3 span.mw-headline{display:table-cell;vertical-align:middle;height:58px;padding-top:0;padding-bottom:0;line-height:1.125em}.section h2 .altblock ~ span.mw-headline,.section h3 .altblock ~ span.mw-headline{padding-left:75px}.section.sample h3 span.mw-headline{padding-top:0}.section.tips h2 .altblock{ background:#93b874 url(/skins/owl/images/tips_icon.svg) center / 32px no-repeat}.section.warnings h2 .altblock{ background:#93b874 url(/skins/owl/images/warnings_icon.svg) center / 32px no-repeat}.section #ingredients .checkmark,.section #thingsyoullneed .checkmark{width:1em;height:1em}.section:not(.steps) h3{font-size:1.25em;font-weight:bold;color:#222222}.section:not(.steps) h3 .altblock{border-radius:0;margin-top:.3em;top:auto;height:1.5em;width:1.5em}.section:not(.steps) h3 span.mw-headline{padding:0 0 0 1.3em}.section h2.sticking,.section h3.sticking,.section .tool div.sticking{position:fixed;top:39px;width:728px;z-index:5;border-radius:0}.section h2.sticking .altblock,.section h3.sticking .altblock,.section .tool div.sticking .altblock{border-radius:4px;margin:7px 16px 7px 7px;width:52px;height:44px}@supports (position:sticky){.section.sticky > h2,.section.sticky > h3{top:37px;z-index:5;position:sticky}.sticky-sentinel{position:absolute;left:0;right:0;visibility:hidden}.sticky-sentinel-top{height:20px;top:-59px}.sticky-sentinel-introa{height:20px;top:-59px;position:absolute;left:0;right:0;visibility:hidden}.section h2.sticking,.section h3.sticking,.section .tool div.sticking{position:sticky}}h4.steps_text{font-size:1.1em}.section_text,.steps_text{border:none}.steps_list_2 > li{border:none;margin-bottom:1.5em;position:relative}.content{margin:0 0 1.5em}.content .edit-page{display:block;position:absolute;top:1.7em;right:1.7em;background:none;font-size:.8rem;font-weight:normal;color:#307530}.content .sticking .edit-page{margin-right:10px}.pre-content{border-radius:4px 4px 0 0}.method_ad{margin-left:-19px}#intro.hasad{padding-bottom:0;border-bottom:0}#intro_ad_1{height:120px}#intro_ad_1.gam{height:90px}#intro_ad_1 > ins{background-color:#F3F3F3}.sticky-ia #intro_ad_1 > ins{background-color:#FFF}.steps .wh_ad_inner{margin-top:25px;margin-left:-20px;margin-bottom:-21px;line-height:0}.steps .wh_ad_inner.al_grey{margin-top:35px}.steps .wh_ad_inner.wh_ad_spacing{margin-top:40px;width:728px;min-height:0 !important}#qa .wh_ad_inner{margin-top:40px;margin-left:-15px;margin-bottom:-15px;line-height:0}#qa .wh_ad_inner.wh_ad_spacing{margin-top:40px}#ingredients .wh_ad_inner{margin-top:40px;margin-left:-26px;margin-bottom:-26px;line-height:0}#tips .wh_ad_inner{margin-left:-15px;margin-bottom:-15px}#tips_ad_1{margin-left:-15px;margin-bottom:-21px}#relatedwikihows{padding-left:15px}#relatedwikihows .wh_ad_inner{margin-top:40px;margin-left:-15px;margin-bottom:-16px;line-height:0}#relatedwikihows .wh_ad_inner.wh_ad_spacing{margin-top:40px}#intro .wh_ad_inner{margin-top:24px;margin-left:-26px}#intro .wh_ad_inner.al_grey{margin-top:40px}.qz_container .wh_ad_inner{margin-left:0;margin-top:0;margin-bottom:5px}#mw-mf-page-center .qz_container{margin:26px auto}.w_label{margin-top:13px;background:#fff}.promopair.w_label{margin-top:0}#rightrail1_ad_1.blockthrough.w_label:before{display:none}.rr_container .w_label{background-color:#f3f3f3}#intro .w_label{display:block}.al_dollar{position:relative}.al_dollar:after{content:'$';font-size:9px;font-weight:bold;position:absolute;left:5px;top:-10px;color:#ecebe8}.al_dollar.w_label:before{margin-top:-18px;left:0px;padding-left:16px;padding-right:4px;padding-top:2px;padding-bottom:2px;border-radius:2px;-moz-border-radius:2px;-webkit-border-radius:2px;background:-webkit-linear-gradient(90deg,#888888 13px,#ecebe8 0%);background:-moz-linear-gradient(90deg,#888888 13px,#ecebe8 0%);background:-o-linear-gradient(90deg,#888888 13px,#ecebe8 0%);background:-ms-linear-gradient(90deg,#888888 13px,#ecebe8 0%);background:linear-gradient(90deg,#888888 13px,#ecebe8 0%);border:1px solid #444;font-weight:normal}#intro .al_dollar.w_label:before{background:-webkit-linear-gradient(90deg,#888888 13px,#ffffff 0%);background:-moz-linear-gradient(90deg,#888888 13px,#ffffff 0%);background:-o-linear-gradient(90deg,#888888 13px,#ffffff 0%);background:-ms-linear-gradient(90deg,#888888 13px,#ffffff 0%);background:linear-gradient(90deg,#888888 13px,#ffffff 0%)}.w_label:before{font-size:9px;line-height:normal;color:#444;position:absolute;left:6px;margin-top:-13px;display:block}.al_grey.w_label:before{color:#bababa}.m-video-wm{display:block;position:absolute;bottom:0;right:0;background-color:#93b874;color:#FFF;font-weight:bold;font-size:13.5px;line-height:13px;opacity:0.6 !important;padding-top:5px;padding-bottom:4px;padding-right:5px;padding-left:0px;text-decoration:none;pointer-events:none}.m-video-wm canvas{height:13px;vertical-align:bottom}.m-video-wm:before{right:100%;bottom:0;content:" ";height:100%;width:0;position:absolute;pointer-events:none;border-bottom:22px solid #93b874;border-left:18px solid transparent}#preload-wm-img{background:url(/skins/WikiHow/images/WH_logo.svg) no-repeat -9999px -9999px}.content .m-video-wm-img{width:auto !important;height:11px !important;padding-right:5px;display:block;float:left}.sourcesandcitations .section_text{padding-left:42px}.content .tips .section_text ul li,.content .warnings .section_text ul li{margin-bottom:0.8em}.content .tips .section_text ul li div.wh_vote_container,.content .warnings .section_text ul li div.wh_vote_container{display:none}#end_options{display:block}#end_options li{display:inline-block}#end_options li:before{content:'|';color:#e7e7e7;margin:0 1em}#end_options li:first-child:before{display:none}#article_rating_mobile{margin-top:1.5rem}#article_rating_mobile .mw-headline{font-weight:bold}#footer{text-align:left}#footer_inner{display:grid;grid-template-columns:1fr 1px 1fr;grid-template-rows:auto auto 30px auto auto auto;align-items:initial}.footer_divider,#footer_logo,#footer_crumbs{grid-column:1 / span 3}#footer_logo{grid-row:1}#footer_crumbs{grid-row:2}#footer_top_divider{display:none}#search_footer{grid-column:1;grid-row:4;width:85%}#footer_links{grid-column:1;grid-row:5;text-align:initial;padding-left:initial;margin-top:10px}#footer_links ul{column-gap:7.5em}#footer_vertical_divider{grid-column:2;grid-row:4 / span 3;border-left:1px solid #77a555}#contribute_footer_inner{max-width:688px}#byline_hover{z-index:6;position:absolute;top:28px;width:375px;max-width:375px;font-size:13px;line-height:1.5em;border:4px solid #7fa065;border-radius:6px;background-color:#FFF}#aboutthisarticle #summary_wrapper{width:100%;height:100%;position:fixed;overflow-y:scroll;top:0;left:0;z-index:100;display:none;background-color:rgba(0,0,0,0.2)}#aboutthisarticle #summary_wrapper .collapse_link{display:block;top:25%;position:relative;left:25%;width:50%;background-color:#93b874;color:#fff;padding:12px 18px;font-size:20px;font-weight:bold}#aboutthisarticle #summary_wrapper .collapse_link.open{margin-bottom:0}#aboutthisarticle #summary_wrapper .collapse_link:after{border:none}#aboutthisarticle #summary_text{position:relative;width:50%;top:25%;border:1px solid #93b874;background-color:#fff;padding:15px 20px 15px 15px;line-height:25px;left:25%;right:25%;display:block}#aboutthisarticle #summary_text h2{background-color:#93b874;color:#fff;margin:-15px -20px 10px -15px;padding:15px}#aboutthisarticle .text_summary_wrapper{overflow-y:auto}#aboutthisarticle #summary_last_sentence{display:inline}#aboutthisarticle #summary_close{position:absolute;top:11px;right:10px;width:30px;height:30px;color:#fff;border:1px solid #fff;border-radius:15px;text-align:center;line-height:30px;font-weight:normal;text-decoration:none;font-size:16px;display:block;background:#93b874}#aboutthisarticle .page_stats{display:block;text-align:center;border-radius:0 0 4px 4px;font-weight:bold}#aboutthisarticle #other_languages .collapse_link{background:none}#aboutthisarticle #other_languages .collapse_link::after{content:':'}#aboutthisarticle #language_links{display:block;margin-top:.5em;-webkit-columns:2;-moz-columns:2;columns:2}.al_method{display:none}#expertadvice > ul{padding-top:10px}.content .section_text.expert_advice_section p{font-size:16px;margin-bottom:0}.content .section_text.expert_advice_section ul li{font-size:16px}.healtharticle .altblock{background:#93b874 url(/extensions/wikihow/wikihowhealth/icon_wikihow_health.svg) center / 32px no-repeat}.healtharticle{margin-bottom:45px}.small_pdf_link{display:none}a.large_pdf_link{display:-ms-flexbox;display:-webkit-flex;display:flex;-webkit-align-items:center;-ms-flex-align:center;align-items:center;float:right;font-weight:bold;margin:-5px 127px 5px 0;font-size:12.5px;color:#333333;background-color:#F6F8F7;padding:.45em 1.1rem;border-radius:8px}a.large_pdf_link:hover{text-decoration:none}a.large_pdf_link.pdf_link_steps{margin:10px 10px 0 0;min-width:135px;white-space:nowrap}a.large_pdf_link.intl{margin-right:0}a.large_pdf_link img{width:23px;margin-right:.3rem}a.large_pdf_link > div{margin-left:.4rem}#footer_newsletter{display:block;grid-column:3;grid-row:4 / span 2;width:210px;margin:0 auto;text-align:center}#footer_newsletter #footer_subscribe_title{font-size:19px}#footer_newsletter #footer_subscribe_email{font-size:12px;width:100%;padding:5px 10px;border-radius:10px}#footer_newsletter a#footer_subscribe_button{font-size:14px;width:initial;border-radius:8px}#footer_newsletter #footer_subscribe_notice{font-size:11px}#footer_newsletter_divider{display:none}#intro .wh_ad_inner.al_grey{margin-top:40px}#watchtheserelatedvideos{grid-template-columns:1fr 1fr}.al_grey{text-transform:uppercase;letter-spacing:1px}}@media only screen and (min-width:975px){.w_label{display:inline-block}.wh_ad_inner.al_grey{margin-top:25px;display:block}.promopair.wh_ad_inner.al_grey{margin-top:0px}@supports (position:sticky){#sticky-iaw:not(.no-sticky-ia){position:absolute;height:685px;top:110px;width:100%;left:0}#mw-mf-viewport #content_wrapper.sticky-iac:not(.no-sticky-ia){padding-top:200px}.w_label.sticky-ia{margin-top:-11px;padding-top:22px;padding-bottom:20px}#sticky-iaw #intro_ad_1.full-width:not(.no-sticky-ia){margin:0 auto}.al_grey.sticky-ia:before{margin:0 auto;left:0;right:0;top:10px}.sticky-ia{top:39px;z-index:7;position:sticky;width:100%;text-align:center}}#rightrail0_ad_1{position:sticky;top:65px}#rightrail0_ad_1.rr_sticky_ia{position:sticky;top:195px}#rightrail1_ad_1{position:sticky;top:65px}#rightrail2_ad_1{position:sticky;top:65px}.article-promo{display:block;position:relative}#promopair_container{display:block;position:relative;height:224px;margin-top:18px}#promopair_container.wh_ad_spacing{height:250px;background-color:#FFF;margin-top:0px}#promopair_container.tip_submit{padding-top:15px}#tips #promopair_container .wh_ad_inner{position:absolute;left:0;width:300px;height:250px}#promopair-img-wrap{position:absolute;right:-26px;width:420px}.wh_ad_spacing #promopair-img-wrap{right:0}#promopair_container img{min-width:auto;min-height:auto}.menu_login,.menu_messages{position:absolute;border:1px solid #91af79;margin:0;padding:10px 0;top:71px;z-index:1000;background-color:#f9f9f9;display:none;right:0}.menu_login{padding:15px 25px} #actionbar{display:block}#mw-mf-viewport{min-width:1070px}.header{height:72px;position:relative;border-top:none;max-width:1050px; }.header #mw-mf-main-menu-button,.header #hamburger_dot{display:none}.header .search{display:block;height:39px}#header_logo{background-position:left 20px;background-size:162px;width:158px;padding-left:0}#hs,#hs_query{width:auto}#hs_query{position:relative;display:block;float:left;border:solid #FFF;border-width:0 0 2px;border-radius:0;font-size:1.25em;background:none;height:auto;width:75%;min-width:200px;padding:9px 7px 4px}#hs_query::placeholder{color:#FFF;opacity:1}.hs_notif #hs_query{margin-right:0}#hs_submit{position:relative;display:inline-block;background-color:#ADC996;border-radius:4px;width:80px;background-position:center;background-size:25px;margin-left:10px}.hs_active #hs_query:valid ~ #hs_submit{display:inline-block}#content_wrapper{padding:71px 1em 1em}.header #actions{display:table-cell;padding:0px;margin:0px;border-right:1px solid #89ac6c;width:50%}.header #actions li{border-left:1px solid #89ac6c;padding:0px;height:72px;float:right;list-style:none !important;margin:0px;cursor:pointer;width:14%;position:relative;display:table}.header #actions li .nav{font-size:calc(8px + (10 - 8) * ((100vw - 975px) / (1020 - 975)));font-weight:bold;color:#475347;display:block;padding-top:40px;position:relative;text-align:center;z-index:1;line-height:normal;display:table-cell;vertical-align:middle;height:auto;width:100%}.header #actions li:hover .nav{color:#2C3C2C;text-decoration:none}.header #actions li .new_bubble{font-size:.7em;padding:0 .5em;margin-left:0}.nav_icon{position:absolute;top:0;width:100%;height:46px;background-repeat:no-repeat;background-position:center;-webkit-transition:all 0.1s ease-out;transition:all 0.1s ease-out}.nav_item:hover,.nav_item_selected{background-color:#85A669}#nav_explore_li .nav_icon{ background-image:url(/skins/owl/images/nav_explore.optimized.svg);background-size:28%}#nav_explore_li:hover .nav_icon{ background-image:url(/skins/owl/images/nav_explore_hover.optimized.svg);background-size:31%}#nav_messages_li .nav_icon{ background-image:url(/skins/owl/images/nav_messages.optimized.svg);background-size:33%}#nav_messages_li:hover .nav_icon{ background-image:url(/skins/owl/images/nav_messages_hover.optimized.svg);background-size:37%}#nav_profile_li .nav_icon{ background-image:url(/skins/owl/images/nav_profile.optimized.svg);background-size:29%}#nav_profile_li:hover .nav_icon{ background-image:url(/skins/owl/images/nav_profile_hover.optimized.svg);background-size:32%}#nav_profile_li.nav_member .nav_icon{ background-image:url(/extensions/wikihow/MembershipManager/images/nav_proprofile.svg);background-size:40%;background-position:center 11px}#nav_profile_li.nav_member:hover .nav_icon{ background-image:url(/extensions/wikihow/MembershipManager/images/nav_proprofile_hover.svg);background-size:43%}.menuitem.menu_separator:hover{background-color:#fff}#nav_help_li .nav_icon{ background-image:url(/skins/owl/images/nav_help.optimized.svg);background-size:31%}#nav_help_li:hover .nav_icon{ background-image:url(/skins/owl/images/nav_help_hover.optimized.svg);background-size:34%}#nav_edit_li .nav_icon{ background-image:url(/skins/owl/images/nav_edit.optimized.svg);background-size:31%}#nav_edit_li:hover .nav_icon{ background-image:url(/skins/owl/images/nav_edit_hover.optimized.svg);background-size:34%}.menuitem.top_cat{padding-left:25px;font-size:14px;line-height:22px}#actions #nav_pro_li{border:none;background:#FFF;border-radius:35px;margin:13px 10px 0 0;box-sizing:border-box;height:45px;width:100px}#actions #nav_pro_li .nav_icon{ background-image:url(/skins/owl/images/nav_pro.svg);background-size:100%;right:16px;width:22px;height:45px}#actions #nav_pro_li .red_dot{display:none;position:absolute;background:#FF3333;height:10px;width:10px;right:13px;bottom:10px;border-radius:50%}#actions #nav_pro_li .menu{top:50px;border:none;border-radius:15px;padding:12px 0;box-shadow:-2px 4px 4px rgba(122,122,122,0.25)}#actions #nav_pro_li .menu hr{color:#D9D9D9;margin:12px 0}#actions #nav_pro .label{display:inline-block;background:#FFCF5A;color:#FFF;font-size:1.2em;padding:.25em .6em;position:absolute;left:16px;top:28%;border-radius:5px} .header #secondary-button.user-button{position:absolute;padding:0;top:-2px;right:-4px;z-index:1}.header #secondary-button.user-button span{font-size:.6em;width:2.2em;height:1.5em;line-height:1.5em;border-radius:1.5em;position:relative}#header_container{height:72px;transform:scaleY(1);transform-origin:top;transition-duration:120ms}#header_top_watch{position:absolute;width:1px;height:1px;top:3px;left:0}#header_container.shrunken{transform:scaleY(0.5);transform-origin:top;transition-duration:210ms} .header_container.shrunk{height:39px}.header_container.shrunk .header{height:39px}.header_container.shrunk .header #secondary-button.user-button{top:-10px}.header_container.shrunk #header_logo{background-position:left 5px}.header_container.shrunk #hs_query{height:32px}.header_container.shrunk #hs_submit{height:32px;background-size:21px;margin-top:3px}.header_container.shrunk .nav_icon{display:none}.header_container.shrunk .menu,.header_container.shrunk .menu_login,.header_container.shrunk .menu_messages{top:38px}.header_container.shrunk #actions li{height:39px}.header_container.shrunk #actions li .nav{padding:0}.header_container.shrunk #actions #nav_pro_li{height:30px;width:77px;margin-top:4px}.header_container.shrunk #actions #nav_pro_li .red_dot{display:none !important}.header_container.shrunk #actions #nav_pro_li .menu{top:33px}.header_container.shrunk #actions #nav_pro .label{position:relative;left:auto;top:auto}.scrollto_wrap{height:90px}#qa .wh_ad_inner{margin-top:18px;margin-bottom:-47px}#tips .wh_ad_inner{margin-left:-26px;margin-bottom:-26px}#warnings .wh_ad_inner{margin-left:-26px;margin-bottom:-26px}#aboutthisarticle .wh_ad_inner{margin-left:-26px;margin-top:5px;margin-bottom:-26px}#aboutthisarticle .wh_ad_inner.al_grey{margin-top:25px}#thingsyoullneed .wh_ad_inner{margin-left:-26px;margin-bottom:-26px}#references .wh_ad_inner{margin-left:-42px}.rtl .method_ad{margin-right:-19px}.rtl #qa .wh_ad_inner{margin-right:-16px}.rtl #intro .wh_ad_inner{margin-right:-26px}.rtl .steps .wh_ad_inner{margin-right:-21px}.rtl #relatedwikihows .wh_ad_inner{margin-right:-16px}.qz_container .wh_ad_inner{margin-left:0;margin-top:0;margin-bottom:5px}.menu_messages{right:0;font-size:.8em;width:300px;padding:0 0 3px 0}.menu_messages .mw-echo-state{background-color:#EEE}.menu_messages .mw-echo-state:hover{background-color:#F9F9F9}.menu_messages .mw-echo-unread{background-color:#F9F9F9}.menu_messages .mw-echo-content{padding-right:.5em}.menu_message_morelink{text-align:center;padding:5px} .oo-ui-windowManager-modal > .oo-ui-window.oo-ui-dialog{z-index:11}#ca-edit{display:none}.section.aidata{margin-top:-1.5em}.section_text{padding:26px}.step_num{font-size:2.8em;line-height:1em;margin-left:10px}.step{margin:0 30px 0 10px}.summarysection.mwimg,.summarysection .mwimg{margin:-26px -26px 0}#qa{padding:26px}.qa_divider{margin:0 -26px 15px}.qa_sq.qa_editing_aq{margin:0 -26px}#qa_ask_heading{margin-top:0}.references a.external,#site_notice a.external{background:none}#site_notice_x{float:right;display:block;width:14px;height:14px;background:url(/skins/owl/images/article_sprite.png) no-repeat -114px 0;margin:0 0px 10px 10px}#trust_banner{top:72px}#trust_banner > div{max-width:1050px}.shrunk_header #trust_banner{visibility:hidden}.coauthor_link:hover,.eat_tag:hover,.recipe_byline_stars:hover{text-decoration:none}#byline_hover_close{display:none}#sidebar{display:block;width:300px;min-height:500px;float:right;position:relative}#sidebar .al_dollar:after{top:-16px}#sidebar #cookie_notice{display:none}#sidebar #top_links{padding:30px 15px;white-space:nowrap;text-align:center;font-size:.65em;font-weight:bold}#sidebar #top_links #gatWriteAnArticle{margin-right:0}#sidebar .sidebox{background-color:#FFF;padding:16px;margin:0 0 15px 0;position:relative;-moz-border-radius:4px;-webkit-border-radius:4px;border-radius:4px;color:#686868;font-size:13px;line-height:1.3em}#sidebar .sidebox p{font-size:14px;line-height:17px;margin:12px 0 0}#sidebar .sidebox h3{font-size:13px;font-weight:bold;color:#686868;margin-bottom:11px;padding:0px;background:none}#sidebar .sidebox.short_sidebox{padding-top:10px}#sidebar #social_proof_sidebox{line-height:normal;padding:0;font-weight:bold}#sidebar .difficult_icon{display:block;margin:.5em auto}#sidebar .arrow_box{position:relative}#sidebar .arrow_box:after,#sidebar .arrow_box:before{right:100%;top:50%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}#sidebar .arrow_box:before{border:none}#sidebar #social_proof_sidebox.arrow_box:after,#sidebar #social_proof_sidebox.arrow_box:before{top:38px}#sidebar #social_proof_sidebox.arrow_box:after{margin-top:0}#sidebar #aag_sidebox{display:none}#sidebar .arrow_box:after{border-color:rgba(255,255,255,0);border-right-color:#FFF;border-width:11px;margin-top:-80px}#sidebar .arrow_box:before{border-color:rgba(229,229,229,0);border-right-color:#e5e5e5;border-width:12px;margin-top:-81px}#sidebar #social_proof_sidebox h3{margin:0;text-align:left;font-size:11px;background-color:#f6f5f4;padding:4px 1em;width:inherit;-moz-border-radius-topright:4px;-moz-border-radius-topleft:4px;-webkit-border-top-left-radius:4px;-webkit-border-top-right-radius:4px;top-left-border-radius:4px;border-top-right-radius:4px}#sidebar #social_proof_sidebox.arrow_box h3{font-size:15px;padding:10px 0 10px 10px}#sidebar #social_proof_sidebox h4{margin:10px 5px -5px 5px;text-align:left;font-size:12px;background-color:inherit}#sidebar .sp_box{float:left;width:130px;height:75px;position:relative;padding:10px 0 10px 15px}#sidebar .sp_thin_box{width:100%;height:auto;padding:0;display:table}#sidebar .sp_star_section_upper{margin-top:4px;display:inline-block}#sidebar #sp_star_rating_lower{font-size:11px}#sidebar .sp_star_rating_text{font-weight:normal}#sidebar .sp_helpful_box,#sidebar #sp_helpful_new,#sidebar .sp_difficult_box{border-right:1px solid #f3f3f3}#sidebar .sp_difficult_box{padding:10px;text-align:center}#sidebar .helpful_sidebox .sp_star_section_upper,#sidebar .helpful_sidebox .sp_helpful_lower{display:table-cell;vertical-align:middle}#sidebar .helpful_sidebox .sp_helpful_lower{padding-left:10px}#sidebar .helpful_sidebox .sp_star_container{height:26px;width:26px}#sidebar .sp_top_box{padding:10px;position:relative;background-color:#f0f5ec;border-radius:4px 4px 0 0;border:1px solid #ECEBE8}#sidebar .ar_avatar.generic{border:2px solid #708461}#sidebar .sp_expert_name a{color:#545454}#sidebar .sp_expert_blurb{font-size:12px}#sidebar #social_proof{font-size:11px;line-height:normal;color:#212121;margin:3px 0 30px 0;padding:0 0 5px 0;list-style:none}#sidebar #social_proof li{margin:0 10px 0 0;float:left;line-height:15px;color:#767676}#sidebar #sp_modified{display:inline-block;min-width:70px}#sidebar .sp_circle{border-radius:50%;width:15px;height:15px;display:inline-block;vertical-align:middle;margin-right:3px;float:left}#sidebar .sp_updated_icon{ background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAQAAACR313BAAABFElEQVQY00WQwS5DURRFLzGX+ARhLjEUHyG+QvyAmHUmxv6BmJhI/ILeu55HGkUrDSJiQrVoFK/L4LaRMznZ62SffU4gjGuBXdpU9DlhnZmsZjTNBg+IySQy5IiFf7yHGMXCYtzxyHLGmxm27fvtj+/eGk3SYC6wSAejT2rlwIGV+pQdtgM7GG2pQ5smk02/1JZRCLSx7qt65amIp16rXaN0Q6pKr/2ysmVpTl/666dJRiH1Cl9U7VmaxOiFIz9MMgwcJ/HVnmcmsW70eRKuE1jjM1lYmMTSjl11kJ32A4GDvBGjTUdq34ZRflgNBOa5Zxzq3DtvTPnq2uSpS1xOBuoZVdSYmuDALFuc8caIIQ8cspL1P0dFas6MaYbtAAAAAElFTkSuQmCC)}#sidebar .sp_updated_icon_sidebar{margin:14px auto 5px auto;position:absolute;left:-2px;right:0;width:22px;height:20px;background-image:url(/skins/owl/images/sp_icon_sidebar.png);background-image:linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='37.593' height='33.009' viewBox='0 0 37.593 33.009'%3E%3Cpath fill='%23FFF' d='M21.089 33.009v-5c6.344 0 11.504-5.161 11.504-11.504S27.433 5 21.089 5 9.584 10.161 9.584 16.504c0 .541.038 1.084.112 1.614l-4.951.694a16.776 16.776 0 0 1-.161-2.309C4.584 7.404 11.988 0 21.089 0s16.504 7.404 16.504 16.504-7.404 16.505-16.504 16.505z'/%3E%3Cpath fill='%23FFF' d='M14.169 17.468l-7.085 7%0A.084L0 17.468z'/%3E%3C/svg%3E");background-size:cover}#sidebar .sp_text{line-height:17px;font-weight:normal;padding-top:2px;padding-bottom:2px;font-size:11px}#sidebar .sp_thin_box .sp_text{display:table-cell;padding:8px 3.5%;vertical-align:top}#sidebar .sp_thin_box .sp_text:first-child{width:26%;padding-left:6.5%}#sidebar .sp_thin_box .sp_text:nth-child(2){width:28%}#sidebar .sp_thin_box .sp_text:last-child{width:22%}#sidebar .sp_thin_box .sp_text,#sidebar .sp_thin_box .sp_text a{color:#595959}#sidebar .sp_thin_box .sp_text_data{display:block;color:#545454}#sidebar .sp_text_data{font-size:12px;font-weight:bold}#sidebar .sp_stats_box.sp_thin_box{width:100%;float:none}#sidebar #sp_stats_sidebox{padding:5px 0}#sidebar #sp_stats_sidebox .sp_text_data{font-size:13px}#sidebar .sp_edit_icon{ background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAQAAACR313BAAAA6ElEQVQY01XQMUoDYRCG4VHsBY8gsRcsxUOIpxAvIHbpxNo7KDY2gmcw+yaKIijB1YQEG9EkKhgk+1r8WbOZr5uHGYYJYpoaR7SZMOKSHZZSN9Eiu3TxP2POqc34uEI2bIj02Ei8V8Ur2z6ZidyxEqyRVzG3UHtpw0FwWMVnC1WHaZ6gPcMXU317m/gjmJQHdab45U1aLUUwRMzsT/HT6xJlHFxgwwf7/qgjWzOUPNjmO/PVR3MH8ygnQXCa+e6bbZvpoDK/bAXBKp2mmM2j1MunrnPPPE2os1BysMw+LQYUjOlyxmbq/wEA8mibiYqo7QAAAABJRU5ErkJggg==)}#sidebar .sp_edit_icon_sidebar{margin:15px auto 5px auto;position:absolute;left:0;right:0;width:18px;height:18px;background-image:url(/skins/owl/images/sp_edit_icon_sidebar.png); background-image:linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='19.813' height='19.82' viewBox='0 0 19.813 19.82'%3E%3Cpath fill='%23FFF' d='M19.801 4.792l-6.398 6.397L6.042 18.5 0 19.82l1.269-6.092 7.362-7.311L15.028.02s1.371-.305 3.199 1.523c1.828 1.877 1.574 3.249 1.574 3.249zM6.296 17.18s-.051-1.117-1.32-2.386c-1.219-1.269-2.387-1.269-2.387-1.269l-.558.609-.457 2.031c.355.203.761.457 1.167.863.457.457.711.812.914 1.219l2.031-.457.61-.61z'/%3E%3C/svg%3E");background-size:cover}#sidebar #sp_section_name{color:#545454;font-size:11px;padding-bottom:6px}#sidebar .sp_nonverifier_text > div{font-size:13px}#sidebar .sp_popup_container{top:110px;left:-20px;position:absolute;z-index:100000007;display:none}#sidebar .hint_box{min-width:150px;max-width:180px;position:relative;background:#FFF;border:3px solid;border-color:rgba(0,0,0,0.13);border-radius:4px;font-weight:normal;padding:9px;-moz-background-clip:padding; -webkit-background-clip:padding; background-clip:padding-box}#sidebar .hint_box p{font-size:12px;line-height:normal;margin:0;text-align:left}#sidebar .hint_box:after,#sidebar .hint_box:before{left:50%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none}#sidebar .hint_box:after{top:-19px;border-color:rgba(255,255,255,0);border-bottom-color:#FFF;border-width:10px;margin-left:-10px}#sidebar .hint_box:before{top:-24px;border-bottom-color:#d5d5d5;border-width:12px;margin-left:-12px;-moz-background-clip:padding; -webkit-background-clip:padding; background-clip:padding-box}#sidebar .noarrow:after,#sidebar .noarrow:before{display:none}#sidebar .sp_helpful_rating_count,#sidebar #sp_helpful_text_sidebox{font-size:11px;font-weight:normal;color:#595959}#sidebar #sp_helpful_text_sidebox{margin-top:5px}#sidebar .helpfulness_text{font-size:12px;color:#545454;padding:4px 0 8px}#sidebar .sp_star_container{position:relative;width:21px;height:21px;float:left;border-right:2px solid transparent; background-image:url(/skins/owl/images/sp_helpful_icon_star_empty.optimized.svg) 0 0 cover no-repeat}#sidebar .social_sidebox{background-color:#FFF;padding:0}#sidebar .social_sidebox h3{margin:0;text-align:left;font-size:11px;background-color:#f6f5f4;padding:4px 1em;width:inherit;-moz-border-radius-topright:4px;-moz-border-radius-topleft:4px;-webkit-border-top-left-radius:4px;-webkit-border-top-right-radius:4px;top-left-border-radius:4px;border-top-right-radius:4px}#sidebar .sp_helpful_box.helpful_sidebox{float:none;border-right:none;width:auto;height:auto;padding:15px;border-bottom:1px solid #e7e7e7}#sidebar .sp_helpful_statement{font-size:13px;margin-bottom:5px}#sidebar .sp_helpful_statement span{font-size:18px;font-weight:bold}#sidebar #sp_icon_header{background-color:#7fa065;color:#FFF;font-size:16px;font-weight:bold;padding:8px 25px}#sidebar #byline_hover_body{padding:10px 25px}#sidebar #byline_hover_body a{font-weight:bold}#sidebar #byline_hover_body .sp_expert_icon{width:20px;height:20px;display:inline-block;margin-bottom:-4px}#sidebar #side_related_articles{padding-right:0px;padding-bottom:8px}#sidebar #side_related_articles_larger .related-article{width:100%;margin-right:0;margin-bottom:4%}#sidebar #side_related_articles .related-article{margin-right:4%;margin-bottom:10px;width:45%}#sidebar #side_related_articles .related-title{bottom:4px}#sidebar #side_related_articles .related-image-link{display:inline}#sidebar .rr_container #side_related_articles{margin-top:10px;width:300px;box-sizing:border-box}#sidebar .related-title-text p{font-size:12px;line-height:15px}#sidebar .rr_container{margin-bottom:15px;position:relative}#sidebar .rr_container.nofixed .w_label{background-color:#ecebe8}#sidebar #userreviews{line-height:normal;margin:3px 0 15px 0;padding:0;color:#686868;font-size:12px;font-weight:bold;position:relative;background-color:white;max-width:300px}#sidebar .ur_review{margin-bottom:1px;background-color:#fff;padding:15px 20px;border-radius:4px}#sidebar .ur_review_text{position:relative;text-align:left;font-weight:normal;font-size:13px;line-height:18px;color:#545454;margin-top:7px}#sidebar .ur_nav_container{background-color:#FFF;margin-top:-6px;padding:0px 20px 15px;min-height:1em;border-radius:0 0 4px 4px}#sidebar .ur_share{float:right;font-weight:normal}#sidebar .ur_share_recipes{display:block;font-size:15px;font-weight:bold}#sidebar .ur_nav{display:block}#sidebar .ur_nav_staff{display:block;background:#f3f3f3;padding:5px}#sidebar .ur_even_more{display:none}#sidebar .ur_hide{display:none}#sidebar .ur_author .ur_name{font-size:13px;color:#545454;font-weight:bold}#sidebar .ur_review .ur_date{font-size:11px;color:#9c9c9c}#sidebar .ur_review p{margin-top:0px}#sidebar .ur_avatar{width:36px;height:36px;display:inline-block;border-radius:16%;margin-right:5px;vertical-align:bottom;overflow:hidden}#sidebar #sidebar_share{text-align:center}#sidebar #sidebar_share h3{text-align:left;padding-bottom:5px}#sidebar #sidebar_share > div{display:inline-block;vertical-align:bottom;margin-right:10px}#sidebar #sidebar_share > div.admin_state{margin:0px 3px -4px -1px}#sidebar #sidebar_share div.like_button{margin-bottom:-8px}#sidebar #sidebar_share div.like_button_es{margin-right:0px}#sidebar #sidebar_share #pinterest{margin-right:3px}#sidebar #sidebar_share #pinterest a{ direction:ltr}#sidebar #sidebar_share div.email_share{margin-left:4px;margin-right:0px;margin-bottom:-6px}#sidebar #sidebar_share div.email_share a{display:inline-block;position:relative;z-index:10}#sidebar #sidebar_share div.email_share img{cursor:pointer}#sidebar .fb_iframe_widget iframe{width:auto;position:absolute}#userreviews_mobile{display:none}#aboutthisarticle > .section_text,#aboutthisarticle .sp_top_box,#aboutthisarticle #sp_expert_desc,#aboutthisarticle .sp_box{padding:15px 26px}#aboutthisarticle .sp_difficult_box{padding:15px 0 0}#aboutthisarticle .sp_top_icon_bg{left:26px}#aboutthisarticle #endoptions{border-radius:0}#aboutthisarticle .page_stats{font-size:1.1em;padding:1.6em 26px}#aboutthisarticle #summary_text{border-bottom:none;margin-bottom:0}.no_sidebar #content_inner{float:none;max-width:1050px}#content_inner{float:left}.full_width #content_wrapper,.full_width #content_inner{max-width:initial}#footer_inner{grid-template-columns:1fr 1fr 1fr;max-width:1070px;align-items:start;margin-top:10px;column-gap:2%}.footer_divider,#footer_logo,#footer_crumbs{grid-column:span 2}#footer_top_divider{display:initial}#footer_bottom_divider{display:none}#footer_vertical_divider{display:none}#search_footer{grid-column:1 / 1;grid-row:span 1;min-width:265px;width:100%}#footer_links{grid-column:2 / span 1;grid-row:span 2;margin:0 0 0 50px;padding-left:1em;text-align:center}#footer_links ul{margin-top:-5px;-webkit-columns:2;-moz-columns:2;columns:2;-webkit-column-gap:.5em;-moz-column-gap:.5em;column-gap:.5em}#footer_links li{margin-right:25px}#contribute_footer_inner{max-width:975px}#contribute_footer_inner p{width:785px}#contribute_footer_inner > a{float:right;margin-top:-58px}.steps_list_2 .mwimg.largeimage{margin-bottom:20px}#qa .wh_ad_inner{margin-left:-26px}#tips_ad_1{margin-left:-26px;margin-bottom:-32px}#side_featured_articles .text{background-color:rgba(50,50,50,0.5);padding:2% 4%;width:92.75%;min-height:32px;position:absolute;bottom:0;cursor:pointer;color:#fff;font-weight:bold}#side_featured_articles .text:hover{background:white}#side_featured_contributor .bottom_button{text-align:center}#side_featured_contributor .bottom_button .button{margin:.1em 0;display:inline-block}#fc_id_img{float:left;margin-right:.8em}.thumbnail a:hover p{color:#2483ef}.sidebox .thumbnail p{font-size:12px !important}.sidebox .thumbnail p span{font-size:13px !important}#gdpr{padding-top:5px;padding-bottom:5px}#gdpr_text{font-size:13px;margin-left:-85px}#gdpr_cp_link{top:0px}.s-help-response{padding-left:10px;cursor:pointer;border:none;font-size:16px;font-family:Helvetica,arial,sans-serif;color:#363;background:none}.s-help-wrap{position:relative;width:50%;top:25%;left:25%;right:25%;display:block;background-color:#fff;padding:0 20px 15px 15px;border:1px solid #93b874;border-top:none}.s-help-response:hover{text-decoration:underline;background-color:inherit;border:none}#introad-outer > .gptlight{width:728px;height:90px}.s-help-wrap > .s-help-feedback-wrap{padding-bottom:30px}.s-help-feedback-wrap{display:none}#sample_loading{display:initial}#footer_newsletter{display:initial;margin:-25px 0 0 40px;min-width:200px;grid-row:2 / span 4;text-align:left}#footer_newsletter #footer_subscribe_title{font-size:18px}#footer_newsletter #footer_subscribe_email{box-sizing:initial;padding:5px 10px;font-size:14px;width:170px;border-radius:5px}#footer_newsletter a#footer_subscribe_button{box-sizing:initial;margin:initial;padding:2px 5px;border-radius:5px;font-size:initial;width:182px}#footer_newsletter #footer_subscribe_notice{width:180px;margin:5px 0;font-size:12px}}@media only screen and (min-width:1020px){.header #actions li .nav{font-size:10px}}@media only screen and (min-width:1200px){@supports (position:sticky){#sticky-iaw #intro_ad_1.full-width:not(.no-sticky-ia){width:1200px}}}</style>
+<script>window.WH.pageName='Stop-Ringing-in-Ears';
+window.WH.pageID=543713;
+window.WH.pageNamespace=0;
+window.WH.pageLang='en';
+window.WH.isMobile=1;
+window.WH.stuCount=1;
+window.WH.isAltDomain=0;
+window.WH.topCat1='Health';
+window.WH.topCat2='';</script>
+<meta name="viewport" content="width=device-width"/>
+<meta property="og:title" content="How to Stop Ringing in Ears"/>
+
+<meta property="og:type" content="article"/>
+
+<meta property="og:url" content="https://www.wikihow.com/Stop-Ringing-in-Ears"/>
+
+<meta property="og:site_name" content="wikiHow"/>
+
+<meta property="og:description" content="Ringing, buzzing, or roaring in the ears is often used to describe tinnitus, which can be extremely annoying and occur without any reason. Tinnitus may signify underlying nerve damage or an issue with your circulatory system, or there may..."/>
+
+<meta property="og:image" content="https://www.wikihow.com/images/4/4a/Stop-Ringing-in-Ears-Step-9-Version-2.jpg"/>
+
+<meta property="og:image:width" content="3200"/>
+
+<meta property="og:image:height" content="2400"/>
+
+<meta name="twitter:card" content="summary_large_image"/>
+
+<meta name="twitter:image:src" content="https://www.wikihow.com/images/4/4a/Stop-Ringing-in-Ears-Step-9-Version-2.jpg"/>
+
+<meta name="twitter:site" content="@wikihow"/>
+
+<meta name="twitter:description" content="Ringing, buzzing, or roaring in the ears is often used to describe tinnitus, which can be extremely annoying and occur without any reason. Tinnitus may signify underlying nerve damage or an issue with your circulatory system, or there may..."/>
+
+<meta name="twitter:title" content="How to Stop Ringing in Ears"/>
+
+<meta name="twitter:url" content="https://www.wikihow.com/Stop-Ringing-in-Ears"/>
+
+<meta name="twitter:app:name:iphone" content="wikiHow"/>
+
+<meta name="twitter:app:id:iphone" content="309209200"/>
+
+<meta name="twitter:app:url:iphone" content="wikihow://article?id=543713"/>
+
+
+<link rel="alternate" hreflang="en" href="https://www.wikihow.com/Stop-Ringing-in-Ears"/>
+
+<link rel="alternate" hreflang="es" href="https://es.wikihow.com/eliminar-el-zumbido-en-los-o%C3%ADdos"/>
+
+<link rel="alternate" hreflang="it" href="https://www.wikihow.it/Eliminare-il-Ronzio-nelle-Orecchie"/>
+
+<link rel="alternate" hreflang="fr" href="https://fr.wikihow.com/arr%C3%AAter-les-sifflements-dans-les-oreilles"/>
+
+<link rel="alternate" hreflang="ru" href="https://ru.wikihow.com/%D0%BF%D1%80%D0%B5%D0%BA%D1%80%D0%B0%D1%82%D0%B8%D1%82%D1%8C-%D0%B7%D0%B2%D0%BE%D0%BD-%D0%B2-%D1%83%D1%88%D0%B0%D1%85"/>
+
+<link rel="alternate" hreflang="zh" href="https://zh.wikihow.com/%E6%B6%88%E9%99%A4%E8%80%B3%E9%B8%A3"/>
+
+<link rel="alternate" hreflang="nl" href="https://nl.wikihow.com/Oorsuizen-stoppen"/>
+
+<link rel="alternate" hreflang="cs" href="https://www.wikihow.cz/Jak-zastavit-zvon%C4%9Bn%C3%AD-v-u%C5%A1%C3%ADch"/>
+
+<link rel="alternate" hreflang="id" href="https://id.wikihow.com/Menghilangkan-Telinga-Berdengung"/>
+
+<link rel="alternate" hreflang="ar" href="https://ar.wikihow.com/%D8%A7%D9%84%D8%AA%D8%AE%D9%84%D9%91%D8%B5-%D9%85%D9%86-%D8%B7%D9%86%D9%8A%D9%86-%D8%A7%D9%84%D8%A3%D8%B0%D9%86%D9%8A%D9%86"/>
+
+<link rel="alternate" hreflang="hi" href="https://hi.wikihow.com/%E0%A4%95%E0%A4%BE%E0%A4%A8-%E0%A4%95%E0%A5%87-%E0%A4%85%E0%A4%82%E0%A4%A6%E0%A4%B0-%E0%A4%AC%E0%A4%9C%E0%A4%A8%E0%A5%87-%E0%A4%B5%E0%A4%BE%E0%A4%B2%E0%A5%80-%E0%A4%98%E0%A4%82%E0%A4%9F%E0%A5%80-%E0%A4%95%E0%A5%8B-%E0%A4%B0%E0%A5%8B%E0%A4%95%E0%A5%87%E0%A4%82"/>
+
+<link rel="alternate" hreflang="ja" href="https://www.wikihow.jp/%E8%80%B3%E9%B3%B4%E3%82%8A%E3%82%92%E6%AD%A2%E3%82%81%E3%82%8B"/>
+
+<link rel="alternate" hreflang="th" href="https://th.wikihow.com/%E0%B9%81%E0%B8%81%E0%B9%89%E0%B8%AD%E0%B8%B2%E0%B8%81%E0%B8%B2%E0%B8%A3%E0%B8%AB%E0%B8%B9%E0%B8%AD%E0%B8%B7%E0%B9%89%E0%B8%AD"/>
+
+<link rel="alternate" hreflang="vi" href="https://www.wikihow.vn/Ng%E1%BB%ABng-ti%E1%BA%BFng-%E1%BB%93n-trong-tai"/>
+
+<link rel="alternate" hreflang="ko" href="https://ko.wikihow.com/%EC%9D%B4%EB%AA%85%EC%9D%84-%EB%A9%88%EC%B6%94%EB%8A%94-%EB%B0%A9%EB%B2%95"/>
+
+<link rel="alternate" hreflang="tr" href="https://www.wikihow.com.tr/Kulak-%C3%87%C4%B1nlamas%C4%B1-Nas%C4%B1l-Giderilir"/>
+<script>window.abgSmall = true;window.abgLarge = true;window.bucketId = 15;window.dfpSmall = false;window.dfpLarge = true;window.dfpPageType = 'article';window.dfpCategory = 'health';window.nlpCategory = '/Health/Health Conditions/Ear Nose & Throat';window.isCoppa = 'false';
+</script><script>(WH.shared.isLargeSize&&window.abgLarge||WH.shared.isSmallSize&&window.abgSmall||WH.shared.isMedSize)&&function(){var a=document.createElement("script");a.async=!0;a.type="text/javascript";a.src=("https:"==document.location.protocol?"https:":"http:")+"//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js";var b=document.getElementsByTagName("script")[0];b.parentNode.insertBefore(a,b)}();window.ccpaOut=0<=document.cookie.indexOf("ccpa_out=");var format="sma",viewportWidth=window.innerWidth||document.documentElement.clientWidth;0==WH.isMobile?format="dsk":viewportWidth>=WH.largeScreenMinWidth?format="lrg":viewportWidth>=WH.mediumScreenMinWidth&&(format="med");function setDFPTargeting(a,c){c=c[a.getAdUnitPath()];for(var b in c)a.setTargeting(b,c[b]);b=window.bucketId;10>b&&(b="0"+b);a.setTargeting("bucket",b);a.setTargeting("language",WH.pageLang);a.setTargeting("format",format);a.setTargeting("site",window.location.hostname);a.setTargeting("coppa",window.isCoppa);window.nlpCategory&&a
+.setTargeting("nlp_category",window.nlpCategory);a.setTargeting("pagetype",window.dfpPageType);""!=dfpCategory&&a.setTargeting("category",window.dfpCategory)}if(WH.shared.isLargeSize&&window.dfpLarge||WH.shared.isSmallSize&&window.dfpSmall){var gads=document.createElement("script");gads.async=!0;gads.type="text/javascript";gads.src="https://securepubads.g.doubleclick.net/tag/js/gpt.js";var node=document.getElementsByTagName("script")[0];node.parentNode.insertBefore(gads,node);window.dfprequested=!0;window.googletag=window.googletag||{};window.googletag.cmd=window.googletag.cmd||[];window.googletag.cmd.push(function(){"true"==window.isCoppa&&(console.log("setting child directed"),window.googletag.pubads().setTagForChildDirectedTreatment(1));window.googletag.pubads().enableSingleRequest();window.googletag.pubads().disableInitialLoad();window.googletag.pubads().collapseEmptyDivs();window.googletag.enableServices();window.googletag.pubads().addEventListener("slotRenderEnded",function(a){WH
+.ads&&WH.ads.slotRendered(a.slot,a.size,a)});window.googletag.pubads().addEventListener("impressionViewable",function(a){WH.ads&&WH.ads.impressionViewable(a.slot)});window.ccpaOut&&window.googletag.pubads().setPrivacySettings({restrictDataProcessing:!0})})};if(WH.shared.isLargeSize&&window.dfpLarge||WH.shared.isSmallSize&&window.dfpSmall){!function(a,b,e,f,g,c,d){b[a]||(b[a]={init:function(){b[a]._Q.push(["i",arguments])},fetchBids:function(){b[a]._Q.push(["f",arguments])},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]},c=e.createElement(f),c.async=!0,c.src=g,d=e.getElementsByTagName(f)[0],d.parentNode.insertBefore(c,d))}("apstag",window,document,"script","//c.amazon-adsystem.com/aax2/apstag.js");var privacyValue=null,vrCACookie=document.cookie.indexOf("vr=US-CA");0<=vrCACookie&&(privacyValue="1YN");var ccpaCookie=document.cookie.indexOf("ccpa_out=");0<=ccpaCookie&&(privacyValue="1YY");privacyValue?apstag.init({pubID:"3271",adServer:"googletag",aps_privacy:
+privacyValue}):apstag.init({pubID:"3271",adServer:"googletag"})};</script><style>.w_label:before{content:'Advertisement';}</style>
+<script>(function(){var wh=window.WH=(window.WH||{}),ok=typeof window.addEventListener=='function',d=document,e='event_tracker_ready';wh.event=function(z,y){ok&&d.addEventListener(e,function(){wh.event(z,y)})}
+wh.eventView=function(z,y,x,w,v,u){ok&&d.addEventListener(e,function(){wh.eventView(z,y,x,w,v,u)})}})();</script>
+<!--[if lt IE 9]><script src="/load.php?debug=false&amp;lang=en&amp;modules=html5shiv&amp;only=scripts&amp;siterev=tmCgL&amp;skin=wh&amp;sync=1"></script><![endif]-->
+</head>
+<body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-Stop_Ringing_in_Ears rootpage-Stop_Ringing_in_Ears stable skin-minervawh action-view"><script>var dfpKeyVals = {"\/10095428\/engl\/engl_gam_lgm_rght2":{"refreshing":"1"}};
+</script><script>WH.gaType = "mobile";
+WH.gaID = "UA-2375655-1";
+WH.gaConfig = {"extraPropertyIds":[],"v4PropertyId":null};
+</script><div id="header_container" class="header_container" data-responsive="1"><div id="header" class="header" role="navigation"><a href="#" title="Open main menu" id="mw-mf-main-menu-button" class="mainmenu element main-menu-button"></a><div id="hamburger_dot"></div><a id="header_logo" href="/Main-Page"></a><div id="hs"><form action="/wikiHowTo" class="search" target="_top" id="search_form_top"><input id="hs_query" role="textbox" tabindex="0" name="search" aria-label="Search here" required="" placeholder="" x-webkit-speech=""><button type="submit" id="hs_submit"></button><div id="hs_close" role="button" tabindex="0"></div></form></div><ul id="actions" role="menubar" aria-label="Header navigation"><li id="nav_messages_li" class="nav_item" role="menuitem" aria-labelledby="nav_messages"><div class="nav_icon"></div><a id="nav_messages" class="nav" href="#">MESSAGES</a></li><li id="nav_profile_li" class="nav_item" role="menuitem" aria-labelledby="nav_profile"><div class="nav_icon"></div><a id="nav_profile" class="nav" href="#wh-dialog-login" rel="nofollow" data-link="#wh-dialog-login">LOG IN</a><div class="menu_login" role="menu">
+	<div name="userlogin" class="userlogin">
+
+	<h3>Log in</h3>
+	<div id='social-login-navbar' data-return-to=''>
+		<label class='social-disabled'>Social login does not work in incognito and private browsers. Please log in with your username or email to continue.</label>
+		<div id="fb_connect_head">
+			<a id="fb_login_head" href="#" role="button" class="ulb_button ulb_social_button loading" aria-label="Log in with Facebook">
+				<span class="ulb_icon"></span>
+				<span class="ulb_label">Facebook</span>
+			</a>
+		</div>
+		<div id="gplus_connect_head">
+			<a id="gplus_login_head" href="#" role="button" class="ulb_button ulb_social_button loading"  aria-label="Log in with Google">
+				<span class="ulb_icon"></span>
+				<span class="ulb_label">Google</span>
+			</a>
+		</div>
+	</div>
+
+	<div>
+		<a href="#wh-dialog-login" role="button" id="wh_login_head" class="ulb_button ulb_login" aria-label="Log in"><span class="ulb_icon"></span><span class="ulb_label">wikiHow Account</span></a>
+	</div>
+
+	<div class="userlogin_links">
+		No account yet?		<a href="/Special:UserLogin?type=signup">Create an account</a>
+			</div>
+</div>
+
+</div>
+</li><li id="nav_explore_li" class="nav_item" role="menuitem" aria-labelledby="nav_explore"><div class="nav_icon"></div><a id="nav_explore" class="nav" href="#">EXPLORE</a><div class="menu" role="menu">
+	<a href="/Course/Explore" class="menuitem "
+		
+		
+		
+	>
+		Courses
+
+		<span class="new_bubble">New</span>
+	</a>
+
+
+	<a href="/Tech-Help-Pro" class="menuitem "
+		
+		
+		
+	>
+		Tech Skills
+
+		<span class="new_bubble">New</span>
+	</a>
+
+
+	<a href="/Special:Randomizer" class="menuitem "
+		
+		
+		
+	>
+		Random Article
+
+	</a>
+
+
+	<a href="/wikiHow:About-wikiHow" class="menuitem "
+		
+		
+		
+	>
+		About Us
+
+	</a>
+
+
+	<a href="/Special:CategoryListing" class="menuitem "
+		
+		
+		
+	>
+		Categories
+
+	</a>
+
+
+	<a href="/Category:Arts-and-Entertainment" class="menuitem top_cat"
+		
+		
+		
+	>
+		Arts and Entertainment
+
+	</a>
+
+
+	<a href="/Category:Cars-%26-Other-Vehicles" class="menuitem top_cat"
+		
+		
+		
+	>
+		Cars & Other Vehicles
+
+	</a>
+
+
+	<a href="/Category:Computers-and-Electronics" class="menuitem top_cat"
+		
+		
+		
+	>
+		Computers and Electronics
+
+	</a>
+
+
+	<a href="/Category:Education-and-Communications" class="menuitem top_cat"
+		
+		
+		
+	>
+		Education and Communications
+
+	</a>
+
+
+	<a href="/Category:Family-Life" class="menuitem top_cat"
+		
+		
+		
+	>
+		Family Life
+
+	</a>
+
+
+	<a href="/Category:Finance-and-Business" class="menuitem top_cat"
+		
+		
+		
+	>
+		Finance and Business
+
+	</a>
+
+
+	<a href="/Category:Food-and-Entertaining" class="menuitem top_cat"
+		
+		
+		
+	>
+		Food and Entertaining
+
+	</a>
+
+
+	<a href="/Category:Health" class="menuitem top_cat"
+		
+		
+		
+	>
+		Health
+
+	</a>
+
+
+	<a href="/Category:Hobbies-and-Crafts" class="menuitem top_cat"
+		
+		
+		
+	>
+		Hobbies and Crafts
+
+	</a>
+
+
+	<a href="/Category:Holidays-and-Traditions" class="menuitem top_cat"
+		
+		
+		
+	>
+		Holidays and Traditions
+
+	</a>
+
+
+	<a href="/Category:Home-and-Garden" class="menuitem top_cat"
+		
+		
+		
+	>
+		Home and Garden
+
+	</a>
+
+
+	<a href="/Category:Personal-Care-and-Style" class="menuitem top_cat"
+		
+		
+		
+	>
+		Personal Care and Style
+
+	</a>
+
+
+	<a href="/Category:Pets-and-Animals" class="menuitem top_cat"
+		
+		
+		
+	>
+		Pets and Animals
+
+	</a>
+
+
+	<a href="/Category:Philosophy-and-Religion" class="menuitem top_cat"
+		
+		
+		
+	>
+		Philosophy and Religion
+
+	</a>
+
+
+	<a href="/Category:Relationships" class="menuitem top_cat"
+		
+		
+		
+	>
+		Relationships
+
+	</a>
+
+
+	<a href="/Category:Sports-and-Fitness" class="menuitem top_cat"
+		
+		
+		
+	>
+		Sports and Fitness
+
+	</a>
+
+
+	<a href="/Category:Travel" class="menuitem top_cat"
+		
+		
+		
+	>
+		Travel
+
+	</a>
+
+
+	<a href="/Category:Work-World" class="menuitem top_cat"
+		
+		
+		
+	>
+		Work World
+
+	</a>
+
+
+	<a href="/Category:Youth" class="menuitem top_cat"
+		
+		
+		
+	>
+		Youth
+
+	</a>
+
+
+	
+</div>
+</li><li id="nav_help_li" class="nav_item" role="menuitem" aria-labelledby="nav_help"><div class="nav_icon"></div><a id="nav_help" class="nav" href="#">HELP US</a><div class="menu" role="menu">
+	<a href="/Special:CommunityDashboard" class="menuitem "
+		
+		
+		
+	>
+		Community Dashboard
+
+	</a>
+
+
+	<a href="/Special:CreatePage" class="menuitem "
+		
+		
+		
+	>
+		Write an Article
+
+	</a>
+
+
+	<a href="/Special:RequestTopic" class="menuitem "
+		
+		
+		
+	>
+		Request a New Article
+
+	</a>
+
+
+	<a href="/Special:CommunityDashboard" class="menuitem "
+		
+		
+		
+	>
+		More Ideas...
+
+	</a>
+
+
+	
+</div>
+</li><li id="nav_edit_li" class="nav_item" role="menuitem" aria-labelledby="nav_edit"><div class="nav_icon"></div><a id="nav_edit" class="nav" href="#wh-dialog-edit" rel="nofollow">EDIT</a><div class="menu" role="menu">
+	<a href="#wh-dialog-edit" class="menuitem "
+		
+		rel=nofollow
+		
+	>
+		Edit this Article
+
+	</a>
+
+
+	
+</div>
+</li><li id="nav_pro_li" class="nav_item" role="menuitem" aria-labelledby="nav_pro"><div class="nav_icon"></div><div class="red_dot"></div><a id="nav_pro" class="nav" href="#"><div class="label">PRO</div></a><div class="menu" role="menu">
+	<a href="/Course/Explore" class="menuitem "
+		
+		
+		
+	>
+		Courses
+
+		<span class="new_bubble">New</span>
+	</a>
+
+
+	<a href="/Tech-Help-Pro?id=skillsforwork" class="menuitem "
+		id="menu-tech-help"
+		
+		data-version="Skills for Work"
+	>
+		Skills for Work
+
+		<span class="new_bubble">New</span>
+	</a>
+
+
+	<a href="/wikiHow:Videos-wikiHowPro" class="menuitem "
+		
+		
+		
+	>
+		Expert Videos
+
+	</a>
+
+
+	<a href="/Pro" class="menuitem "
+		
+		
+		
+	>
+		About wikiHow Pro
+
+	</a>
+
+	<hr />
+
+	<a href="#wh-dialog-pro" class="menuitem upgrade"
+		
+		rel=nofollow
+		
+	>
+		Upgrade
+
+	</a>
+
+
+	<a href="#wh-dialog-login" class="menuitem sign_in"
+		
+		rel=nofollow
+		
+	>
+		Sign In
+
+	</a>
+
+
+	
+</div>
+</li></ul></div></div><div id="header_container_small" class="header_container shrunk"></div><div id="header_top_watch"></div><div id="mw-mf-viewport"><div id="mw-mf-page-left"><ul id="mobile_menu"><li class="icon-home"><a href="/Main-Page">Home</a></li><li id="randomButton" class="icon-random"><a href="/Special:Randomizer">Random</a></li><li id="icon-categories" class="icon-categories"><a href="/Special:CategoryListing">Browse Articles</a></li><li id="icon-courses" class="icon-courses"><a href="/Course/Explore">Courses<span class="new_bubble">New</span></a></li><li id="icon-aboutwikihow" class="icon-aboutwikihow"><a href="/wikiHow:About-wikiHow">About wikiHow</a></li><li id="header2" class="side_header">Easy Ways to Help</li><li id="icon-sortquestions" class="icon-sortquestions"><a href="/Special:SortQuestions">Approve Questions</a></li><li id="icon-spellchecker" class="icon-spellchecker"><a href="/Special:MobileSpellchecker">Fix Spelling</a></li><li id="icon-quizyourself" class="icon-quizyourself"><a href="/Special:QuizYourself">Quiz App</a></li><li id="icon-morethings" class="icon-morethings"><a href="/Special:MobileCommunityDashboard">More Things to Try...</a></li></ul><ul><li class="icon-anon"><a href="#wh-dialog-login">Log in / Sign up</a></li></ul><div class="mw-mf-display-toggle"><a href="/wikiHow:Terms-of-Use" class="gdpr-menu">Terms of Use</a></div></div><div id="mw-mf-page-center"><div id="gdpr"><div id="gdpr_text"><span id="gdpr_text_inner">We use cookies to make wikiHow great. By using our site, you agree to our <a href="/wikiHow:Cookie-Policy" title="wikiHow:Cookie Policy">cookie policy</a>.</span><a id="gdpr_cp_link" href="/wikiHow:Cookie-Policy#eu_cookie_policy">Cookie Settings</a></div><div id="gdpr_accept_wrap"><div id="gdpr_accept" class="gdpr_button">Okay</div></div><div id="gdpr_close">&#10006</div></div><script>if(WH.gdpr){WH.gdpr.initialize();}</script><div id="trust_banner">
+	<div>
+		<a href="/wikiHow:Delivering-a-Trustworthy-Experience" target="_blank">
+			<span>wikiHow is where trusted research and expert knowledge come together. </span>Learn why people <b>trust wikiHow</b>
+		</a>
+	</div>
+</div><div id="siteNotice"></div><div id="content_wrapper" role="main"><script>var $jscomp=$jscomp||{};$jscomp.scope={};$jscomp.ASSUME_ES5=!1;$jscomp.ASSUME_NO_NATIVE_MAP=!1;$jscomp.ASSUME_NO_NATIVE_SET=!1;$jscomp.defineProperty=$jscomp.ASSUME_ES5||"function"==typeof Object.defineProperties?Object.defineProperty:function(c,e,f){c!=Array.prototype&&c!=Object.prototype&&(c[e]=f.value)};$jscomp.getGlobal=function(c){return"undefined"!=typeof window&&window===c?c:"undefined"!=typeof global&&null!=global?global:c};$jscomp.global=$jscomp.getGlobal(this);$jscomp.SYMBOL_PREFIX="jscomp_symbol_";$jscomp.initSymbol=function(){$jscomp.initSymbol=function(){};$jscomp.global.Symbol||($jscomp.global.Symbol=$jscomp.Symbol)};$jscomp.Symbol=function(){var c=0;return function(e){return $jscomp.SYMBOL_PREFIX+(e||"")+c++}}();$jscomp.initSymbolIterator=function(){$jscomp.initSymbol();var c=$jscomp.global.Symbol.iterator;c||(c=$jscomp.global.Symbol.iterator=$jscomp.global.Symbol("iterator"));"function"!=typeof Array.prototype[c]&&$jscomp.defineProperty(Array.prototype,c,{configurable:!
+0,writable:!0,value:function(){return $jscomp.arrayIterator(this)}});$jscomp.initSymbolIterator=function(){}};$jscomp.initSymbolAsyncIterator=function(){$jscomp.initSymbol();var c=$jscomp.global.Symbol.asyncIterator;c||(c=$jscomp.global.Symbol.asyncIterator=$jscomp.global.Symbol("asyncIterator"));$jscomp.initSymbolAsyncIterator=function(){}};$jscomp.arrayIterator=function(c){var e=0;return $jscomp.iteratorPrototype(function(){return e<c.length?{done:!1,value:c[e++]}:{done:!0}})};$jscomp.iteratorPrototype=function(c){$jscomp.initSymbolIterator();c={next:c};c[$jscomp.global.Symbol.iterator]=function(){return this};return c};$jscomp.iteratorFromArray=function(c,e){$jscomp.initSymbolIterator();c instanceof String&&(c+="");var f=0,p={next:function(){if(f<c.length){var n=f++;return{value:e(n,c[n]),done:!1}}p.next=function(){return{done:!0,value:void 0}};return p.next()}};p[Symbol.iterator]=function(){return p};return p};$jscomp.polyfill=function(c,e,f,p){if(e){f=$jscomp.global;c=c.split(".")
+;for(p=0;p<c.length-1;p++){var n=c[p];n in f||(f[n]={});f=f[n]}c=c[c.length-1];p=f[c];e=e(p);e!=p&&null!=e&&$jscomp.defineProperty(f,c,{configurable:!0,writable:!0,value:e})}};$jscomp.polyfill("Array.prototype.keys",function(c){return c?c:function(){return $jscomp.iteratorFromArray(this,function(c){return c})}},"es6","es3");$jscomp.polyfill("Object.is",function(c){return c?c:function(c,f){return c===f?0!==c||1/c===1/f:c!==c&&f!==f}},"es6","es3");$jscomp.polyfill("Array.prototype.includes",function(c){return c?c:function(c,f){var e=this;e instanceof String&&(e=String(e));var n=e.length;f=f||0;for(0>f&&(f=Math.max(f+n,0));f<n;f++){var r=e[f];if(r===c||Object.is(r,c))return!0}return!1}},"es7","es3");$jscomp.checkStringArgs=function(c,e,f){if(null==c)throw new TypeError("The 'this' value for String.prototype."+f+" must not be null or undefined");if(e instanceof RegExp)throw new TypeError("First argument to String.prototype."+f+" must not be a regular expression");return c+""};$jscomp.
+polyfill("String.prototype.includes",function(c){return c?c:function(c,f){return-1!==$jscomp.checkStringArgs(this,c,"includes").indexOf(c,f||0)}},"es6","es3");$jscomp.findInternal=function(c,e,f){c instanceof String&&(c=String(c));for(var p=c.length,n=0;n<p;n++){var r=c[n];if(e.call(f,r,n,c))return{i:n,v:r}}return{i:-1,v:void 0}};$jscomp.polyfill("Array.prototype.find",function(c){return c?c:function(c,f){return $jscomp.findInternal(this,c,f).v}},"es6","es3");WH.ads=function(){function c(){return 0<=[1,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24].indexOf(parseInt(window.bucketId))?!0:!1}function e(){var a=(new URLSearchParams(window.location.search)).get("forcebidder");if(a){k("prebid force bidder:",a);var b=[],d;for(d in t){var g=t[d],c=[],f;for(f in g.bids){var e=g.bids[f];e.bidder==a&&c.push(e)}0<c.length&&(g.bids=c,b.push(g))}k("prebid filtered adUnits",b);t=b}}function f(){var a=window.location.href,b="";0<a.indexOf("pwtv=")&&(a=/pwtv=(.*?)(&|$)/g.exec(a),2<=a.
+length&&0<a[1].length&&(b="/"+a[1]));a=document.createElement("script");a.addEventListener("load",function(){1==window.pbjsloaded&&(k("pwt loaded second"),WH.event("pubmatic_ih",{pwtloaded:!0,pwt_first:!1}),I=!0,t.forEach(function(a){a.bids.forEach(function(a){a.userId=window.PWT.getUserIds();a.userIdAsEids=owpbjs.getUserIdsAsEids()})}))});a.async=!0;a.type="text/javascript";a.src="//ads.pubmatic.com/AdServer/js/pwt/159508/3580"+b+"/pwt.js";b=document.getElementsByTagName("script")[0];b.parentNode.insertBefore(a,b)}function p(){if(1!=window.pbjsrequested){c()&&f();var a=document.createElement("script");a.async=!0;a.type="text/javascript";a.src="/load.php?modules=ext.wikihow.prebid43&only=scripts&v=1";var b=document.getElementsByTagName("script")[0];b.parentNode.insertBefore(a,b);window.pbjsrequested=!0;k("prebid js requested");window.pbjs.que.push(function(){k("prebid initializing prebid configuration and adding ad units");window.pbjsloaded=!0;window.pbjs.bidderSettings={triplelift:{
+sendStandardTargeting:!0,adserverTargeting:[{key:"tl_source",val:function(a){return a.tl_source}}]},districtmDMX:{bidCpmAdjustment:function(a,b){return.9*a}}};var a={enableSendAllBids:!1,priceGranularity:O};24==window.bucketId&&P()&&(a={enableSendAllBids:!1,priceGranularity:O,s2sConfig:[{accountId:"1",bidders:["pubmatic"],adapter:"prebidServer",enabled:!0,endpoint:"https://bid.wikihow.com/openrtb2/auction",syncEndpoint:"https://bid.wikihow.com/cookie_sync",timeout:500}]});k("prebid useBidCache",!0);a.useBidCache=!0;e();pbjs.setConfig(a);c()&&window.PWT&&"function"==typeof window.PWT.getUserIds&&(k("pwt loaded first"),WH.event("pubmatic_ih",{pwtloaded:!0,pwt_first:!0}),I=!0,t.forEach(function(a){a.bids.forEach(function(a){a.userId=window.PWT.getUserIds();a.userIdAsEids=owpbjs.getUserIdsAsEids()})}));window.pbjs.addAdUnits(t)})}}function n(a){k("pbRequestBids",a.adTargetId,a.adunitpath);c()&&0==I&&WH.event("pubmatic_ih",{pwtloaded:!1,pwt_first:!0});a.pbTimedOut=!1;a.last_pb_request_time=
+(new Date).getTime();window.pbjs.requestBids({adUnitCodes:[a.adunitpath],timeout:1E3,bidsBackHandler:function(b,d){a.pbTimedOut=d;var g=Object.keys(b)[0];"undefined"!=typeof g&&(k("pbRequestBids result",a.adTargetId,b[g],", timedOut:",d),window.pbjs.setTargetingForGPTAsync([a.adunitpath]));a.pbTargetingAdded=!0;1==a.apsDisplayBidsCalled||0==a.apsload?(k("pbRequestBids: done and aps targeting done (or inactive). will load ad",a.adTargetId),D(a)):k("pbRequestBids: done. waiting on aps bid",a.adTargetId)}})}function r(a){window.pbjs.que.push(function(){n(a)})}function ba(a){a=a.slot;var b=a.getSlotId().getDomId();if(w&&w.adTargetId==b)return w;for(b=0;b<m.length;b++){var d=m[b];if(l[d.adTargetId]==a)return d}for(b in q)if(d=q[b],l[d.adTargetId]==a)return d;for(b in x)if(d=x[b],l[d.adTargetId]==a)return d;return null}function k(){-1!=window.location.href.indexOf("adslog=1")&&console.log.apply(console,arguments)}function P(){if(-1!=window.location.href.indexOf("adsraw=1"))return!0}function
+ca(){var a=!1;null!=document.hidden?a=document.hidden:null!=document.mozHidden?a=document.mozHidden:null!=document.webkitHidden?a=document.webkitHidden:null!=document.msHidden&&(a=document.msHidden);return a}function da(a,b,d){k("apsFetchBids:",d.adTargetId);d.apsTimeout||console.warn("ad has no timeout value",d);for(var g=[],c=0;c<b.length;c++)g.push(l[b[c]]);apstag.fetchBids({slots:a,timeout:d.apsTimeout},function(a){window.googletag.cmd.push(function(){apstag.setDisplayBids();d.apsDisplayBidsCalled=!0;d.pbload?1==d.pbTargetingAdded?(k("apsFetchBids: done. pb targeting also done. will load ad",d.adTargetId),D(d)):k("apsFetchBids: done. waiting for prebid bids",d.adTargetId):(k("apsFetchBids: done will load ad",d.adTargetId),D(d))})})}function Q(a){var b=window.location.href;a=a.replace(/[\[\]]/g,"\\$&");return(a=(new RegExp("[?&]"+a+"(=([^&#]*)|&|#|$)")).exec(b))?a[2]?decodeURIComponent(a[2].replace(/\+/g," ")):"":null}function D(a){k("setDFPTargetingAndRefresh",a.adTargetId);var b=l
+[a.adTargetId];setDFPTargeting(b,dfpKeyVals);b.getTargetingMap();a.pbload&&(a.insertSlotValue&&b.setTargeting("slot",a.insertSlotValue),a=b.getTargetingMap().hb_pb,"undefined"!=typeof a&&"undefined"!=typeof a[0]&&(a=(new URLSearchParams(window.location.search)).get("forceprice"))&&(k("setDFPTargetingAndRefresh: updating bid price on hb_pb for testing",a),b.setTargeting("hb_pb",a)),a=b.getTargetingMap().hb_bidder,"undefined"!=typeof a&&"triplelift"!=a[0]&&b.clearTargeting("tl_source"));-1!=window.location.href.indexOf("amzntest=1")&&(b.clearTargeting("amzniid"),b.clearTargeting("amznsz"),b.setTargeting("amznp",2),b.setTargeting("amznbid",2),b.clearTargeting("hb_adid"),b.clearTargeting("hb_bidder"),b.clearTargeting("hb_format"),b.clearTargeting("hb_pb"),b.clearTargeting("hb_size"),b.clearTargeting("hb_source"),b.clearTargeting("tl_source"));(a=Q("testad"))&&b.setTargeting("testad",a);E&&WH.event("gpt_request",{bucket:window.bucketId});window.googletag.pubads().refresh([b])}function F(a){
+for(var b=a.adTargetId,d=l[b].getAdUnitPath(),g=l[b].getSizes(),c=[],f=0;f<g.length;f++){var k=[];k.push(g[f].getWidth());k.push(g[f].getHeight());c.push(k)}da([{slotID:b,slotName:d,sizes:c}],[b],a)}function R(a,b,d){l[a]&&dfpKeyVals[l[a].getAdUnitPath()]&&(dfpKeyVals[l[a].getAdUnitPath()][b]=d)}function ea(a){var b=a.adTargetId,d=a.gptLateLoad,g=a.getRefreshValue();window.googletag.cmd.push(function(){d&&window.googletag.display(b);R(b,"refreshing",g);setDFPTargeting(l[b],dfpKeyVals);var a=Q("testad");a&&l[b].setTargeting("testad",a);E&&WH.event("gpt_request",{bucket:window.bucketId});window.googletag.pubads().refresh([l[b]])})}function fa(a){var b=window.document.createElement("script");b.async=!0;b.type="text/javascript";b.src=a.adElement.getAttribute("data-scriptsrc");b.setAttribute("data-divid",a.adTargetId);b.setAttribute("data-adslot","demo_optout");b.setAttribute("data-adsizes","300x250");window.document.getElementById(a.adTargetId).appendChild(b)}function S(a){k(
+"inserting adsense ad",a.type);var b=window.document.createElement("ins");b.setAttribute("data-ad-client","ca-pub-9543332082073187");a.adLabelClass?b.setAttribute("class","adsbygoogle "+a.adLabelClass):b.setAttribute("class","adsbygoogle");var d=a.slot;if(d){b.setAttribute("data-ad-slot",d);d=null;var g=0<=document.cookie.indexOf("ccpa_out=")?!0:!1;g?(b.setAttribute("data-restrict-data-processing",1),"intro"==a.type&&(d=2385774741)):"intro"==a.type&&(d=2001974826);a.adElement.getAttribute("data-ad-format")&&b.setAttribute("data-ad-format",a.adElement.getAttribute("data-ad-format"));a.adElement.getAttribute("data-full-width-responsive")&&b.setAttribute("data-full-width-responsive",a.adElement.getAttribute("data-full-width-responsive"));WH.shared.isSmallSize&&a.adElement.getAttribute("data-full-width-intro")&&(a.width=document.documentElement.clientWidth);"middlerelated"==a.type&&(b.setAttribute("data-ad-format","fluid"),b.setAttribute("data-ad-layout-key","-fb+5w+4e-db+86"));g=0;var c=
+document.getElementById("mw-content-text");c&&(g=c.offsetWidth);"medium"==a.adSize&&700>g||("medium"==a.adSize&&728>g&&(a.width=g),g="display:inline-block;width:"+a.width+"px;height:"+a.height+"px;",c=["method","qa","tips","warnings"],"small"==a.adSize&&c.includes(a.type)&&(g="display:block;height:"+a.height+"px;"),b.style.cssText=g,a.adTargetId&&(window.document.getElementById(a.adTargetId).appendChild(b),a.channels&&(d=d?a.channels+","+d:a.channels),d||(d=""),"undefined"===typeof adsbygoogle&&(window.adsbygoogle=[]),a.nonPersonalized&&((window.adsbygoogle=window.adsbygoogle||[]).requestNonPersonalizedAds=1),(window.adsbygoogle=window.adsbygoogle||[]).push({params:{google_ad_channel:d}})))}}function ha(a){var b=document.documentElement.clientWidth;switch(a){case"intro":b-=30;break;case"method":b-=20;break;case"related":b-=14;break;default:b-=20}return b}function T(a){var b=a.parentElement;this.element=a;this.adElement=b;this.height=this.adElement.offsetHeight;this.adTargetId=a.id;a=1
+==this.adElement.getAttribute("data-small");var d=1==this.adElement.getAttribute("data-medium"),g=1==this.adElement.getAttribute("data-large");this.okForSize=!1;if(a&&WH.shared.isSmallSize||d&&WH.shared.isMedSize||g&&WH.shared.isLargeSize)this.okForSize=!0;var c=window.navigator.userAgent.toLowerCase();/safari/.test(c);/iphone|ipod|ipad/.test(c);this.type=this.adElement.getAttribute("data-type");this.width=this.adElement.getAttribute("data-width");this.service=this.adElement.getAttribute("data-service");if(this.sizesArray=this.adElement.getAttribute("data-size"))this.sizesArray=JSON.parse(this.sizesArray);this.disabled=!1;if(this.okForSize){this.adElement.classList.add("wh_ad_active");this.questionsPage=1==this.adElement.getAttribute("data-questionspage");this.listPage=1==this.adElement.getAttribute("data-listpage");this.gptLateLoad=1==this.adElement.getAttribute("data-lateload");this.apsload=1==this.adElement.getAttribute("data-apsload");this.apsDisplayBidsCalled=!1;var f=this.
+adElement.getAttribute("data-adunitpath");if(this.pbload=1==this.adElement.getAttribute("data-prebidload")){var e=!1;t.forEach(function(a){a.code==f&&(e=!0)});0==e&&(this.pbload=!1,k("ad set up for prebid but not found in bids list. will set prebid to false for",f))}this.pbTargetingAdded=!1;this.last_hb_adid=null;this.insertSlotValue=this.adElement.getAttribute("data-insertslotvalue");this.insertPosition=0;if("true"==window.isCoppa||window.ccpaOut)this.pbload=!1;U?(this.pbload=!1,this.nonPersonalized=!0):this.nonPersonalized=!1;this.slot=this.adElement.getAttribute("data-slot");this.adunitpath=this.adElement.getAttribute("data-adunitpath");this.channels=this.adElement.getAttribute("data-channels");this.mobileChannels=this.adElement.getAttribute("data-mobilechannels");this.refreshable=1==this.adElement.getAttribute("data-refreshable");this.emptyLogging=1==this.adElement.getAttribute("data-emptylogging");this.slotName=this.adElement.getAttribute("data-slot-name");this.refreshType=this.
+adElement.getAttribute("data-refresh-type");this.last_pb_request_time=0;this.dfpdisplaylate=1==this.adElement.getAttribute("data-gptdisplaylate");"rightrail"==this.type&&(this.position="initial");this.notfixedposition=1==this.adElement.getAttribute("data-notfixedposition");this.viewablerefresh=1==this.adElement.getAttribute("data-viewablerefresh");this.renderrefresh=1==this.adElement.getAttribute("data-renderrefresh");this.height=this.adElement.getAttribute("data-height");this.lastRRAd=1==this.adElement.getAttribute("data-lastrrad");a&&WH.shared.isSmallSize&&(this.adSize="small",this.channels=this.mobileChannels,this.smallchannels=this.adElement.getAttribute("data-smallchannels"),this.channels=this.channels?this.channels+","+this.smallchannels:this.smallchannels,this.slot=this.adElement.getAttribute("data-smallslot")||this.slot,this.height=this.adElement.getAttribute("data-smallheight")||this.height,this.width=ha(this.type),this.service=this.adElement.getAttribute("data-smallservice")
+||this.service);d&&WH.shared.isMedSize&&(this.element.className=this.element.className?this.element.className+" medium_a":"medium_a",this.adSize="medium",this.slot=this.adElement.getAttribute("data-mediumslot")||this.slot,this.height=this.adElement.getAttribute("data-mediumslot")||this.height,this.width=this.adElement.getAttribute("data-mediumwidth")||this.width,this.service=this.adElement.getAttribute("data-mediumservice")||this.service,this.channels=this.mediumChannels=this.adElement.getAttribute("data-mediumchannels"));g&&WH.shared.isLargeSize&&(this.adSize="large",this.channels=this.largeChannels=this.adElement.getAttribute("data-largechannels"));"adsense"!=this.service||this.slot?(this.instantLoad=1==this.adElement.getAttribute("data-instantload"),"intro"==this.type&&"small"!=this.adSize&&J()&&(this.instantLoad=!1,this.service="dfp",this.height=90,this.element.style.height="90px",this.adElement.style.height="90px"),"intro"==this.type&&J()&&"small"!=this.adSize&&!J()&&(this.
+channels=this.channels?this.channels+",5517265073":"5517265073"),this.adLabelClass=this.adElement.getAttribute("data-adlabelclass"),this.apsTimeout=this.adElement.getAttribute("data-aps-timeout"),this.refreshtimeout=!1,this.refreshNumber=1,this.maxRefresh=this.adElement.getAttribute("data-max-refresh"),this.refreshTime=(this.refreshTime=this.adElement.getAttribute("data-refresh-time"))?parseInt(this.refreshTime):3E4,this.firstRefresh=!0,this.firstRefreshTime=(this.firstRefreshTime=this.adElement.getAttribute("data-first-refresh-time"))?parseInt(this.firstRefreshTime):this.refreshTime,this.useScrollLoader=!0,this.observerLoading=1==this.adElement.getAttribute("data-observerloading"),this.getRefreshTime=function(){return 1==this.firstRefresh?(this.firstRefresh=!1,this.firstRefreshTime):this.refreshTime},this.getRefreshValue=function(){if(0==this.refreshNumber&&!this.refreshable)return"not";this.refreshNumber++;return 20<this.refreshNumber?"max":this.refreshNumber.toString()},this.load=
+function(){var a=1==this.adElement.getAttribute("data-small"),b=1==this.adElement.getAttribute("data-medium"),d=1==this.adElement.getAttribute("data-large"),g=!1;if(a&&WH.shared.isSmallSize||b&&WH.shared.isMedSize||d&&WH.shared.isLargeSize)g=!0;if(!g)this.disabled=!0;else if(!("undefined"!=typeof WH.gdpr&&WH.gdpr.isEULocation()&&WH.gdpr.hasCookiePolicyPageOptOut()||1==this.isLoaded)){if("dfp"==this.service){"small"!=this.adSize&&0<this.height&&(this.element.style.minHeight=this.height+"px");c&&(k("clearing kvp for ad",this.adTargetId),c.clearTargeting());if(this.apsload){var c=l[this.adTargetId],N=this;c?F(N):window.googletag.cmd.push(function(){F(N)})}this.pbload&&r(this);this.apsload||this.pbload||ea(this)}else"dfplight"==this.service?insertDFPLightAd(this):"optout"==this.service?fa(this):S(this);this.isLoaded=!0}},this.refresh=function(){var a=this;if(ca())k("refresh: doc hidden"),setTimeout(function(){a.refresh()},5E3);else{this.lastRefreshScrollY=window.scrollY;var b=window.
+innerHeight||document.documentElement.clientHeight,d=this.element.getBoundingClientRect();if(y(d,b,!1,a))if(b=this.getRefreshValue(),this.maxRefresh&&b>this.maxRefresh)k("max refreshes reached returning"),this.refreshable=!1;else{if("adsense"!=this.service&&R(this.adTargetId,"refreshing",b),this.apsload&&F(this),this.pbload&&r(this),!this.apsload&&!this.pbload){var g=this.adTargetId;window.googletag.cmd.push(function(){setDFPTargeting(l[g],dfpKeyVals);E&&WH.event("gpt_request",{bucket:window.bucketId});window.googletag.pubads().refresh([l[g]])})}}else setTimeout(function(){a.refresh()},5E3)}},this.show=function(){this.adElement.style.display="block"},this.instantLoad&&"adsense"==this.service&&this.load()):(this.disabled=!0,b.style.display="none")}else this.disabled=!0,b.parentElement.removeChild(b),b.style.display="none"}function V(a){T.call(this,a)}function ia(a){T.call(this,a);a.parentElement.style.display="none";this.scrollToTimer=null;this.slotRendered=!0;this.lastScrollPositionY=0
+;this.maxNonSteps=parseInt(this.adElement.getAttribute("data-maxnonsteps"));this.maxSteps=parseInt(this.adElement.getAttribute("data-maxsteps"));this.maxDFP=null;this.adElement.getAttribute("data-maxdfp")&&(this.maxDFP=parseInt(this.adElement.getAttribute("data-maxdfp")));this.noStepsAds=!1;0<document.getElementsByClassName("questions_as_methods_articles").length&&(this.noStepsAds=!0);this.updateVisibility=function(){if(0==this.slotRendered)k("updateVisibility: will not try to insert scrollto ad because prev render is not done");else if(1>this.maxNonSteps&&1>this.maxSteps)z&&(window.removeEventListener("scroll",z),z=null);else if(this.lastScrollPositionY=window.scrollY,10<this.lastScrollPositionY){null!==this.scrollToTimer&&clearTimeout(this.scrollToTimer);var a=this;this.scrollToTimer=setTimeout(function(){a.load()},1E3)}};this.load=function(){if((window.innerWidth||document.documentElement.clientWidth)<WH.mediumScreenMinWidth)this.maxSteps=this.maxNonSteps=0;else if("undefined"==
+typeof WH.gdpr||!WH.gdpr.isEULocation()||WH.gdpr.hasAcceptCookie()){a:{var a=window.innerHeight||document.documentElement.clientHeight;var d=document.getElementsByClassName("section"),g=!1;this.questionsPage&&(g=!0,d=document.getElementsByClassName("qa_aq"));this.listPage&&(g=!0);for(var c=null,f=!1,k=0;k<d.length;k++)if(!(g&&k%2)){var e=d[k];if("aiinfo"!=e.id&&!e.classList.contains("bss_share_container")&&!e.classList.contains("tips")&&!e.classList.contains("references")){if(1==f){var h=e.getElementsByClassName("section_text");if(!h.length&&!g){a=null;break a}g||(e=h[h.length-1]);if("references_second"==e.id)continue;h=e.getBoundingClientRect();if(h.bottom>=screenTop&&h.bottom<=a)continue;c=e;break}if("intro"!=e.id){if(e.classList.contains("steps")&&!this.noStepsAds){h=e.getElementsByClassName("steps_list_2");if(!h||!h[0])continue;e=a;h=h[0].childNodes;for(var l=null,m=0;m<h.length;m++){var n=h[m];if("LI"==n.nodeName){var p=n.getBoundingClientRect();if(y(p,e,!1,this)&&!(p.bottom>=
+screenTop&&p.bottom<=e)){l=n;break}}}e=l;if(!e)continue;c=e;break}if((h=e.getElementsByClassName("section_text"))&&h[0]||g)if(g||(e=h[0]),h=e.getBoundingClientRect(),y(h,a,!1,this))if(h.bottom>=screenTop&&h.bottom<=a)f=!0;else{c=e;break}}}}a=c}a&&(d="LI"==a.tagName,d&&1>this.maxSteps||!d&&1>this.maxNonSteps||(g=a.getElementsByTagName("INS"),0<g.length||(g=a.getElementsByClassName("wh_ad_active"),0<g.length||(0<a.getElementsByClassName("addTipElement").length&&a.classList.add("has_scrolltoad"),g=document.createElement("div"),c=document.createElement("div"),this.height&&(g.style.minHeight=this.height+"px"),c.id=this.adTargetId,g.className="wh_ad_inner wh_ad_active wh_ad_spacing",g.className+=" w_label al_grey al_t",g.appendChild(c),a.appendChild(g),this.insertPosition=a.id,this.insertSlotValue=10<A?"0"+A:"00"+A,A++,this.element.id="scrollto_ad_"+A,d?this.maxSteps--:this.maxNonSteps--,"dfp"==this.service&&this.slot&&0==this.maxDFP&&(this.service="adsense"),null!=this.maxDFP&&0<this.maxDFP
+&&this.maxDFP--,ja(this)))))}}}function ka(a){var b=document.getElementById("scrollto-promo"),d=b.getAttribute("data-promos"),c=JSON.parse(d);d=c.pop();b.setAttribute("data-promos",JSON.stringify(c));b=document.createElement("a");b.setAttribute("href",d.url);c=a.adTargetId+"_a";b.id=c;var e=document.createElement("img");e.setAttribute("loading","lazy");e.setAttribute("width",728);e.setAttribute("height",90);e.setAttribute("src",d.src);b.appendChild(e);e=document.getElementById(a.adTargetId);e.appendChild(b);e.style.width="728px";document.getElementById(a.adTargetId).appendChild(b);K&&WH.event("article_promo_house_image_load_go_sc",{ad_unit:"scrollto",img_name:d.name});WH.eventView("article_promo_house_scrollto_click_go_sc",{course_name:d.course_name,dest_url:d.url},"#"+c,"click");a.adTargetId=a.element.id;a.slotRendered=!0}function ja(a){"house"==a.service?ka(a):"dfp"==a.service?(a.slotRendered=!1,window.googletag.cmd.push(function(){k("defining new ad slot",a.adTargetId);l[a.
+adTargetId]=window.googletag.defineSlot(a.adunitpath,a.sizesArray,a.adTargetId);l[a.adTargetId].addService(window.googletag.pubads());l[a.adTargetId].clearTargeting();l[a.adTargetId].setTargeting("slot",a.insertSlotValue);window.googletag.display(a.adTargetId);a.apsload&&F(a);a.pbload&&r(a);a.pbload||a.apsload||D(a)})):(S(a),a.adTargetId=a.element.id,a.slotRendered=!0)}function y(a,b,d,c){var g=B;d&&(d=b,c instanceof V&&(d=2*b),g=0-d,b+=d);return a.top>=g&&a.top<=b||a.bottom>=g&&a.bottom<=b||a.top<=g&&a.bottom>=b||c.last&&a.top<=g?!0:!1}function W(a,b){if(!a.isLoaded&&0!=a.useScrollLoader){var d=a.element.getBoundingClientRect();y(d,b,!0,a)&&a.load()}}function X(a,b){if(!G){var d=a.adElement.getBoundingClientRect();if(!y(d,b,!1,a))return"fixed"==a.position&&(a.element.style.position="absolute",a.element.style.top="0",a.element.style.bottom="auto",a.position="top"),d.height;b=B+parseInt(a.height);if(d.bottom<b&&!a.last)"bottom"!=a.position&&(a.element.style.position="absolute",a.element
+.style.top="auto",a.element.style.bottom="0",a.position="bottom");else if(d.top<=B){"fixed"!=a.position&&(a.element.style.position="fixed",a.isFixed=!0,a.position="fixed");b=B;if(a.last){var c=window.scrollY+B+parseInt(a.height),e=document.documentElement.scrollHeight-L;c>e&&(b-=c-e)}a.element.style.top=b+"px"}else"top"!=a.position&&(a.element.style.position="absolute",a.element.style.top="0",a.element.style.bottom="auto",a.position="top");return d.height}}function la(){for(var a=window.innerHeight||document.documentElement.clientHeight,b=[],d=0;d<m.length;d++){var c=m[d];c.notfixedposition||(b[d]=X(c,a))}a=m;if(WH.shared.isLargeSize&&!(Y||40<=Z||"complete"!=document.readyState)){Z++;d=0;if(c=document.getElementById("sidebar"))d=c.offsetHeight;c=0;var e=document.getElementById("article");e&&(c=e.offsetHeight);if(0<c&&0<d&&d>c){c=parseInt((d-c+10)/3);e=!1;for(d=0;d<a.length;d++){var f=b[d]-c;if(600>f){e=!0;break}a[d].element.style.height=f+"px"}if(1==e){for(d=1;d<a.length;d++)b=a[d].
+element,b.parentElement.removeChild(b);a.length=1}Y=!0}}}function M(){for(var a=!0,b=window.innerHeight||document.documentElement.clientHeight,d=0;d<m.length;d++){var c=m[d];c.isLoaded||(a=!1,W(c,b))}for(d in q)c=q[d],c.isLoaded||(a=!1,W(c,b));a&&(window.removeEventListener("scroll",H),H=null)}function ma(){w.updateVisibility()}function J(){if(null!==C)return C;var a=("; "+document.cookie).split("; vr="),b=null;2==a.length&&(b=a.pop().split(";").shift());a=window.location.href;-1==a.indexOf("?EUintrotest=")&&-1==a.indexOf("&EUintrotest=")||(b="ES-A");if(!b)return C=!1;a=["^ES","^FR","^DE","^RU","^IT"];for(var c in a)if(b.match(a[c]))return C=!0;return C=!1}var m=[],l=[],Y=!1,Z=0,x={},w,A=1,u,q={},H=null,z=null,aa=null,B=WH.shared.TOP_MENU_HEIGHT,L=114,v=null,na="0px 0px "+2*(window.innerHeight||document.documentElement.clientHeight)+"px 0px",C=null,oa=parseInt(1E5*Math.random()).toString(),U=!1,G=!1;window.CSS&&window.CSS.supports&&window.CSS.supports("position","sticky")&&(G=!0);var I
+=!1,E=!1;0==Math.floor(100*Math.random())&&(E=!0);var K=!1;0==Math.floor(100*Math.random())&&(K=!0);"undefined"!==typeof WH.gdpr&&WH.gdpr.isEULocation()&&(U=!0);window.googletag=window.googletag||{};window.googletag.cmd=window.googletag.cmd||[];var O={buckets:[{precision:2,max:3,increment:.01},{precision:2,max:8,increment:.05},{precision:2,max:20,increment:.5},{precision:2,max:45,increment:1}]},t=[{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,250]}},bids:[{bidder:"appnexus",params:{placementId:19512203}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,600]}},bids:[{bidder:"appnexus",params:{placementId:19512204}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[120,600]}},bids:[{bidder:"appnexus",params:{placementId:19512206}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[160,600]}},bids:[{bidder:"appnexus",params:{placementId:19512207}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",
+mediaTypes:{banner:{sizes:[300,250]}},bids:[{bidder:"pubmatic",params:{publisherId:"159508",adSlot:"2946786"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,600]}},bids:[{bidder:"pubmatic",params:{publisherId:"159508",adSlot:"2946788"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[120,600]}},bids:[{bidder:"pubmatic",params:{publisherId:"159508",adSlot:"2946816"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[160,600]}},bids:[{bidder:"pubmatic",params:{publisherId:"159508",adSlot:"2946817"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[[300,250],[300,600],[120,600],[160,600]]}},bids:[{bidder:"rubicon",params:{accountId:"15274",zoneId:"1753132",siteId:"333816"}},{bidder:"triplelift",params:{inventoryCode:"Wikihow_engl_gam_lgm_rght2_Prebid"}},{bidder:"districtm",params:{placementId:"19511756"}},{bidder:"districtmDMX",params:{dmxid:529251,memberid:100369}}]},{code:
+"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,250]}},bids:[{bidder:"ix",params:{siteId:"531042",size:[300,250]}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,600]}},bids:[{bidder:"ix",params:{siteId:"531043",size:[300,600]}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[120,600]}},bids:[{bidder:"ix",params:{siteId:"531044",size:[120,600]}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[160,600]}},bids:[{bidder:"ix",params:{siteId:"531045",size:[160,600]}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,250]}},bids:[{bidder:"openx",params:{unit:"541138158",delDomain:"wikihow-d.openx.net"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,600]}},bids:[{bidder:"openx",params:{unit:"541138159",delDomain:"wikihow-d.openx.net"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[120,600]}},bids:[{bidder:"openx",params:{
+unit:"541138160",delDomain:"wikihow-d.openx.net"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[160,600]}},bids:[{bidder:"openx",params:{unit:"541138161",delDomain:"wikihow-d.openx.net"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,250]}},bids:[{bidder:"sovrn",params:{tagid:"741351"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,600]}},bids:[{bidder:"sovrn",params:{tagid:"741352"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[120,600]}},bids:[{bidder:"sovrn",params:{tagid:"741353"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[160,600]}},bids:[{bidder:"sovrn",params:{tagid:"741354"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,250]}},bids:[{bidder:"onemobile",params:{pos:"8a96954f01747430358b365407b70330",dcn:"8a96954f01747430358b3651f057032b"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300
+,600]}},bids:[{bidder:"onemobile",params:{pos:"8a96954f01747430358b36549b1d0332",dcn:"8a96954f01747430358b3651f057032b"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[120,600]}},bids:[{bidder:"onemobile",params:{pos:"8a96954f01747430358b3654d1b40333",dcn:"8a96954f01747430358b3651f057032b"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[160,600]}},bids:[{bidder:"onemobile",params:{pos:"8a96954f01747430358b3653c5d0032f",dcn:"8a96954f01747430358b3651f057032b"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,250]}},bids:[{bidder:"yieldmo",params:{placementId:"2508866731389165650"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,600]}},bids:[{bidder:"yieldmo",params:{placementId:"2508866731498217555"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[120,600]}},bids:[{bidder:"yieldmo",params:{placementId:"2508866731573715028"}}]},{code:
+"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[160,600]}},bids:[{bidder:"yieldmo",params:{placementId:"2508866731657601109"}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[160,600]}},bids:[{bidder:"sharethrough",params:{pkey:"TEFyg552FA0rWm8WyfBGUjyZ",iframeSize:[160,600]}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,250]}},bids:[{bidder:"sharethrough",params:{pkey:"QdqFVSPLRV5oZNThNKyH9cpm",iframeSize:[300,250]}}]},{code:"/10095428/engl/engl_gam_lgm_rght2",mediaTypes:{banner:{sizes:[300,600]}},bids:[{bidder:"sharethrough",params:{pkey:"iclw8Nduh0yGDBIML8Fh0I08",iframeSize:[300,600]}}]},{code:"/10095428/engl/engl_gam_lgm_promo",mediaTypes:{banner:{sizes:[300,250]}},bids:[{bidder:"pubmatic",params:{publisherId:"159508",adSlot:"3484049"}},{bidder:"ix",params:{siteId:"632550",size:[300,250]}},{bidder:"openx",params:{unit:"543971537",delDomain:"wikihow-d.openx.net"}},{bidder:"districtm",params:{placementId:"21099068"}}
+,{bidder:"districtmDMX",params:{dmxid:593764,memberid:100369}},{bidder:"appnexus",params:{placementId:"21222616"}},{bidder:"triplelift",params:{inventoryCode:"Wikihow_engl_gam_lgm_promo_300x250_Prebid"}},{bidder:"sovrn",params:{tagid:"861659"}},{bidder:"onemobile",params:{pos:"engl_gam_lgm_promo",dcn:"8a96954f01747430358b3651f057032b"}},{bidder:"yieldmo",params:{placementId:"2687163485543932751"}},{bidder:"rubicon",params:{accountId:"15274",zoneId:"1986294",siteId:"333816"}},{bidder:"sharethrough",params:{pkey:"2dgIVEkekDipUsLpIoCw26EN",iframeSize:[300,250]}}]},{code:"/10095428/engl/engl_gam_lgm_intro",mediaTypes:{banner:{sizes:[728,90]}},bids:[{bidder:"pubmatic",params:{publisherId:"159508",adSlot:"3224244"}},{bidder:"ix",params:{siteId:"579269",size:[728,90]}},{bidder:"openx",params:{unit:"542288967",delDomain:"wikihow-d.openx.net"}},{bidder:"districtm",params:{placementId:"20261544"}},{bidder:"districtmDMX",params:{dmxid:559286,memberid:100369}},{bidder:"appnexus",params:{
+placementId:"20261433"}},{bidder:"triplelift",params:{inventoryCode:"Wikihow_engl_gam_lgm_intro_728x90_Prebid"}},{bidder:"sovrn",params:{tagid:"777741"}},{bidder:"onemobile",params:{pos:"8a9694c7017474db0327dc33df760300",dcn:"8a96954f01747430358b3651f057032b"}},{bidder:"yieldmo",params:{placementId:"2581129714336735279"}},{bidder:"rubicon",params:{accountId:"15274",zoneId:"1849302",siteId:"333816"}},{bidder:"sharethrough",params:{pkey:"QziDJYElLkw7LFscfNzZmTfF",iframeSize:[728,90]}}]},{code:"/10095428/engl/engl_gam_all_scrol",mediaTypes:{banner:{sizes:[728,90]}},bids:[{bidder:"pubmatic",params:{publisherId:"159508",adSlot:"2946818"}},{bidder:"ix",params:{siteId:"531046",size:[728,90]}},{bidder:"openx",params:{unit:"541138162",delDomain:"wikihow-d.openx.net"}},{bidder:"districtm",params:{placementId:"19511766"}},{bidder:"districtmDMX",params:{dmxid:529252,memberid:100369}},{bidder:"appnexus",params:{placementId:"19512208"}},{bidder:"triplelift",params:{inventoryCode:
+"Wikihow_engl_gam_all_728x90_Prebid"}},{bidder:"sovrn",params:{tagid:"741355"}},{bidder:"onemobile",params:{pos:"8a96954f01747430358b365459b80331",dcn:"8a96954f01747430358b3651f057032b"}},{bidder:"yieldmo",params:{placementId:"2508866731741487190"}},{bidder:"rubicon",params:{accountId:"15274",zoneId:"1753134",siteId:"333816"}},{bidder:"sharethrough",params:{pkey:"YRwAUQ4n3r0xdDMH0TOrPfnH",iframeSize:[728,90]}}]},{code:"/10095428/engl/engl_gam_lgm_early",mediaTypes:{banner:{sizes:[728,90]}},bids:[{bidder:"pubmatic",params:{publisherId:"159508",adSlot:"3224245"}},{bidder:"ix",params:{siteId:"579271",size:[728,90]}},{bidder:"openx",params:{unit:"542288968",delDomain:"wikihow-d.openx.net"}},{bidder:"districtm",params:{placementId:"20261577"}},{bidder:"districtmDMX",params:{dmxid:559288,memberid:100369}},{bidder:"appnexus",params:{placementId:"20261434"}},{bidder:"triplelift",params:{inventoryCode:"Wikihow_engl_gam_lgm_early_728x90_Prebid"}},{bidder:"sovrn",params:{tagid:"777742"}},{bidder:
+"onemobile",params:{pos:"8a9690fd017474dafe8adc342f970052",dcn:"8a96954f01747430358b3651f057032b"}},{bidder:"yieldmo",params:{placementId:"2581129714420621360"}},{bidder:"rubicon",params:{accountId:"15274",zoneId:"1849304",siteId:"333816"}},{bidder:"sharethrough",params:{pkey:"gRRuNlH2aMjBmEgjkjw9vqwh",iframeSize:[728,90]}}]},{code:"/10095428/engl/engl_gam_lgm_later",mediaTypes:{banner:{sizes:[728,90]}},bids:[{bidder:"pubmatic",params:{publisherId:"159508",adSlot:"3224246"}},{bidder:"ix",params:{siteId:"579273",size:[728,90]}},{bidder:"openx",params:{unit:"542288969",delDomain:"wikihow-d.openx.net"}},{bidder:"districtm",params:{placementId:"20262329"}},{bidder:"districtmDMX",params:{dmxid:559289,memberid:100369}},{bidder:"appnexus",params:{placementId:"20261435"}},{bidder:"triplelift",params:{inventoryCode:"Wikihow_engl_gam_lgm_later_728x90_Prebid"}},{bidder:"sovrn",params:{tagid:"777743"}},{bidder:"onemobile",params:{pos:"8a9694c7017474db0327dc347a0a0301",dcn:
+"8a96954f01747430358b3651f057032b"}},{bidder:"yieldmo",params:{placementId:"2581129714504507441"}},{bidder:"rubicon",params:{accountId:"15274",zoneId:"1849306",siteId:"333816"}}]}];window.pbjs=window.pbjs||{};window.pbjs.que=window.pbjs.que||[];window.pbjsrequested=!1;window.pbjsloaded=!1;window.googletag&&(window.googletag.cmd.push(function(){window.googletag.pubads().addEventListener("slotRequested",function(a){a=a.slot;var b=a.getSlotId().getDomId(),c=a.getSlotId().getAdUnitPath();k("GPT slotRequested:",b,c,a.getTargetingMap())})}),window.googletag.cmd.push(function(){window.googletag.pubads().addEventListener("slotResponseReceived",function(a){a=a.slot;var b=a.getSlotId().getDomId(),c=a.getSlotId().getAdUnitPath(),g=a.getResponseInformation(),e=null,f=null;g?(e=g.campaignId,f=g.lineItemId):k("GPT slotResponseReceived: no response information received for request",b);2622783038==e?k("GPT slotResponseReceived: aps won",b,c,"campaign:",e,"lineItem:",f,"queryId:",a.getEscapedQemQueryId
+()):2709340992==e?k("GPT slotResponseReceived: prebid won",b,c,"campaign:",e,"lineItem:",f,"queryId:",a.getEscapedQemQueryId()):k("GPT slotResponseReceived",b,c,"response info",g,"queryId:",a.getEscapedQemQueryId())})}));"IntersectionObserver"in window&&(v=new IntersectionObserver(function(a,b){a.forEach(function(a){if(a.isIntersecting){var b=a.target,c=q[b.id];c&&c.load();for(var d=0;d<m.length;d+=1)c=m[d],c.element==b&&c.load();v.unobserve(a.target)}})},{rootMargin:na}));WH.isMobile&&(L=314);return{init:function(){var a=(window.innerWidth||document.documentElement.clientWidth)>=WH.largeScreenMinWidth;v||(H=WH.shared.throttle(M,100),window.addEventListener("scroll",H));1!=a||G||(aa=WH.shared.throttle(la,10),window.addEventListener("scroll",aa));document.addEventListener("DOMContentLoaded",function(){M()},!1);WH.shared&&WH.shared.addResizeFunction(M);G&&"ResizeObserver"in window&&(a=new ResizeObserver(function(a){if(!(1>m.length||(a=m[m.length-1],2>m.length&&1!=a.lastRRAd))){var b=
+document.getElementById("sidebar").offsetHeight,c=document.scrollingElement.scrollHeight;b=c-(b-a.adElement.offsetHeight)-500;a.adElement.style.height=b+"px";var e=document.scrollingElement.scrollHeight;e>c&&(a.adElement.style.height=b-(e-c)-50+"px")}}),a.observe(document.scrollingElement),a.observe(document.getElementById("mw-mf-page-center")))},addBodyAd:function(a){a=document.getElementById(a);var b=null;b="scrollto"==a.parentElement.getAttribute("data-type")?new ia(a):new V(a);a=null==v?!1:!0;b.disabled||("rightrail"==b.type?(b.last=!0,0<m.length&&(m[m.length-1].last=!1),m.push(b),a&&b.observerLoading&&0==b.instantLoad&&(b.useScrollLoader=!1,v.observe(b.element))):"toc"==b.type?(u=b,b.adElement.style.display="none"):"scrollto"==b.type?(w=b,z=WH.shared.throttle(ma,100),window.addEventListener("scroll",z)):"quiz"==b.type?(x[b.adElement.parentElement.id]=b,b.adElement.parentElement.addEventListener("change",function(a){a=this.id;x[a]&&(b.adElement.classList.remove("hidden"),x[a].load(
+))})):(q[b.element.id]=b,a&&b.observerLoading&&0==b.instantLoad&&(b.useScrollLoader=!1,v.observe(b.element))),"dfp"==b.service&&("scrollto"!=b.type&&b.dfpdisplaylate?window.googletag.cmd.push(function(){k("defining new ad slot",b.adTargetId);l[b.adTargetId]=window.googletag.defineSlot(b.adunitpath,b.sizesArray,b.adTargetId);l[b.adTargetId].addService(window.googletag.pubads());"intro"==b.type&&l[b.adTargetId].setCollapseEmptyDiv(!1);window.googletag.display(b.adTargetId);b.instantLoad&&b.load()}):"scrollto"!=b.type&&window.googletag.cmd.push(function(){window.googletag.display(b.adTargetId)})),b.pbload&&(k("prebid active on",b.adTargetId),p()))},loadTOCAd:function(a){if("string"===typeof a&&(a=a.slice(1),a=document.getElementById(a),u)){var b=$(a).next(".section").find(".steps_list_2 > li:first");$(a).hasClass("mw-headline")&&(b=$(a).parents(".section:first").find(".steps_list_2 > li:first"));b.length&&(b.append($(u.adElement)),u.load(),u.adElement.style.display="block",u=null)}},
+slotRendered:function(a,b,c){a=c.slot;var d=a.getSlotId().getDomId(),e=a.getSlotId().getAdUnitPath(),f=c.isEmpty,l="",m=a.getResponseInformation();if(-1!=window.location.href.indexOf("adslog=1"))if(m&&0==m.isBackfill&&(P()?l=a.getHtml():(l=a.getHtml(),l=[l])),1==f){if(k("GPT slotRenderedEnded: ad is empty:",d,e),-1<d.indexOf("scrollto_ad")||-1<d.indexOf("method_ad"))if(d=document.getElementById(d))k("GPT slotRenderedEnded: removing empty ad:",d),d.parentElement.parentElement.removeChild(d.parentElement)}else e=a.getResponseInformation().campaignId,2622783038==e?k("GPT slotRenderedEnded:",d,"aps creative:",l):2709340992==e?k("GPT slotRenderedEnded:",d,"prebid creative:",l):k("GPT slotRenderedEnded creative:",d,l);var h=ba(c);h&&(h.pbTargetingAdded=!1,h.apsDisplayBidsCalled=!1,h.slotRendered=!0,"scrollto"==h.type&&(h.adTargetId=h.element.id),h.pbload&&(c=a.getTargetingMap().hb_adid,c="undefined"!=typeof c?c[0]:"unset",1==h.emptyLogging&&f&&(f=a.getTargetingMap().hb_pb,f="undefined"!=
+typeof f?f[0]:"unset",d=a.getTargetingMap().amznp,d="undefined"!=typeof d?d[0]:"unset",l=a.getTargetingMap().amznbid,l="undefined"!=typeof l?l[0]:"unset",e=a.getTargetingMap().hb_bidder,e="undefined"!=typeof e?e[0]:"unset",a=a.getTargetingMap().tl_source,a="undefined"!=typeof a?a[0]:"unset",m=(new Date).getTime()-h.last_pb_request_time,WH.event("gpt_ad_rendered",{empty:1,type:h.type,bucket:window.bucketId,hb_pb:f,hb_adid:c,last_hb_adid:h.last_hb_adid,tl_source:a,insertSlot:h.insertSlotValue,hb_bidder:e,session_id:oa,insert_target:h.insertPosition,pbtimedout:h.pbTimedOut,pb_time_since_request:m,amznp:d,amznbid:l})),h.last_hb_adid=c),"rightrail"==h.type&&(h.height=h.element.offsetHeight,h.element.classList.remove("blockthrough"),a=window.innerHeight||document.documentElement.clientHeight,h.extraChild&&b&&300>parseInt(b[1])?h.extraChild.style.visibility="visible":h.extraChild&&(h.extraChild.style.visibility="hidden"),h.notfixedposition||X(h,a),h.refreshable&&h.renderrefresh&&setTimeout(
+function(){h.refresh()},h.getRefreshTime())))},impressionViewable:function(a){for(var b,c=0;c<m.length;c++){var e=m[c];l[e.adTargetId]==a&&(b=e)}b&&(b.height=b.element.offsetHeight,b.refreshable&&b.viewablerefresh&&setTimeout(function(){b.refresh()},b.getRefreshTime()))},loadAdSpacing:function(){for(var a in q){var b=q[a];b&&b.element&&b.height&&(b.element.style.height=b.height+"px")}},gdprAccepted:function(){for(var a=0;a<m.length;a++){var b=m[a];0==a&&b.load()}for(a in q)b=q[a],b.instantLoad&&b.load()},promoLoadEvent:function(a,b,c){K&&document.addEventListener&&(a=document.getElementById(a),"undefined"!=typeof a&&"IMG"==a.nodeName&&a.addEventListener("load",function(){WH.event("article_promo_house_image_load_go_sc",{ad_unit:b,img_name:c})}))},setCustomBottomMarginHeight:function(a){L=parseInt(a)}}}();WH.ads.init();</script><div id="content_inner"><script>if (typeof mw != 'undefined') { mw.mobileFrontend.emit( 'header-loaded' ); }</script><div class="pre-content"><ul id="breadcrumb" class="breadcrumbs" aria-label="Category breadcrumbs"><li><a href="/Special:CategoryListing" title="Special:CategoryListing">Categories</a></li><li><a href="/Category:Health" title="Category:Health">Health</a></li><li><a href="/Category:Ear-Health" title="Category:Ear Health">Ear Health</a></li><li><a href="/Category:Tinnitus" title="Category:Tinnitus">Tinnitus</a></li></ul><h1 id="section_0" class="title_lg"><a href="https://www.wikihow.com/Stop-Ringing-in-Ears">How to Stop Ringing in Ears</a></h1></div><div id="bodyContent" class="content"><script>window.a=window.a||{};window.a.f=function(){function D(){var b=E().split("x")[0];return"undefined"!=typeof h.largeScreenMinWidth&&b&&parseInt(b,10)<h.largeScreenMinWidth?1:0}function q(){var b=F;if(k){var c=+new Date-k;0<c&&(b+=c)}return b}function G(b){if("undefined"!==typeof b&&"undefined"!==typeof b.target&&"undefined"!==typeof b.target.getAttribute&&(b=b.target.getAttribute("id"),"undefined"!==typeof b&&0!==b.indexOf("whvid-player")))return;H||(H=!0,l&&6>=l||(b=r({d:y?D()?"vm":"vw":"pv",m:h.pageName+" btraw "+q()/1E3,b:"6"}),delete b.dl,t("exit",b,!0)))}function I(){k&&(F+=+new Date-k,k=!1)}function J(){k||(k=+new Date)}function K(){var b=document.querySelectorAll("#intro, .section.steps, #quick_summary_section");if(b){var c=1E6,f=0;Array.prototype.forEach.call(b,function(b){var d=b;for(var e=0;d;)e+=d.offsetTop-d.clientTop,d=d.offsetParent;d=e;b=b.offsetHeight||b.clientHeight;c=Math.min(d,c);f=Math.max(d+b,f)});p=c;z=f}}function V(){var b=!1;try{var c=Object.defineProperty({},
+"passive",{get:function(){b=!0}});window.addEventListener("testPassive",null,c);window.removeEventListener("testPassive",null,c)}catch(f){}window.addEventListener("scroll",function(){g++;if(-1!=u){var b=+new Date-v;b>=u+250&&(u=b,K())}var c=q();b=c-L;L=c;if(!(0>=b)){var d=window.scrollY||window.pageYOffset;c=d+(window.innerHeight||document.documentElement.clientHeight);if(!(d>z||c<p)){var e=z-p;if(!(0>=e))for(d=Math.floor(128*(1*d-p)/e),0>d&&(d=0),c=Math.ceil(128*(1*c-p)/e),127<c&&(c=127),e=d;e<=c;)"undefined"===typeof w[e]&&(w[e]=0),w[e]+=b,e++}}});window.addEventListener("resize",function(){g++});window.addEventListener("click",function(){g++});c=b?{passive:!0}:!1;window.addEventListener("touchstart",function(){g++},c);window.addEventListener("touchend",function(){g++});window.addEventListener("touchcancel",function(){g++});window.addEventListener("touchmove",function(){g++},c);document.addEventListener("keydown",function(){g++});document.addEventListener("keyup",function(){g++});
+document.addEventListener("keypress",function(){g++});setInterval(function(){u=-1;K();0<g&&(M++,g=0);var b=q();b>N&&(N=b,O<A&&O++)},3E3)}function t(b,c,f){var g="",d=!0,e;for(e in c)c.hasOwnProperty(e)&&(g+=(d?"":"&")+e+"="+encodeURIComponent(c[e]),d=!1);b=(P?"/x/collect.php":"/x/collect")+"?t="+b+"&"+g;f&&"function"===typeof navigator.sendBeacon?navigator.sendBeacon(b,""):(c=new XMLHttpRequest,c.open("GET",b,!f),c.send())}function Q(){function b(){var b={ti:x[m].t};if(0===m){a:{try{var c=window.navigator,d=document,e=window.screen;b=R(b,{de:d&&(d.characterSet||d.charset),ul:(c&&(c.language||c.browserLanguage)||"").toLowerCase(),sd:e&&e.colorDepth+"-bit",sr:e&&e.width+"x"+e.height,vp:E(),pr:"undefined"!=typeof window.devicePixelRatio?window.devicePixelRatio:0});var g=r(b);break a}catch(Y){}g={}}t("first",g,!1)}else t("later",r(b),!1);m++;m<x.length&&Q()}var c=+new Date;m<x.length&&(c=v+1E3*x[m].t-c,0>=c?b():setTimeout(b,c))}function R(b,c){for(var f in c)c.hasOwnProperty(f)&&
+"undefined"==typeof b[f]&&(b[f]=c[f]);return b}function E(){var b=document,c=b.documentElement,f=b.body,g=f&&f.clientWidth&&f.clientHeight,d=[];c&&c.clientWidth&&c.clientHeight&&("CSS1Compat"===b.compatMode||!g)?d=[c.clientWidth,c.clientHeight]:g&&(d=[f.clientWidth,f.clientHeight]);return c=0>=d[0]||0>=d[1]?"":d.join("x")}function r(b){var c=W();250>c&&(c=1500);var f={gg:y,to:Math.round((+new Date-v)/1E3),ac:Math.round(q()/1E3),pg:h.pageID,ns:h.pageNamespace,ra:S,cv:X,cl:T,cm:D(),dl:location.href,b:"6"};f=R(b,f);0===h.pageNamespace&&(B=c/1500*180,A=B/3,b=Math.round(100*M/A),0>b&&(b=0),100<b&&(b=100),f.a1=Math.round(b));return f}function W(){var b=document.querySelectorAll("#intro, .section.steps, #quick_summary_section");if(!b)return 0;var c=0;Array.prototype.forEach.call(b,function(b){b=b.textContent.split(/\s/).filter(function(b){return""!==b}).length;c+=b});return c}var h=window.WH,X=h.stuCount,T=h.pageLang,P=!!location.href.match(/\.wikidogs\.com/),n=location.href.match(
+/\.wikihow(-fun)?\.[a-z]+\//)&&"en"==T||P,v=!1,k=!1,F=0,y=0,H=!1,S,l=!1,m=0,B=180,A=B/3,O=0,M=0,g=0,N=0,w=[],u=0,p=0,z=0,L=0,U=null,C=[],x=[{t:1},{t:9},{t:10},{t:12},{t:175},{t:180},{t:185},{t:300},{t:600},{t:900},{t:1200},{t:1500},{t:1800},{t:2100},{t:2400}];return{start:function(){if("undefined"==typeof window.a.c||!window.a.c){window.a.c=!0;var b=navigator.userAgent.match(/MSIE (\d+)/);b&&(l=b[1]);b="";for(var c=0;12>c;c++)b+="abcdefghijklmnopqrstuvwxyz0123456789".charAt(Math.floor(36*Math.random()));S=b;y=("string"===typeof document.referrer?document.referrer:"").match(/^[a-z]*:\/\/[^\/]*google/i)?1:0;k=v="number"==typeof h.timeStart&&0<h.timeStart?h.timeStart:+new Date;"visibilityState"in document&&"hidden"==document.visibilityState&&(k=!1);n&&Q();l&&7<=l&&9>=l?(document.onfocusin=J,document.onfocusout=I):(window.onfocus=J,window.onblur=I);n&&(window.onunload=G,window.onbeforeunload=G);(n||n)&&V()}},ping:function(b){(n||n)&&t("event",r(b),!1)},registerDebug:function(b){if(
+"function"!=typeof b)console.log("registerDebug: must be a function");else{U=b;for(b=0;b<C.length;b++)U(C[b]);C=[]}}}}();window.a.f.start();(function(){'use strict';window.WH=window.WH||{};window.WH.performance={};window.WH.performance.mark=function(name){if(typeof performance!=='undefined'&&typeof performance.mark==='function'){return performance.mark(name);}};window.WH.performance.clearMarks=function(name){if(typeof performance!=='undefined'&&typeof performance.clearMarks==='function'){return performance.clearMarks(name);}};}());</script>
+<div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr">
+<script>function mfTempOpenSection(id){var block=document.getElementById("mf-section-"+id);block.className+=" open-block";block.previousSibling.className+=" open-block";}</script><div class="mw-parser-output">
+<div id="intro" class="section hasad sticky">
+<a class="large_pdf_link pdf_link  disabled  " href="#">
+	
+	<img src="/extensions/wikihow/socialstamp/images/icon-pdf.svg" width="15" height="15">
+	Download Article
+	
+</a><div role="navigation" id="method_toc" class="en_toc">
+	<div>
+		<span class="header_toc">Explore this Article</span>
+		<div id="method_toc_list">
+			<div class="toc_header">methods</div>
+			<div class="method_toc_item  toc_method " id="" data-section="">
+				<a href="#Treating-Momentary-Ringing-in-the-Ears">
+						<span>1</span>
+					Treating Momentary Ringing in the Ears
+					
+				</a>
+			</div>
+			<div class="method_toc_item  toc_method " id="" data-section="">
+				<a href="#Treating-Chronic-Ringing-in-the-Ears">
+						<span>2</span>
+					Treating Chronic Ringing in the Ears
+					
+				</a>
+			</div>
+			<div class="method_toc_item  toc_method " id="" data-section="">
+				<a href="#Preventing-Tinnitus">
+						<span>3</span>
+					Preventing Tinnitus
+					
+				</a>
+			</div>
+
+			<div class="toc_header">Other Sections</div>
+				<div class="method_toc_item   toc_post" id="qa_toc" data-section="#qa_headline">
+					<a href="#qa_headline">
+						Expert Q&amp;A
+						
+					</a>
+				</div>
+				<div class="method_toc_item   toc_post" id="tips_toc" data-section="#tips">
+					<a href="#tips">
+						Tips and Warnings
+						
+					</a>
+				</div>
+				<div class="method_toc_item   toc_post" id="rwh_toc" data-section="#relatedwikihows">
+					<a href="#relatedwikihows">
+						Related Articles
+						
+					</a>
+				</div>
+				<div class="method_toc_item   toc_post" id="toc_ref" data-section="#References">
+					<a href="#References">
+						References
+						
+					</a>
+				</div>
+				<div class="method_toc_item   toc_post" id="summary_toc" data-section="#summary_wrapper">
+					<a href="#summary_wrapper">
+						Article Summary
+						
+					</a>
+				</div>
+
+		</div>
+
+		<div id="toc_line"></div>
+
+	</div>
+</div>
+<div id="coauthor_byline" class="article_byline ">
+
+
+	<div id="byline_info">
+
+		<b>Medically reviewed by</b>
+
+		<a href="/Author/Luba-Lee-FNP-BC-MS" class="coauthor_link  coauthor_checkstar">Luba Lee, FNP-BC, MS</a>
+
+
+
+
+		<p>
+			<a href="#" class="byline_info_link hover_pop">
+				<span class="last_updated_highlighted">Last Updated: August 27, 2021</span>
+			</a>
+
+			<a href="#References" class="byline_references">References</a>
+
+		</p>
+
+
+	</div>
+
+</div>
+<a class="small_pdf_link pdf_link  disabled  " href="#">
+	
+	<img src="/extensions/wikihow/socialstamp/images/icon-pdf.svg" width="15" height="15">
+	Download Article
+	
+</a>
+
+<div id="byline_hover" hidden>
+	<div id="byline_hover_close">X</div>
+
+	<div id="byline_hover_body">
+		<p>
+		This article was medically reviewed by <a href="/Author/Luba-Lee-FNP-BC-MS">Luba Lee, FNP-BC, MS</a>. Luba Lee, FNP-BC is a board certified Family Nurse Practitioner (FNP) and educator in Tennessee with over a decade of clinical experience. Luba has certifications in Pediatric Advanced Life Support (PALS), Emergency Medicine, Advanced Cardiac Life Support (ACLS), Team Building, and Critical Care Nursing. She received her Master of Science in Nursing (MSN) from the University of Tennessee in 2006.
+
+			<br><br>
+			There are <a href="#References">16 references</a> cited in this article, which can be found at the bottom of the page.
+
+
+			<br><br>
+			 This article has been viewed 3,337,197 times.
+
+
+		</p>
+	</div>
+
+</div>
+
+<div class="mf-section-0" id="mf-section-0">
+<p>Ringing, buzzing, or roaring in the ears is often used to describe tinnitus, which can be extremely annoying and occur without any reason. Tinnitus may signify underlying nerve damage or an issue with your circulatory system, or there may not be a clear reason for the problem, so it is best to consult your doctor.<sup id="_ref-1" class="reference trusted" aria-label="Link to Reference 1"><a href="#_note-1">[1]</a><span class="ts_popup trustedsource" hidden id="ts_popup_1" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">Mayo Clinic</span>
+		<span class="ts_description">Educational website from one of the world's leading hospitals</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup> One way to stop ringing in your ears is prevention, but the issue may also be genetic and you cannot control this.<sup id="_ref-2" class="reference trusted" aria-label="Link to Reference 2"><a href="#_note-2">[2]</a><span class="ts_popup trustedsource" hidden id="ts_popup_2" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">PubMed Central</span>
+		<span class="ts_description">Journal archive from the U.S. National Institutes of Health</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup> There are steps that you can take to treat the ringing buzz even after the damage is done. Read on for helpful hints and tips.
+</p>
+</div>
+<div class="clearall"></div>
+<div class="wh_ad_inner w_label al_grey" data-service="adsense" data-instantload="1" data-slot="7672188889" data-width="728" data-height="120" data-smallslot="8943394577" data-smallheight="120" data-innerclass="full-width" data-full-width-intro="true" data-type="intro" data-small="1" data-medium="1" data-large="1" data-channels="9848412230,8596984590" data-adunitpath="/10095428/engl/engl_gam_lgm_intro" data-size="[728, 90]" data-largechannels="5788212177 7020581953" data-mediumchannels="8142447154" data-smallchannels="1761065154" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="[728, 90]" data-gptdisplaylate="1"><div id="intro_ad_1" class="full-width"></div></div>
+<script>WH.ads.addBodyAd('intro_ad_1')</script><script>WH.performance.mark('intro_rendered');</script>
+</div>
+<div class="wh_ad_inner" data-service="dfp" data-type="scrollto" data-adunitpath="/10095428/engl/engl_gam_all_scrol" data-size="[728, 90]" data-prebidload="1" data-apsload="1" data-aps-timeout="800" data-maxsteps="6" data-maxnonsteps="3" data-width="728" data-height="90" data-large="1" data-channels="8596984590" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="[728, 90]" data-gptdisplaylate="1"><div id="scrollto_ad_1"></div></div>
+<script>WH.ads.addBodyAd('scrollto_ad_1')</script><h2 class="section-heading hidden" onclick="javascript:mfTempOpenSection(1)">
+<div class="mw-ui-icon mw-ui-icon-element indicator"></div>
+<span class="mw-headline" id="Steps">Steps</span>
+</h2>
+<div class="mf-section-1 collapsible-block" id="mf-section-1">
+<div class="section steps   steps_first sticky">
+<h3 class="in-block">
+<div class="altblock"><div>Method <span>1</span><span class="method_of_count"> of 3:</span>
+</div>
+</div>
+<span class="mw-headline" id="Treating-Momentary-Ringing-in-the-Ears">Treating Momentary Ringing in the Ears</span>
+</h3>
+<div id="steps_1" class="section_text">
+<ol class="steps_list_2">
+<li id="step-id-00">
+<a name="step_1_1" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Stop-Ringing-in-Ears-Step-1-Version-3.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Stop Ringing in Ears Step 1" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/4/42/Stop-Ringing-in-Ears-Step-1-Version-3.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-1-Version-3.jpg" data-width="460" data-height="345" id="e9e572a0c0ebeaf5459286962afca1e0" onload="WH.performance.clearMarks('image1_rendered'); WH.performance.mark('image1_rendered');" data-src="https://www.wikihow.com/images/thumb/4/42/Stop-Ringing-in-Ears-Step-1-Version-3.jpg/v4-460px-Stop-Ringing-in-Ears-Step-1-Version-3.jpg"><script>WH.shared.addScrollLoadItem('e9e572a0c0ebeaf5459286962afca1e0')</script>
+</div>
+<noscript><img alt="Image titled Stop Ringing in Ears Step 1" src="https://www.wikihow.com/images/thumb/4/42/Stop-Ringing-in-Ears-Step-1-Version-3.jpg/v4-460px-Stop-Ringing-in-Ears-Step-1-Version-3.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/4/42/Stop-Ringing-in-Ears-Step-1-Version-3.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-1-Version-3.jpg" data-width="460" data-height="345" id="e9e572a0c0ebeaf5459286962afca1e0" onload="WH.performance.clearMarks('image1_rendered'); WH.performance.mark('image1_rendered');"></noscript>
+<script>WH.performance.clearMarks('image1_rendered'); WH.performance.mark('image1_rendered');</script><div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/4\/42\/Stop-Ringing-in-Ears-Step-1-Version-3.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-1-Version-3.jpg","bigUrl":"\/images\/thumb\/4\/42\/Stop-Ringing-in-Ears-Step-1-Version-3.jpg\/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-1-Version-3.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">1</div><div class="step">
+<b class="whb">Try the skull-thumping trick.</b> If you're coming home from a concert or a club, and your ears won't stop ringing, it's because you've damaged some of the little hairs in your cochlea, which causes inflammation and stimulation of nerves. Your brain interprets this inflammation as constant ringing or buzzing, and this trick can help make that annoying sound go away. While some people think skull-thumping has a positive effect, more research needs to be done to determine whether it is effective.
+<ul>
+<li>Cover your ears with your palms. Your fingers should be pointed back and resting on the back of your skull. Point your middle fingers toward each other at the very back of your skull.</li>
+<li>Rest your index fingers on top of your middle fingers.</li>
+<li>Using a snapping motion, flip your index fingers down off your middle fingers and onto the back of the skull. This motion will sound like the beating of drums. Because the fingers will also hit your skull, the noise may be quite loud. This is normal.</li>
+<li>Continue snapping your fingers onto the back of your skull 40 to 50 times. After 40 or 50 times, see if the ringing has subsided.</li>
+</ul>
+<script>WH.performance.mark('step1_rendered');</script>
+</div>
+<div class="clearall"></div>
+</li>
+<li id="step-id-01">
+<a name="step_1_2" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Stop-Ringing-in-Ears-Step-2-Version-3.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Stop Ringing in Ears Step 2" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/9/95/Stop-Ringing-in-Ears-Step-2-Version-3.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-2-Version-3.jpg" data-width="460" data-height="345" id="8e6b6604457b25af1818a485591d798a" data-src="https://www.wikihow.com/images/thumb/9/95/Stop-Ringing-in-Ears-Step-2-Version-3.jpg/v4-460px-Stop-Ringing-in-Ears-Step-2-Version-3.jpg"><script>WH.shared.addScrollLoadItem('8e6b6604457b25af1818a485591d798a')</script>
+</div>
+<noscript><img alt="Image titled Stop Ringing in Ears Step 2" src="https://www.wikihow.com/images/thumb/9/95/Stop-Ringing-in-Ears-Step-2-Version-3.jpg/v4-460px-Stop-Ringing-in-Ears-Step-2-Version-3.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/9/95/Stop-Ringing-in-Ears-Step-2-Version-3.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-2-Version-3.jpg" data-width="460" data-height="345" id="8e6b6604457b25af1818a485591d798a"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/9\/95\/Stop-Ringing-in-Ears-Step-2-Version-3.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-2-Version-3.jpg","bigUrl":"\/images\/thumb\/9\/95\/Stop-Ringing-in-Ears-Step-2-Version-3.jpg\/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-2-Version-3.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">2</div><div class="step">
+<b class="whb">Try waiting it out.</b> Ringing in the ears that is caused by exposure to loud noises usually goes away after a few hours. Take your mind off it by resting and staying away from anything that might exacerbate the symptoms. If the ringing doesn't go away after 24 hours, visit the doctor for further treatment.<sup id="_ref-3" class="reference trusted" aria-label="Link to Reference 3"><a href="#_note-3">[3]</a><span class="ts_popup trustedsource" hidden id="ts_popup_3" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">Cleveland Clinic</span>
+		<span class="ts_description">Educational website from one of the world's leading hospitals</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup>
+</div>
+<div class="clearall"></div>
+</li>
+<li id="step-id-02">
+<a name="step_1_3" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Choose-Earplugs-Step-12.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Choose Earplugs Step 12" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/5/58/Choose-Earplugs-Step-12.jpg/aid543713-v4-728px-Choose-Earplugs-Step-12.jpg" data-width="460" data-height="345" id="9f7074abaeaa7e78188f517aacac6452" data-src="https://www.wikihow.com/images/thumb/5/58/Choose-Earplugs-Step-12.jpg/v4-460px-Choose-Earplugs-Step-12.jpg"><script>WH.shared.addScrollLoadItem('9f7074abaeaa7e78188f517aacac6452')</script>
+</div>
+<noscript><img alt="Image titled Choose Earplugs Step 12" src="https://www.wikihow.com/images/thumb/5/58/Choose-Earplugs-Step-12.jpg/v4-460px-Choose-Earplugs-Step-12.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/5/58/Choose-Earplugs-Step-12.jpg/aid543713-v4-728px-Choose-Earplugs-Step-12.jpg" data-width="460" data-height="345" id="9f7074abaeaa7e78188f517aacac6452"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/5\/58\/Choose-Earplugs-Step-12.jpg\/v4-460px-Choose-Earplugs-Step-12.jpg","bigUrl":"\/images\/thumb\/5\/58\/Choose-Earplugs-Step-12.jpg\/aid543713-v4-728px-Choose-Earplugs-Step-12.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">3</div><div class="step">
+<b class="whb">Avoid loud noises and protect your ears when you are exposed to noise.</b> Being exposed to loud noises over and over again can lead to recurring episodes of tinnitus. If you are often exposed to loud noises in your environment, make sure to wear ear protection. 
+<ul><li>Get some foam earplugs that fit in your ears or get a pair of over-the-ear ear protectors.</li></ul>
+</div>
+<div class="clearall"></div>
+<div class="wh_ad_inner w_label al_grey" data-service="dfp" data-adunitpath="/10095428/engl/engl_gam_lgm_early" data-size="[728, 90]" data-prebidload="1" data-apsload="1" data-aps-timeout="2000" data-width="728" data-height="90" data-large="1" data-channels="8596984590" data-type="method" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="[728, 90]" data-gptdisplaylate="1"><div id="method_ad_1"></div></div>
+<script>WH.ads.addBodyAd('method_ad_1')</script><div class="wh_ad_inner w_label al_grey" data-service="adsense" data-slot="7710650179" data-width="728" data-height="90" data-smallheight="250" data-type="method" data-small="1" data-medium="1" data-channels="8596984590" data-mediumchannels="3005955957" data-smallchannels="2811805837" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="0" data-gptdisplaylate="1">
+<div id="mobilemethod_ad_1"></div>
+<div class="al_method">Advertisement</div>
+</div>
+<script>WH.ads.addBodyAd('mobilemethod_ad_1')</script>
+</li>
+</ol>
+<div class="clearall"></div>
+</div>
+</div>
+<div class="section steps   sticky">
+<h3 class="in-block">
+<div class="altblock"><div>Method <span>2</span><span class="method_of_count"> of 3:</span>
+</div>
+</div>
+<span class="mw-headline" id="Treating-Chronic-Ringing-in-the-Ears">Treating Chronic Ringing in the Ears</span>
+</h3>
+<div id="steps_2" class="section_text">
+<ol class="steps_list_2">
+<li id="step-id-13">
+<a name="step_2_1" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Stop-Ringing-in-Ears-Step-3-Version-3.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Stop Ringing in Ears Step 3" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/7/77/Stop-Ringing-in-Ears-Step-3-Version-3.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-3-Version-3.jpg" data-width="460" data-height="345" id="49f59750ebac985f990a0520131c9f35" data-src="https://www.wikihow.com/images/thumb/7/77/Stop-Ringing-in-Ears-Step-3-Version-3.jpg/v4-460px-Stop-Ringing-in-Ears-Step-3-Version-3.jpg"><script>WH.shared.addScrollLoadItem('49f59750ebac985f990a0520131c9f35')</script>
+</div>
+<noscript><img alt="Image titled Stop Ringing in Ears Step 3" src="https://www.wikihow.com/images/thumb/7/77/Stop-Ringing-in-Ears-Step-3-Version-3.jpg/v4-460px-Stop-Ringing-in-Ears-Step-3-Version-3.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/7/77/Stop-Ringing-in-Ears-Step-3-Version-3.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-3-Version-3.jpg" data-width="460" data-height="345" id="49f59750ebac985f990a0520131c9f35"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/7\/77\/Stop-Ringing-in-Ears-Step-3-Version-3.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-3-Version-3.jpg","bigUrl":"\/images\/thumb\/7\/77\/Stop-Ringing-in-Ears-Step-3-Version-3.jpg\/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-3-Version-3.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">1</div><div class="step">
+<b class="whb">See your doctor about treating underlying conditions.</b> Much of the time, tinnitus, or ringing in the ears, is caused by a treatable condition. Treating this underlying condition may help remove some or all of the ringing.<sup id="_ref-4" class="reference trusted" aria-label="Link to Reference 4"><a href="#_note-4">[4]</a><span class="ts_popup trustedsource" hidden id="ts_popup_4" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">Mayo Clinic</span>
+		<span class="ts_description">Educational website from one of the world's leading hospitals</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup>
+<ul>
+<li>Have your doctor remove earwax from your ear. Alternately, <a href="/Get-Rid-of-Earwax" title="Get Rid of Earwax">do it safely</a> yourself.<sup id="_ref-5" class="reference trusted" aria-label="Link to Reference 5"><a href="#_note-5">[5]</a><span class="ts_popup trustedsource" hidden id="ts_popup_5" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">Harvard Medical School</span>
+		<span class="ts_description">Harvard Medical School's Educational Site for the Public</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup> Removing an excess buildup of earwax can help relieve symptoms of tinnitus.</li>
+<li>Fluid buildup due to a perforated membrane or allergies may lead to tinnitus.</li>
+<li>Have your doctor re-examine the interactions of your medications. If you take several medications, talk with your doctor about possible side-effects that could be causing the ringing in your ears.</li>
+<li>Make sure to tell your doctor about any other symptoms you are having. Temporomandibular joint dysfunction (Costen’s syndrome) may be associated with tinnitus.<sup id="_ref-6" class="reference" aria-label="Link to Reference 6"><a href="#_note-6">[6]</a><span class="ts_popup " hidden id="ts_popup_6" style="display: none;">
+	<span class="ts_close">X</span>
+		<span class="ts_name">Research source</span>
+		<span class="ts_description"></span>
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener"></a>
+
+</span>
+</sup>
+</li>
+<li>A flutter or spasm of the tensor tympani or stapedius muscle in the inner ear may also result in tinnitus.</li>
+</ul>
+</div>
+<div class="clearall"></div>
+</li>
+<li id="step-id-14">
+<a name="step_2_2" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Cure-Tinnitus-Step-4-Version-4.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Cure Tinnitus Step 4" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/e/ec/Cure-Tinnitus-Step-4-Version-4.jpg/aid543713-v4-728px-Cure-Tinnitus-Step-4-Version-4.jpg" data-width="460" data-height="345" id="03506d07341a5d69181d1f5a700e6998" data-src="https://www.wikihow.com/images/thumb/e/ec/Cure-Tinnitus-Step-4-Version-4.jpg/v4-460px-Cure-Tinnitus-Step-4-Version-4.jpg"><script>WH.shared.addScrollLoadItem('03506d07341a5d69181d1f5a700e6998')</script>
+</div>
+<noscript><img alt="Image titled Cure Tinnitus Step 4" src="https://www.wikihow.com/images/thumb/e/ec/Cure-Tinnitus-Step-4-Version-4.jpg/v4-460px-Cure-Tinnitus-Step-4-Version-4.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/e/ec/Cure-Tinnitus-Step-4-Version-4.jpg/aid543713-v4-728px-Cure-Tinnitus-Step-4-Version-4.jpg" data-width="460" data-height="345" id="03506d07341a5d69181d1f5a700e6998"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/e\/ec\/Cure-Tinnitus-Step-4-Version-4.jpg\/v4-460px-Cure-Tinnitus-Step-4-Version-4.jpg","bigUrl":"\/images\/thumb\/e\/ec\/Cure-Tinnitus-Step-4-Version-4.jpg\/aid543713-v4-728px-Cure-Tinnitus-Step-4-Version-4.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">2</div><div class="step">
+<b class="whb">Look into biofeedback therapy for your tinnitus.</b> If you are depressed, stressed, or fatigued, then you may be more susceptible to normal head sounds. Look into biofeedback therapy from a counselor who can help you to tune into the feelings and situations that cause or worsen your tinnitus. This may help you to stop tinnitus when it starts and prevent it from coming back.<sup id="_ref-7" class="reference trusted" aria-label="Link to Reference 7"><a href="#_note-7">[7]</a><span class="ts_popup trustedsource" hidden id="ts_popup_7" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">University of California San Francisco Health Center</span>
+		<span class="ts_description">Research hospital associated with UCSF, a leading medical university, providing innovative patient care and public health resources</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup>
+<ul>
+<li>Research has shown that biofeedback therapy can be very effective for treating tinnitus.<sup id="_ref-8" class="reference trusted" aria-label="Link to Reference 8"><a href="#_note-8">[8]</a><span class="ts_popup trustedsource" hidden id="ts_popup_8" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">PubMed Central</span>
+		<span class="ts_description">Journal archive from the U.S. National Institutes of Health</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup>
+</li>
+<li>Ask your doctor for a referral to a therapist who has experience with biofeedback for tinnitus.</li>
+</ul>
+</div>
+<div class="clearall"></div>
+</li>
+<li id="step-id-15">
+<a name="step_2_3" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Stop-Ringing-in-Ears-Step-4-Version-3.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Stop Ringing in Ears Step 4" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/d/da/Stop-Ringing-in-Ears-Step-4-Version-3.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-4-Version-3.jpg" data-width="460" data-height="345" id="68bc254e25b1478925b05ad828fb7681" data-src="https://www.wikihow.com/images/thumb/d/da/Stop-Ringing-in-Ears-Step-4-Version-3.jpg/v4-460px-Stop-Ringing-in-Ears-Step-4-Version-3.jpg"><script>WH.shared.addScrollLoadItem('68bc254e25b1478925b05ad828fb7681')</script>
+</div>
+<noscript><img alt="Image titled Stop Ringing in Ears Step 4" src="https://www.wikihow.com/images/thumb/d/da/Stop-Ringing-in-Ears-Step-4-Version-3.jpg/v4-460px-Stop-Ringing-in-Ears-Step-4-Version-3.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/d/da/Stop-Ringing-in-Ears-Step-4-Version-3.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-4-Version-3.jpg" data-width="460" data-height="345" id="68bc254e25b1478925b05ad828fb7681"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/d\/da\/Stop-Ringing-in-Ears-Step-4-Version-3.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-4-Version-3.jpg","bigUrl":"\/images\/thumb\/d\/da\/Stop-Ringing-in-Ears-Step-4-Version-3.jpg\/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-4-Version-3.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">3</div><div class="step">
+<b class="whb">Treat tinnitus with noise-suppression tactics.</b> Several different noise-suppression tactics are used by doctors to mask the sound of ringing in your ears. These tactics include the following devices and techniques.<sup id="_ref-9" class="reference trusted" aria-label="Link to Reference 9"><a href="#_note-9">[9]</a><span class="ts_popup trustedsource" hidden id="ts_popup_9" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">Mayo Clinic</span>
+		<span class="ts_description">Educational website from one of the world's leading hospitals</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup>
+<ul>
+<li>Make use of white noise machines. White noise machines that produce "background" sounds, such as rain falling or wind whooshing, may help drown out the ringing in your ears. Fans, humidifiers, dehumidifiers and air conditioners also serve as effective white noise machines.</li>
+<li>Make use of masking devices. Masking devices are fitted over your ears and produce a continuous wave of white noise to mask the chronic ringing.</li>
+<li>Wear hearing aids. This is especially effective if you have hearing problems in addition to tinnitus.</li>
+</ul>
+</div>
+<div class="clearall"></div>
+</li>
+<li id="step-id-16">
+<a name="step_2_4" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Stop-Ringing-in-Ears-Step-5-Version-2.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Stop Ringing in Ears Step 5" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/b/b9/Stop-Ringing-in-Ears-Step-5-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-5-Version-2.jpg" data-width="460" data-height="345" id="3eaf4f47105218c1daa4e59320082494" data-src="https://www.wikihow.com/images/thumb/b/b9/Stop-Ringing-in-Ears-Step-5-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-5-Version-2.jpg"><script>WH.shared.addScrollLoadItem('3eaf4f47105218c1daa4e59320082494')</script>
+</div>
+<noscript><img alt="Image titled Stop Ringing in Ears Step 5" src="https://www.wikihow.com/images/thumb/b/b9/Stop-Ringing-in-Ears-Step-5-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-5-Version-2.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/b/b9/Stop-Ringing-in-Ears-Step-5-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-5-Version-2.jpg" data-width="460" data-height="345" id="3eaf4f47105218c1daa4e59320082494"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/b\/b9\/Stop-Ringing-in-Ears-Step-5-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-5-Version-2.jpg","bigUrl":"\/images\/thumb\/b\/b9\/Stop-Ringing-in-Ears-Step-5-Version-2.jpg\/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-5-Version-2.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">4</div><div class="step">
+<b class="whb">Take medications to relieve some of the tinnitus symptoms.</b> Although medications probably won't stop the ringing, taking medications can make the ringing sound less noticeable.
+<ul>
+<li>Talk to your doctor about tricyclic antidepressants. Tricyclic antidepressants can be effective for severe tinnitus, but have some undesirable side-effects, such as dry mouth, blurred vision, constipation and heart problems. Although some studies support the use of tricyclic antidepressants for tinnitus, more research needs to be done to determine whether it is effective.<sup id="_ref-10" class="reference trusted" aria-label="Link to Reference 10"><a href="#_note-10">[10]</a><span class="ts_popup trustedsource" hidden id="ts_popup_10" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">PubMed Central</span>
+		<span class="ts_description">Journal archive from the U.S. National Institutes of Health</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup>
+</li>
+<li>Talk to your doctor about Alprazolam. Better known as Xanax, Alprazolam has been shown to be effective in reducing tinnitus buzzing, but it is habit-forming and also has undesirable side-effects. Although some studies support the use of alprazolam for tinnitus, more research needs to be done to determine whether it is effective.<sup id="_ref-11" class="reference trusted" aria-label="Link to Reference 11"><a href="#_note-11">[11]</a><span class="ts_popup trustedsource" hidden id="ts_popup_11" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">PubMed Central</span>
+		<span class="ts_description">Journal archive from the U.S. National Institutes of Health</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup>
+</li>
+</ul>
+</div>
+<div class="clearall"></div>
+</li>
+<li id="step-id-17">
+<a name="step_2_5" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Stop-Ringing-in-Ears-Step-6-Version-2.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Stop Ringing in Ears Step 6" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/f/f5/Stop-Ringing-in-Ears-Step-6-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-6-Version-2.jpg" data-width="460" data-height="345" id="cd81ed1c53185e5218c7734e8f09fb6f" data-src="https://www.wikihow.com/images/thumb/f/f5/Stop-Ringing-in-Ears-Step-6-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-6-Version-2.jpg"><script>WH.shared.addScrollLoadItem('cd81ed1c53185e5218c7734e8f09fb6f')</script>
+</div>
+<noscript><img alt="Image titled Stop Ringing in Ears Step 6" src="https://www.wikihow.com/images/thumb/f/f5/Stop-Ringing-in-Ears-Step-6-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-6-Version-2.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/f/f5/Stop-Ringing-in-Ears-Step-6-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-6-Version-2.jpg" data-width="460" data-height="345" id="cd81ed1c53185e5218c7734e8f09fb6f"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/f\/f5\/Stop-Ringing-in-Ears-Step-6-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-6-Version-2.jpg","bigUrl":"\/images\/thumb\/f\/f5\/Stop-Ringing-in-Ears-Step-6-Version-2.jpg\/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-6-Version-2.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">5</div><div class="step">
+<b class="whb">Try ginkgo extract.</b> Taking ginkgo extract 3 times a day (with meals) may help increase blood flow to the head and neck, reducing the ringing caused by blood pressure. Try taking ginkgo for 2 months before evaluating the effectiveness of the treatment. Although some studies support the use of ginkgo biloba for tinnitus more research needs to be done to determine whether it is effective.<sup id="_ref-12" class="reference trusted" aria-label="Link to Reference 12"><a href="#_note-12">[12]</a><span class="ts_popup trustedsource" hidden id="ts_popup_12" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">PubMed Central</span>
+		<span class="ts_description">Journal archive from the U.S. National Institutes of Health</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup>
+<ul>
+<li>Follow the manufacturer’s instructions for how much to take.</li>
+<li>Make sure to ask your doctor first to ensure that it is safe for you to take ginkgo extract.</li>
+</ul>
+</div>
+<div class="clearall"></div>
+<div class="wh_ad_inner w_label al_grey" data-service="adsense" data-slot="7710650179" data-width="728" data-height="90" data-smallheight="250" data-type="method" data-small="1" data-medium="1" data-channels="8596984590" data-mediumchannels="3005955957" data-smallchannels="2811805837" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="0" data-gptdisplaylate="1">
+<div id="mobilemethod_ad_2"></div>
+<div class="al_method">Advertisement</div>
+</div>
+<script>WH.ads.addBodyAd('mobilemethod_ad_2')</script>
+</li>
+</ol>
+<div class="clearall"></div>
+</div>
+</div>
+<div class="section steps   sticky">
+<h3 class="in-block">
+<div class="altblock"><div>Method <span>3</span><span class="method_of_count"> of 3:</span>
+</div>
+</div>
+<span class="mw-headline" id="Preventing-Tinnitus">Preventing Tinnitus</span>
+</h3>
+<div id="steps_3" class="section_text">
+<ol class="steps_list_2">
+<li id="step-id-28">
+<a name="step_3_1" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Stop-Ringing-in-Ears-Step-7-Version-2.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Stop Ringing in Ears Step 7" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/f/fa/Stop-Ringing-in-Ears-Step-7-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-7-Version-2.jpg" data-width="460" data-height="345" id="72ec02e04d9c7ff07e98b55ceec6afa7" data-src="https://www.wikihow.com/images/thumb/f/fa/Stop-Ringing-in-Ears-Step-7-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-7-Version-2.jpg"><script>WH.shared.addScrollLoadItem('72ec02e04d9c7ff07e98b55ceec6afa7')</script>
+</div>
+<noscript><img alt="Image titled Stop Ringing in Ears Step 7" src="https://www.wikihow.com/images/thumb/f/fa/Stop-Ringing-in-Ears-Step-7-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-7-Version-2.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/f/fa/Stop-Ringing-in-Ears-Step-7-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-7-Version-2.jpg" data-width="460" data-height="345" id="72ec02e04d9c7ff07e98b55ceec6afa7"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/f\/fa\/Stop-Ringing-in-Ears-Step-7-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-7-Version-2.jpg","bigUrl":"\/images\/thumb\/f\/fa\/Stop-Ringing-in-Ears-Step-7-Version-2.jpg\/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-7-Version-2.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">1</div><div class="step">
+<b class="whb">Avoid situations in which damage to the cochlea could cause tinnitus.</b> Because tinnitus is so hard to treat, the most effective option is to avoid causing it in the first place, or avoid making the symptoms worse. The following may exacerbate the symptoms of tinnitus:<sup id="_ref-13" class="reference" aria-label="Link to Reference 13"><a href="#_note-13">[13]</a><span class="ts_popup " hidden id="ts_popup_13" style="display: none;">
+	<span class="ts_close">X</span>
+		<span class="ts_name">Research source</span>
+		<span class="ts_description"></span>
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener"></a>
+
+</span>
+</sup>
+<ul>
+<li>Loud noises. Concerts are the main culprit, but construction work, traffic, airplanes, gunshots, fireworks, and other loud noises can also be harmful.</li>
+<li>Swimming. Water and chlorine can get stuck in your inner ear while swimming, causing or intensifying your tinnitus. Keep this from happening by wearing earplugs while swimming.</li>
+</ul>
+</div>
+<div class="clearall"></div>
+</li>
+<li id="step-id-29">
+<a name="step_3_2" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Stop-Ringing-in-Ears-Step-8-Version-2.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Stop Ringing in Ears Step 8" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/c/c4/Stop-Ringing-in-Ears-Step-8-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-8-Version-2.jpg" data-width="460" data-height="345" id="d90233852b5d2a028b7f477259b095ae" data-src="https://www.wikihow.com/images/thumb/c/c4/Stop-Ringing-in-Ears-Step-8-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-8-Version-2.jpg"><script>WH.shared.addScrollLoadItem('d90233852b5d2a028b7f477259b095ae')</script>
+</div>
+<noscript><img alt="Image titled Stop Ringing in Ears Step 8" src="https://www.wikihow.com/images/thumb/c/c4/Stop-Ringing-in-Ears-Step-8-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-8-Version-2.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/c/c4/Stop-Ringing-in-Ears-Step-8-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-8-Version-2.jpg" data-width="460" data-height="345" id="d90233852b5d2a028b7f477259b095ae"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/c\/c4\/Stop-Ringing-in-Ears-Step-8-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-8-Version-2.jpg","bigUrl":"\/images\/thumb\/c\/c4\/Stop-Ringing-in-Ears-Step-8-Version-2.jpg\/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-8-Version-2.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">2</div><div class="step">
+<b class="whb">Find an outlet for your stress.</b> If you have constant ringing in your ears, any stress might make the condition worse.<sup id="_ref-14" class="reference trusted" aria-label="Link to Reference 14"><a href="#_note-14">[14]</a><span class="ts_popup trustedsource" hidden id="ts_popup_14" style="display: none;">
+	<span class="ts_close">X</span>
+		<a class="ts_trustworthy" href="/wikiHow:Delivering-a-Trustworthy-Experience">Trustworthy Source</a>
+
+		<span class="ts_name">Harvard Medical School</span>
+		<span class="ts_description">Harvard Medical School's Educational Site for the Public</span>
+
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener">Go to source</a>
+</span>
+</sup> Find ways such as exercise, meditation, and massage therapy to relieve your stress.<sup id="_ref-15" class="reference" aria-label="Link to Reference 15"><a href="#_note-15">[15]</a><span class="ts_popup " hidden id="ts_popup_15" style="display: none;">
+	<span class="ts_close">X</span>
+		<span class="ts_name">Research source</span>
+		<span class="ts_description"></span>
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener"></a>
+
+</span>
+</sup>
+</div>
+<div class="clearall"></div>
+</li>
+<li class="final_li" id="step-id-210">
+<a name="step_3_3" class="stepanchor"></a><div class="mwimg  largeimage  floatcenter " style="max-width:728px"><a href="#/Image:Stop-Ringing-in-Ears-Step-9-Version-2.jpg" class="image"><div class="content-spacer" style="padding-top:75%">
+<img alt="Image titled Stop Ringing in Ears Step 9" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/4/4a/Stop-Ringing-in-Ears-Step-9-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-9-Version-2.jpg" data-width="460" data-height="345" id="a088bcd820e7f39bfda25d13bf7e5124" data-src="https://www.wikihow.com/images/thumb/4/4a/Stop-Ringing-in-Ears-Step-9-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-9-Version-2.jpg"><script>WH.shared.addScrollLoadItem('a088bcd820e7f39bfda25d13bf7e5124')</script>
+</div>
+<noscript><img alt="Image titled Stop Ringing in Ears Step 9" src="https://www.wikihow.com/images/thumb/4/4a/Stop-Ringing-in-Ears-Step-9-Version-2.jpg/v4-460px-Stop-Ringing-in-Ears-Step-9-Version-2.jpg" decoding="async" class="whcdn content-fill" data-srclarge="/images/thumb/4/4a/Stop-Ringing-in-Ears-Step-9-Version-2.jpg/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-9-Version-2.jpg" data-width="460" data-height="345" id="a088bcd820e7f39bfda25d13bf7e5124"></noscript>
+<div class="image_details" style="display:none;"><span style="display:none;">{"smallUrl":"https:\/\/www.wikihow.com\/images\/thumb\/4\/4a\/Stop-Ringing-in-Ears-Step-9-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-9-Version-2.jpg","bigUrl":"\/images\/thumb\/4\/4a\/Stop-Ringing-in-Ears-Step-9-Version-2.jpg\/aid543713-v4-728px-Stop-Ringing-in-Ears-Step-9-Version-2.jpg","smallWidth":460,"smallHeight":345,"bigWidth":728,"bigHeight":546,"licensing":"&lt;div class=\"mw-parser-output\"&gt;&lt;p&gt;License: &lt;a target=\"_blank\" rel=\"nofollow noreferrer noopener\" class=\"external text\" href=\"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/\"&gt;Creative Commons&lt;\/a&gt;&lt;br&gt;\n&lt;\/p&gt;&lt;p&gt;&lt;br \/&gt;\n&lt;\/p&gt;&lt;\/div&gt;"}</span></div></a></div>
+<div class="step_num">3</div><div class="step">
+<b class="whb">Consume less alcohol and nicotine.</b> These substances increase the stress put on blood vessels by dilating them. This happens especially in the inner ear. Limit your intake of alcoholic beverages and tobacco products to reduce the symptoms.<sup id="_ref-16" class="reference" aria-label="Link to Reference 16"><a href="#_note-16">[16]</a><span class="ts_popup " hidden id="ts_popup_16" style="display: none;">
+	<span class="ts_close">X</span>
+		<span class="ts_name">Research source</span>
+		<span class="ts_description"></span>
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener"></a>
+
+</span>
+</sup>
+</div>
+<div class="clearall"></div>
+<div class="wh_ad_inner w_label al_grey" data-service="adsense" data-slot="7710650179" data-width="728" data-height="90" data-smallheight="250" data-type="method" data-small="1" data-medium="1" data-channels="8596984590" data-mediumchannels="3005955957" data-smallchannels="2811805837" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="0" data-gptdisplaylate="1">
+<div id="mobilemethod_ad_3"></div>
+<div class="al_method">Advertisement</div>
+</div>
+<script>WH.ads.addBodyAd('mobilemethod_ad_3')</script>
+</li>
+</ol>
+<div class="clearall"></div>
+</div>
+</div>
+<a name="Questions_and_Answers_sub" class="anchor"></a>
+<div class="qa section sticky    " data-few_contribs="1" data-search_enabled="0" data-aid="543713" data-answers-count="39" data-expert-answers-count="2" data-staff-answers-count="0" data-purchase-group="" data-purchase-type="" data-obscure-answers="0" data-obscure-answers-type="" data-purchase-obscured-cta-header="" data-purchase-obscured-cta-prompt="" data-obscured-answer-header="" data-obscured-answer-prompt="" data-obscured-answer-link="" data-purchase-obscured-answer-header="Support wikiHow by" data-purchase-obscured-answer-prompt="unlocking this expert answer." data-purchase-obscured-answer-link="#">
+	<h2 class="qa_heading">
+		<div class="altblock"></div>
+		<span class="mw-headline" id="qa_headline">
+			Expert Q&amp;A
+			
+		</span>
+	</h2>
+	<div id="qa" class="section_text">
+		<div id="qa_answered_questions_container">
+			<div id="qa_aq_search_container">
+				<div id="qa_aq_search_heading" class="qa_section_heading">Search</div>
+				<input class="qa_aq_search" placeholder="Type your query here">
+</div>
+			<a id="qa_add_curated_question">Add New Question</a>
+			<ul id="qa_article_questions" class="qa_questions qa_aqs ">
+<li id="qa_question_0" class="qa_aq qa_block " data-aqid="511729" data-cqid="511746" data-caid="512602" data-sqid="760137" data-qa_inactive="0" data-votes_up="11" data-votes_down="6" data-verifier_id="10992" data-submitter_id="0">
+					<div class="qa_divider"></div>
+				
+					<div class="qa_li_container">
+						<div class="qa_question_tab">Question</div>
+						<div class="qa_q_txt">I have ringing in ears at night only when l lie down. What could this be? What can I do?</div>
+						
+				
+				
+						<div class="qa_answers">
+							<div class="qa_expert_area">
+								<div class="qa_badge"></div>
+				
+								<div class="qa_user_hover hint_box">
+										<a href="/Author/Luba-Lee-FNP-BC-MS" class="sp_namelink qa_person_circle" target="_blank">
+	<picture><source type="image/webp" srcset="/images/thumb/6/66/Luba_Leev5.jpg/-crop-200-200-200px-Luba_Leev5.jpg.webp"></source><img src="/images/thumb/6/66/Luba_Leev5.jpg/-crop-200-200-200px-Luba_Leev5.jpg" alt="Luba Lee, FNP-BC, MS" loading="lazy" width="52" height="52" style="max-width: 52px"></picture></a>
+
+<div class="qa_expert_name">
+	<a href="/Author/Luba-Lee-FNP-BC-MS" class="sp_namelink click_out" target="_blank">
+		Luba Lee, FNP-BC, MS
+	</a>
+
+
+	<br>
+
+	Master's Degree, Nursing, University of Tennessee Knoxville
+</div>
+Luba Lee, FNP-BC is a board certified Family Nurse Practitioner (FNP) and educator in Tennessee with over a decade of clinical experience. Luba has certifications in Pediatric Advanced Life Support (PALS), Emergency Medicine, Advanced Cardiac Life Support (ACLS), Team Building, and Critical Care Nursing. She received her Master of Science in Nursing (MSN) from the University of Tennessee in 2006.
+
+										
+								</div>
+				
+									<a href="/Author/Luba-Lee-FNP-BC-MS" class="sp_namelink qa_person_circle" target="_blank"><picture><source type="image/webp" srcset="/images/thumb/6/66/Luba_Leev5.jpg/-crop-200-200-200px-Luba_Leev5.jpg.webp"></source><img src="/images/thumb/6/66/Luba_Leev5.jpg/-crop-200-200-200px-Luba_Leev5.jpg" alt="Luba Lee, FNP-BC, MS" loading="lazy" width="52" height="52" style="max-width: 52px"></picture></a>
+				
+				
+								<div class="qa_answerer_info">
+									<div class="qa_user_name">
+										<a href="/Author/Luba-Lee-FNP-BC-MS" target="_blank">Luba Lee, FNP-BC, MS</a>
+									</div>
+									<div class="qa_user_title">Master's Degree, Nursing, University of Tennessee Knoxville</div>
+				
+				
+									<div class="qa_user_label">Expert Answer</div>
+									
+								</div>
+							</div>
+				
+							<div class="qa_answer answer ">
+								Most people do experience some form of ringing in their ears especially in quiet settings.  Most tinnitus results from conditions that cause hearing loss.  Stress, fatigue and physical exertion may worsen the ringing in the ears. Managing daily stress well, taking care of your body through good nutrition and exercise, avoiding exposure to loud noises should help to minimize ringing in your ears.  Also, try using some sort of white noise device such as an air filter, special noise machine, peaceful nature sounds, or music.  
+							</div>
+								<div class="qa_answer_footer">
+									<div class="wh_vote_container qa_vote_buttons">
+	<span class="wh_thumb_response wh_thumb_msg">Thanks!</span>
+	<div class="qa_widget_vote_links">
+		<a href="#" class="wh_vote_up wh_vote_box button secondary">Yes</a>
+		<a href="#" class="wh_vote_down wh_vote_box button secondary">No</a>
+	</div>
+	<div class="qa_widget_vote_buttons">
+		<a href="#" class="wh_vote_down wh_vote_box">Not Helpful <span>6</span></a>
+		<a href="#" class="wh_vote_up wh_vote_box">Helpful <span>11</span></a>
+	</div>
+</div>
+
+
+
+								</div>
+						</div>
+					</div>
+				</li>
+					<li id="qa_question_1" class="qa_aq qa_block " data-aqid="511731" data-cqid="511748" data-caid="512604" data-sqid="891466" data-qa_inactive="0" data-votes_up="9" data-votes_down="8" data-verifier_id="10992" data-submitter_id="0">
+					<div class="qa_divider"></div>
+				
+					<div class="qa_li_container">
+						<div class="qa_question_tab">Question</div>
+						<div class="qa_q_txt">What is the remedy for tinnitus?</div>
+						
+				
+				
+						<div class="qa_answers">
+							<div class="qa_expert_area">
+								<div class="qa_badge"></div>
+				
+								<div class="qa_user_hover hint_box">
+										<a href="/Author/Luba-Lee-FNP-BC-MS" class="sp_namelink qa_person_circle" target="_blank">
+	<picture><source type="image/webp" srcset="/images/thumb/6/66/Luba_Leev5.jpg/-crop-200-200-200px-Luba_Leev5.jpg.webp"></source><img src="/images/thumb/6/66/Luba_Leev5.jpg/-crop-200-200-200px-Luba_Leev5.jpg" alt="Luba Lee, FNP-BC, MS" loading="lazy" width="52" height="52" style="max-width: 52px"></picture></a>
+
+<div class="qa_expert_name">
+	<a href="/Author/Luba-Lee-FNP-BC-MS" class="sp_namelink click_out" target="_blank">
+		Luba Lee, FNP-BC, MS
+	</a>
+
+
+	<br>
+
+	Master's Degree, Nursing, University of Tennessee Knoxville
+</div>
+Luba Lee, FNP-BC is a board certified Family Nurse Practitioner (FNP) and educator in Tennessee with over a decade of clinical experience. Luba has certifications in Pediatric Advanced Life Support (PALS), Emergency Medicine, Advanced Cardiac Life Support (ACLS), Team Building, and Critical Care Nursing. She received her Master of Science in Nursing (MSN) from the University of Tennessee in 2006.
+
+										
+								</div>
+				
+									<a href="/Author/Luba-Lee-FNP-BC-MS" class="sp_namelink qa_person_circle" target="_blank"><picture><source type="image/webp" srcset="/images/thumb/6/66/Luba_Leev5.jpg/-crop-200-200-200px-Luba_Leev5.jpg.webp"></source><img src="/images/thumb/6/66/Luba_Leev5.jpg/-crop-200-200-200px-Luba_Leev5.jpg" alt="Luba Lee, FNP-BC, MS" loading="lazy" width="52" height="52" style="max-width: 52px"></picture></a>
+				
+				
+								<div class="qa_answerer_info">
+									<div class="qa_user_name">
+										<a href="/Author/Luba-Lee-FNP-BC-MS" target="_blank">Luba Lee, FNP-BC, MS</a>
+									</div>
+									<div class="qa_user_title">Master's Degree, Nursing, University of Tennessee Knoxville</div>
+				
+				
+									<div class="qa_user_label">Expert Answer</div>
+									
+								</div>
+							</div>
+				
+							<div class="qa_answer answer ">
+								 The remedy depends on the cause of the tinnitus.  There are several drugs that are used to help relieve constant ringing such as nicotinic acid, vasodilators, tranquilizers, antidepressants and seizure medications. Many times treatment is unsuccessful. Biofeedback may help in certain cases when tinnitus is related to stress.  There is also tinnitus retraining therapy.  You may want to explore information and support provided by the American Tinnitus Association.
+							</div>
+								<div class="qa_answer_footer">
+									<div class="wh_vote_container qa_vote_buttons">
+	<span class="wh_thumb_response wh_thumb_msg">Thanks!</span>
+	<div class="qa_widget_vote_links">
+		<a href="#" class="wh_vote_up wh_vote_box button secondary">Yes</a>
+		<a href="#" class="wh_vote_down wh_vote_box button secondary">No</a>
+	</div>
+	<div class="qa_widget_vote_buttons">
+		<a href="#" class="wh_vote_down wh_vote_box">Not Helpful <span>8</span></a>
+		<a href="#" class="wh_vote_up wh_vote_box">Helpful <span>9</span></a>
+	</div>
+</div>
+
+
+
+								</div>
+						</div>
+					</div>
+				</li>
+			</ul>
+</div>
+		<div class="qa_divider qa_no_unpatrolled_questions"></div>
+		<div class="qa_divider "></div>
+
+
+
+		<div class="qa_section_heading" id="qa_ask_heading">Ask a Question</div>
+		<div id="qa_submitted_question_form">
+			<input id="qa_asked_question" type="text" maxlength="200" placeholder="What is your question?"><div id="qa_asked_count">200 characters left</div>
+			<input id="qa_email" type="text" placeholder="Email address (optional)"><div id="qa_email_prompt">Include your email address to get a message when this question is answered.</div>
+			<a id="qa_submit_button" class="button primary">Submit</a>
+		</div>
+
+
+		<div id="qa_flag_options" data-type="">
+			<div class="hint_box">
+				<ul></ul>
+</div>
+		</div>
+		<div id="qa_answer_flag_options" data-type="">
+			<div class="hint_box">
+				<ul></ul>
+</div>
+		</div>
+
+		<!--  Template form for creating/updating a curated question  -->
+		<script id="qa_question_edit_form" type="text/x-handlebars-template">
+			&lt;div class=&quot;qa_aq_edit_form&quot;&gt;
+	&lt;div class=&quot;qa_aq_edit_form_status&quot;&gt;&lt;/div&gt;
+	&lt;textarea class=&quot;qa_cq_text&quot; spellcheck=&quot;true&quot; placeholder=&quot;{{qa_edit_form_question_placeholder}}&quot;&gt;{{qa_edit_form_question}}&lt;/textarea&gt;
+	&lt;div class=&quot;qa_invalid_msg qa_cq_text_error qap_char_limit&quot;&gt;{{qa_cq_text_error}}&lt;/div&gt;
+	&lt;textarea class=&quot;qa_ca_text&quot; spellcheck=&quot;true&quot; placeholder=&quot;{{qa_edit_form_answer_placeholder}}&quot;&gt;{{qa_edit_form_answer}}&lt;/textarea&gt;
+	&lt;div class=&quot;qa_invalid_msg qa_ca_text_error qap_char_limit&quot;&gt;{{qa_ca_text_error}}&lt;/div&gt;
+	&lt;div class=&quot;qa_invalid_msg qa_ca_text_error2 qap_char_limit&quot;&gt;{{qa_ca_text_min}}&lt;/div&gt;
+	&lt;div class=&quot;qa_invalid_msg qa_ca_text_error3 qap_char_limit&quot;&gt;{{qa_ca_error_url}}&lt;/div&gt;
+	&lt;div class=&quot;qa_invalid_msg qa_ca_text_error_phone qap_char_limit&quot;&gt;{{qa_ca_error_phone}}&lt;/div&gt;
+	&lt;input class=&quot;qa_pa_email&quot; placeholder=&quot;{{qa_pa_email_placeholder}}&quot;/&gt;
+
+	{{#qa_admin}}
+		&lt;span class=&quot;qa_edit_form_verifier_container&quot;&gt;
+			{{qa_edit_form_verifier_label}}
+			&lt;select class=&quot;qa_edit_form_verifier&quot;&gt;
+				{{#qa_edit_form_verifiers}}
+					&lt;option value=&quot;{{id}}&quot; {{selected}}&gt;{{name}}&lt;/option&gt;
+				{{/qa_edit_form_verifiers}}
+			&lt;/select&gt;
+		&lt;/span&gt;
+		{{#qa_edit_form_show_remove_submitter}}
+		&lt;span class=&quot;qa_edit_form_remove_submitter_container&quot;&gt;
+			&lt;label for=&quot;qa_aq_remove_submitter&quot;&gt;{{qa_edit_form_remove_submitter}}&lt;/label&gt; &lt;input type=&quot;checkbox&quot; id=&quot;qa_aq_remove_submitter&quot; class=&quot;qa_checkbox&quot; /&gt;
+		&lt;/span&gt;
+		{{/qa_edit_form_show_remove_submitter}}
+	{{/qa_admin}}
+
+	&lt;span class=&quot;qa_edit_form_inactive_container&quot;&gt;
+		&lt;label for=&quot;qa_aq_inactive&quot;&gt;{{qa_edit_form_inactive}}&lt;/label&gt; &lt;input type=&quot;checkbox&quot; id=&quot;qa_aq_inactive&quot; class=&quot;qa_checkbox&quot; {{qa_edit_form_inactive_val}}&gt;
+	&lt;/span&gt;
+
+	&lt;div class=&quot;clearall&quot;&gt;&lt;/div&gt;
+
+	{{#qa_admin}}&lt;a class=&quot;qa_aq_delete button primary&quot;&gt;{{qa_edit_form_delete}}&lt;/a&gt;{{/qa_admin}}
+	&lt;a class=&quot;qa_aq_submit button primary&quot;&gt;{{qa_edit_form_submit}}&lt;/a&gt;
+	&lt;span class=&quot;qa_spinner&quot;&gt;&lt;/span&gt;
+	&lt;a class=&quot;qa_aq_cancel button secondary&quot;&gt;{{qa_edit_form_cancel}}&lt;/a&gt;
+&lt;/div&gt;
+
+		</script><!--  Template for rendering a desktop ArticleQuestion --><script id="qa_article_question_item" type="text/x-handlebars-template">
+				&lt;li id=&quot;qa_question_{{rank}}&quot; class=&quot;qa_aq qa_block {{#inactive}}qa_inactive{{/inactive}}&quot; data-aqid=&quot;{{id}}&quot; data-cqid=&quot;{{curatedQuestion.id}}&quot; data-caid=&quot;{{curatedQuestion.curatedAnswer.id}}&quot; data-sqid=&quot;{{curatedQuestion.submittedId}}&quot; data-qa_inactive=&quot;{{inactive}}&quot; data-votes_up=&quot;{{votesUp}}&quot; data-votes_down=&quot;{{votesDown}}&quot; data-verifier_id=&quot;{{verifierId}}&quot; data-submitter_id=&quot;{{submitterUserId}}&quot;&gt;
+	&lt;div class=&quot;qa_divider&quot;&gt;&lt;/div&gt;
+
+	&lt;div class=&quot;qa_li_container&quot;&gt;
+		&lt;div class=&quot;qa_question_tab&quot;&gt;{{qa_question_label}}&lt;/div&gt;
+		&lt;div class=&quot;qa_q_txt{{#qa_desktop}} question{{/qa_desktop}}&quot;&gt;{{{curatedQuestion.text}}}&lt;/div&gt;
+		{{#qa_staff}}&lt;div class=&quot;qa_staff_info&quot;&gt;{{staffInfo}}&lt;/div&gt;{{/qa_staff}}
+
+		{{#show_editor_tools}}
+		&lt;div class=&quot;qa_editor_tools&quot;&gt;
+			&lt;a class=&quot;qa_edit_aq&quot;&gt;{{qa_edit}}&lt;/a&gt;
+		&lt;/div&gt;
+		{{/show_editor_tools}}
+
+		&lt;div class=&quot;qa_answers&quot;&gt;
+			&lt;div class=&quot;{{qa_answerer_class}}&quot;&gt;
+				{{#show_badge}}&lt;div class=&quot;qa_badge&quot;&gt;&lt;/div&gt;{{/show_badge}}
+
+				{{^qa_amp}}
+				&lt;div class=&quot;qa_user_hover hint_box&quot;&gt;
+						{{#verifierId}}{{&gt; qa_expert_hover.mustache}}{{/verifierId}}
+						{{#staffAnswerer}}{{&gt; qa_staff_hover.mustache}}{{/staffAnswerer}}
+				&lt;/div&gt;
+				{{/qa_amp}}
+
+				{{#verifierId}}
+					{{#verifierData.articleReviewersUrl}}
+					&lt;a href=&quot;{{verifierData.articleReviewersUrl}}&quot; class=&quot;sp_namelink qa_person_circle&quot; target=&quot;_blank&quot;&gt;{{{verifierData.imageHtml}}}&lt;/a&gt;
+					{{/verifierData.articleReviewersUrl}}
+					{{^verifierData.articleReviewersUrl}}
+						&lt;div class=&quot;sp_namelink qa_person_circle&quot;&gt;{{{verifierData.imageHtml}}}&lt;/div&gt;
+					{{/verifierData.articleReviewersUrl}}
+				{{/verifierId}}
+
+				{{^verifierId}}
+				&lt;div class=&quot;qa_person_circle&quot;&gt;
+					&lt;picture&gt;
+						&lt;source type=&quot;image/webp&quot; srcset=&quot;{{avatarUrl}}.webp&quot; /&gt;
+						&lt;img src=&quot;{{avatarUrl}}&quot; width=&quot;{{avatarWidth}}&quot; height=&quot;{{avatarHeight}}&quot; style=&quot;max-width:{{avatarWidth}}px&quot; loading=&quot;lazy&quot; alt=&quot;{{submitterTextName}}&quot; /&gt;
+					&lt;/picture&gt;
+				&lt;/div&gt;
+				{{/verifierId}}
+
+				&lt;div class=&quot;qa_answerer_info&quot;&gt;
+				{{#verifierId}}
+					&lt;div class=&quot;qa_user_name&quot;&gt;
+					{{#verifierData.articleReviewersUrl}}
+						&lt;a href=&quot;{{verifierData.articleReviewersUrl}}&quot; target=&quot;_blank&quot;&gt;{{verifierData.name}}&lt;/a&gt;
+					{{/verifierData.articleReviewersUrl}}
+					{{^verifierData.articleReviewersUrl}}
+						{{verifierData.name}}
+					{{/verifierData.articleReviewersUrl}}
+					&lt;/div&gt;
+					&lt;div class=&quot;qa_user_title&quot;&gt;{{{verifierData.blurb}}}&lt;/div&gt;
+				{{/verifierId}}
+
+				{{^verifierId}}
+					&lt;div class=&quot;qa_user_name&quot;&gt;{{{submitterDisplayName}}}&lt;/div&gt;
+				{{/verifierId}}
+
+					&lt;div class=&quot;qa_user_label&quot;&gt;{{qa_answerer_label}}&lt;/div&gt;
+					{{#isTopAnswerer}}{{^qa_desktop}}&lt;div class=&quot;qa_ta_mobile_extra&quot;&gt;&lt;/div&gt;{{/qa_desktop}}{{/isTopAnswerer}}
+				&lt;/div&gt;
+			&lt;/div&gt;
+
+			&lt;div class=&quot;qa_answer answer {{#obscureAnswer}}{{#staffAnswerer}} qa_obscured_answer qa_obscured_answer_staff{{/staffAnswerer}}{{/obscureAnswer}}{{#obscureAnswers}}{{#verifierId}} qa_obscured_answer qa_obscured_answer_expert qa_obscured_answer_{{obscureAnswersType}}{{/verifierId}}{{/obscureAnswers}}{{#obscureAnswers}}{{#staffAnswerer}} qa_obscured_answer qa_obscured_answer_{{obscureAnswersType}}{{/staffAnswerer}}{{/obscureAnswers}}&quot;&gt;
+				{{#obscureAnswers}}
+					{{#staffAnswerer}}
+					&lt;a href=&quot;{{qa_purchase_obscured_answer_link}}&quot; class=&quot;qa_obscured_prompt&quot;&gt;
+						&lt;div class=&quot;qa_obscured_answer_overlay&quot;&gt;
+							{{#qa_amp}}
+							&lt;amp-img class=&quot;qa_obscured_answer_overlay_img&quot; src=&quot;/extensions/wikihow/qa/widget/assets/icon-lock.svg&quot; width=&quot;37&quot; height=&quot;46&quot; /&gt;
+							{{/qa_amp}}
+							{{^qa_amp}}
+							&lt;img class=&quot;qa_obscured_answer_overlay_img&quot; src=&quot;/extensions/wikihow/qa/widget/assets/icon-lock.svg&quot; /&gt;
+							{{/qa_amp}}
+							&lt;p&gt;
+								{{qa_purchase_obscured_answer_staff_header}}
+								&lt;strong&gt;{{qa_purchase_obscured_answer_staff_prompt}}&lt;/strong&gt;
+							&lt;/p&gt;
+						&lt;/div&gt;
+					&lt;/a&gt;
+					{{/staffAnswerer}}
+					{{#verifierId}}
+					&lt;a href=&quot;{{qa_purchase_obscured_answer_link}}&quot; class=&quot;qa_obscured_prompt&quot;&gt;
+						&lt;div class=&quot;qa_obscured_answer_overlay&quot;&gt;
+							{{#qa_amp}}
+							&lt;amp-img class=&quot;qa_obscured_answer_overlay_img&quot; src=&quot;/extensions/wikihow/qa/widget/assets/icon-lock.svg&quot; width=&quot;37&quot; height=&quot;46&quot; /&gt;
+							{{/qa_amp}}
+							{{^qa_amp}}
+							&lt;img class=&quot;qa_obscured_answer_overlay_img&quot; src=&quot;/extensions/wikihow/qa/widget/assets/icon-lock.svg&quot; /&gt;
+							{{/qa_amp}}
+							&lt;p&gt;
+								{{qa_purchase_obscured_answer_header}}
+								&lt;strong&gt;{{qa_purchase_obscured_answer_prompt}}&lt;/strong&gt;
+							&lt;/p&gt;
+						&lt;/div&gt;
+					&lt;/a&gt;
+					{{/verifierId}}
+				{{/obscureAnswers}}
+				{{{curatedQuestion.curatedAnswer.text}}}
+			&lt;/div&gt;
+			{{^qa_amp}}
+				&lt;div class=&quot;qa_answer_footer&quot;&gt;
+					{{^qa_hide_ratings}}{{&gt; thumbs_qa_widget}}{{/qa_hide_ratings}}
+					{{^qa_anon}}
+					&lt;a class=&quot;qa_ignore_answered&quot; href=&quot;#&quot;&gt;{{qa_flag_duplicate}}&lt;/a&gt;
+					&lt;p class=&quot;qa_ignore_answered_thanks&quot;&gt;Thanks!&lt;/p&gt;
+					{{/qa_anon}}
+				&lt;/div&gt;
+			{{/qa_amp}}
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/li&gt;
+
+		</script><!-- Template for rendering an unpatrolled QA --><!--  Template form for desktop thumbs up/down functionality  --><script id="qa_thumbs_qa_widget" type="text/x-handlebars-template">
+			&lt;div class=&quot;wh_vote_container qa_vote_buttons&quot;&gt;
+	&lt;span class='wh_thumb_response wh_thumb_msg'&gt;{{thumbs_response}}&lt;/span&gt;
+	&lt;div class=&quot;qa_widget_vote_links&quot;&gt;
+		&lt;a href=&quot;#&quot; class=&quot;wh_vote_up wh_vote_box button secondary&quot;&gt;{{qa_thumbs_yes}}&lt;/a&gt;
+		&lt;a href=&quot;#&quot; class=&quot;wh_vote_down wh_vote_box button secondary&quot;&gt;{{qa_thumbs_no}}&lt;/a&gt;
+	&lt;/div&gt;
+	&lt;div class=&quot;qa_widget_vote_buttons&quot;&gt;
+		&lt;a href=&quot;#&quot; class=&quot;wh_vote_down wh_vote_box&quot;&gt;{{qa_thumbs_nohelp}} &lt;span&gt;{{votesDown}}&lt;/span&gt;&lt;/a&gt;
+		&lt;a href=&quot;#&quot; class=&quot;wh_vote_up wh_vote_box&quot;&gt;{{qa_thumbs_help}} &lt;span&gt;{{votesUp}}&lt;/span&gt;&lt;/a&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+
+
+		</script><!--  Template for rendering a Top Answerers data --><script id="top_answerers_qa_widget" type="text/x-handlebars-template">
+			&lt;div class=&quot;qa_person_circle&quot;&gt;
+	{{{ta_image}}}
+&lt;/div&gt;
+
+&lt;div class='qa_ta_name'&gt;
+	&lt;span&gt;
+			{{userName}}, {{ta_label}}
+	&lt;/span&gt;&lt;br /&gt;
+	{{answersCount}} {{ta_answers_label}}
+&lt;/div&gt;
+&lt;div class=&quot;qa_ta_cats&quot;&gt;
+{{#topCats.0}}
+	{{ta_subcats_intro}}
+	{{#topCats}}&lt;a href=&quot;{{cat_link}}&quot; class=&quot;click_out&quot;&gt;{{cat}}&lt;/a&gt;, {{/topCats}}
+	{{ta_subcats_outro}}
+{{/topCats.0}}
+&lt;/div&gt;
+		</script><br><div class="wh_ad_inner w_label al_grey" data-service="adsense" data-slot="4167749029" data-width="728" data-height="90" data-smallslot="1240030252" data-smallheight="250" data-type="qa" data-small="1" data-medium="1" data-channels="8596984590" data-largechannels="9818776313" data-mediumchannels="3005955957" data-smallchannels="2811805837" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="0" data-gptdisplaylate="1">
+<div id="mobileqa_ad_1"></div>
+<div class="al_method">Advertisement</div>
+</div>
+<script>WH.ads.addBodyAd('mobileqa_ad_1')</script>
+</div>
+</div>
+
+
+</div>
+<div class="section tips sticky">
+<h2 class="section-heading" onclick="javascript:mfTempOpenSection(2)">
+<div class="altblock"></div>
+<div class="mw-ui-icon mw-ui-icon-element indicator"></div>
+<span class="mw-headline" id="Tips">Tips</span>
+</h2>
+<div id="tips" class="section_text">
+<ul>
+<li><div>Boosting your immune system may also stop ringing in your ears. This will help to protect you from infections and diseases that may increase the level of unwanted sound. Also, an improvement in your health can mean an improvement in your tinnitus. Have a healthy lifestyle, which especially includes a healthy diet, proper and regular exercise, and enough sleep at night.<div class="clearall"></div>
+</div>
+<div class="wh_vote_container">
+	<span class="wh_thumb_response wh_thumb_msg">Thanks!</span>
+	<div>
+		<a href="#" class="trvote_up_4d020ed8948889c5dd91678866446ae3_1 vote_up wh_vote_box">
+			Helpful
+			<span class="tr_vote">0</span>
+		</a>
+		<a href="#" class="trvote_down_4d020ed8948889c5dd91678866446ae3_1 vote_down wh_vote_box">
+			Not Helpful
+			<span class="tr_vote">0</span>
+		</a>
+	</div>
+</div>
+
+
+</li>
+<li><div>You may also want to look into the American Tinnitus Association for information and resources.<sup id="_ref-17" class="reference" aria-label="Link to Reference 17"><a href="#_note-17">[17]</a><span class="ts_popup " hidden id="ts_popup_17" style="display: none;">
+	<span class="ts_close">X</span>
+		<span class="ts_name">Research source</span>
+		<span class="ts_description"></span>
+				<a href="#" class="ts_source" target="_blank" rel="nofollow noreferrer noopener"></a>
+
+</span>
+</sup><div class="clearall"></div>
+</div>
+<div class="wh_vote_container">
+	<span class="wh_thumb_response wh_thumb_msg">Thanks!</span>
+	<div>
+		<a href="#" class="trvote_up_ce9fec5480d3db523734b75cf211bac3_1 vote_up wh_vote_box">
+			Helpful
+			<span class="tr_vote">0</span>
+		</a>
+		<a href="#" class="trvote_down_ce9fec5480d3db523734b75cf211bac3_1 vote_down wh_vote_box">
+			Not Helpful
+			<span class="tr_vote">0</span>
+		</a>
+	</div>
+</div>
+
+
+</li>
+</ul>
+<div class="clearall"></div>
+<div class="wh_ad_inner" data-service="adsense" data-smallslot="8787347780" data-smallheight="250" data-type="tips" data-small="1" data-channels="8596984590" data-mediumchannels="3005955957" data-smallchannels="2811805837" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="0" data-gptdisplaylate="1">
+<div id="tips_ad_1"></div>
+<div class="al_method">Advertisement</div>
+</div>
+<script>WH.ads.addBodyAd('tips_ad_1')</script>
+</div>
+<div id="promopair_container" class="wh_ad_spacing">
+<script>if (WH.shared.isLargeSize) {WH.eventView('article_promo_house_promopair_click_go_sc', {course_name:'techhelp', dest_url:'https://www.wikihow.com/Tech-Help-Pro?utm_source=wikihow&utm_medium=promopair&utm_campaign=tech_v08'}, '#promopair-img-wrap', 'click');}</script><a href="https://www.wikihow.com/Tech-Help-Pro?utm_source=wikihow&amp;utm_medium=promopair&amp;utm_campaign=tech_v08" id="promopair-img-wrap"><img width="420" height="250" data-width="420" data-height="250" id="6131f97c77290" class="scrolldefer content-fill" data-src="/images/2/25/Tech_v08_0420x0250.jpg"><script>WH.shared.addScrollLoadItem('6131f97c77290')</script><noscript><img src="/images/2/25/Tech_v08_0420x0250.jpg" width="420" height="250" data-width="420" data-height="250" id="6131f97c77290" class="scrolldefer content-fill"></noscript></a><script>WH.ads.promoLoadEvent( '6131f97c77290', 'promopair', 'tech_v08_0420x0250.jpg');</script><div class="wh_ad_inner w_label al_grey promopair" data-service="dfp" data-adunitpath="/10095428/engl/engl_gam_lgm_promo" data-size="[300, 250]" data-width="300" data-height="250" data-prebidload="1" data-large="1" data-channels="8596984590" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="[300, 250]" data-gptdisplaylate="1"><div id="promopair_ad_1"></div></div>
+<script>WH.ads.addBodyAd('promopair_ad_1')</script>
+</div>
+</div>
+<div class="mf-section-2 collapsible-block" id="mf-section-2">
+</div>
+<div id="rmb_container" class="section_text" style="display:none"><input type="button" class="button primary" id="rmbutton" value="Read More"></div>
+<div class="section relatedwikihows sticky">
+<h2><span class="mw-headline" id="Related_wikiHows">Related wikiHows</span></h2>
+<div id="relatedwikihows" class="section_text">
+<a class="related-wh" href="/Get-Rid-of-an-Ear-Ache"><div class="content-spacer">
+<img id="803a56d0acd0a593515c4e5f69761558" class="scrolldefer content-fill" alt="Get Rid of an Ear Ache" width="342" height="184" data-src="https://www.wikihow.com/images/thumb/7/73/Get-Rid-of-an-Ear-Ache-Step-10-Version-6.jpg/-crop-342-184-245px-Get-Rid-of-an-Ear-Ache-Step-10-Version-6.jpg"><span class="related-wh-title"><div class="related-wh-howto">How to</div>Get Rid of an Ear Ache</span>
+</div>
+<script>WH.shared.addScrollLoadItem('803a56d0acd0a593515c4e5f69761558')</script><noscript><img src="https://www.wikihow.com/images/thumb/7/73/Get-Rid-of-an-Ear-Ache-Step-10-Version-6.jpg/-crop-342-184-245px-Get-Rid-of-an-Ear-Ache-Step-10-Version-6.jpg"></noscript></a><a class="related-wh" href="/Cure-an-Earache"><div class="content-spacer">
+<img id="4d53c4c36b3cd5a03d78939553fb6449" class="scrolldefer content-fill" alt="Cure an Earache" width="342" height="184" data-src="https://www.wikihow.com/images/thumb/8/89/Cure-an-Earache-Step-12-Version-3.jpg/-crop-342-184-245px-Cure-an-Earache-Step-12-Version-3.jpg"><span class="related-wh-title"><div class="related-wh-howto">How to</div>Cure an Earache</span>
+</div>
+<script>WH.shared.addScrollLoadItem('4d53c4c36b3cd5a03d78939553fb6449')</script><noscript><img src="https://www.wikihow.com/images/thumb/8/89/Cure-an-Earache-Step-12-Version-3.jpg/-crop-342-184-245px-Cure-an-Earache-Step-12-Version-3.jpg"></noscript></a><div class="wh_ad_inner" data-service="adsense" data-smallslot="3859396687" data-smallheight="250" data-type="middlerelated" data-small="1" data-channels="8596984590" data-mediumchannels="3005955957" data-smallchannels="2811805837" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="0" data-gptdisplaylate="1"><div id="middlerelated_ad_1"></div></div>
+<script>WH.ads.addBodyAd('middlerelated_ad_1')</script><a class="related-wh" href="/Treat-Tinnitus"><div class="content-spacer">
+<img id="a3414074fc29337877f162865bc3c6d3" class="scrolldefer content-fill" alt="Treat Tinnitus" width="342" height="184" data-src="https://www.wikihow.com/images/thumb/c/cd/Cure-Tinnitus-Step-16.jpg/-crop-342-184-245px-Cure-Tinnitus-Step-16.jpg"><span class="related-wh-title"><div class="related-wh-howto">How to</div>Treat Tinnitus</span>
+</div>
+<script>WH.shared.addScrollLoadItem('a3414074fc29337877f162865bc3c6d3')</script><noscript><img src="https://www.wikihow.com/images/thumb/c/cd/Cure-Tinnitus-Step-16.jpg/-crop-342-184-245px-Cure-Tinnitus-Step-16.jpg"></noscript></a><a class="related-wh" href="/Reduce-Tinnitus-Naturally"><div class="content-spacer">
+<img id="01874b115a15bb04d291b3db1940e0e5" class="scrolldefer content-fill" alt="Reduce Tinnitus Naturally" width="342" height="184" data-src="https://www.wikihow.com/images/thumb/d/d9/Recognize-Hearing-Loss-Step-19.jpg/-crop-342-184-245px-Recognize-Hearing-Loss-Step-19.jpg"><span class="related-wh-title"><div class="related-wh-howto">How to</div>Reduce Tinnitus Naturally</span>
+</div>
+<script>WH.shared.addScrollLoadItem('01874b115a15bb04d291b3db1940e0e5')</script><noscript><img src="https://www.wikihow.com/images/thumb/d/d9/Recognize-Hearing-Loss-Step-19.jpg/-crop-342-184-245px-Recognize-Hearing-Loss-Step-19.jpg"></noscript></a><a class="related-wh" href="/Cope-with-Tinnitus"><div class="content-spacer">
+<img id="a50bcc216a4b0c8b0f378bd0a3c97932" class="scrolldefer content-fill" alt="Cope with Tinnitus" width="342" height="184" data-src="https://www.wikihow.com/images/thumb/9/9e/Cope-with-Tinnitus-Step-13.jpg/-crop-342-184-245px-Cope-with-Tinnitus-Step-13.jpg"><span class="related-wh-title"><div class="related-wh-howto">How to</div>Cope with Tinnitus</span>
+</div>
+<script>WH.shared.addScrollLoadItem('a50bcc216a4b0c8b0f378bd0a3c97932')</script><noscript><img src="https://www.wikihow.com/images/thumb/9/9e/Cope-with-Tinnitus-Step-13.jpg/-crop-342-184-245px-Cope-with-Tinnitus-Step-13.jpg"></noscript></a><a class="related-wh" href="/Find-the-Causes-of-Tinnitus"><div class="content-spacer">
+<img id="21bece49bed73cf94f9e3d9999fdabda" class="scrolldefer content-fill" alt="Find the Causes of Tinnitus" width="342" height="184" data-src="https://www.wikihow.com/images/thumb/6/64/Find-the-Causes-of-Tinnitus-Step-10.jpg/-crop-342-184-245px-Find-the-Causes-of-Tinnitus-Step-10.jpg"><span class="related-wh-title"><div class="related-wh-howto">How to</div>Find the Causes of Tinnitus</span>
+</div>
+<script>WH.shared.addScrollLoadItem('21bece49bed73cf94f9e3d9999fdabda')</script><noscript><img src="https://www.wikihow.com/images/thumb/6/64/Find-the-Causes-of-Tinnitus-Step-10.jpg/-crop-342-184-245px-Find-the-Causes-of-Tinnitus-Step-10.jpg"></noscript></a><div class="clearall"></div>
+<div class="wh_ad_inner w_label al_grey" data-service="adsense" data-slot="3648874275" data-width="728" data-height="90" data-smallslot="9047782573" data-smallheight="250" data-type="related" data-small="1" data-medium="1" data-channels="8596984590" data-largechannels="9818776313" data-mediumchannels="3005955957" data-smallchannels="2811805837" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="0" data-gptdisplaylate="1">
+<div id="mobilerelated_ad_1"></div>
+<div class="al_method">Advertisement</div>
+</div>
+<script>WH.ads.addBodyAd('mobilerelated_ad_1')</script>
+</div>
+</div>
+<div class="mf-section-3 collapsible-block" id="mf-section-3">
+</div>
+<div class="mf-section-4 collapsible-block" id="mf-section-4">
+
+</div>
+<div class="mf-section-5 collapsible-block" id="mf-section-5">
+
+
+
+
+
+
+</div>
+</div>
+</div>
+<div class="printfooter">
+</div>
+<div class="section references sourcesandcitations sticky">
+<h2 class="section-heading">
+<div class="mw-ui-icon mw-ui-icon-element indicator" id="references_first"></div>
+<span class="mw-headline" id="References">References</span>
+</h2>
+<div id="references" class="section_text"><ol class="firstref references">
+<li id="_note-1">
+<a href="#_ref-1" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="http://www.mayoclinic.org/diseases-conditions/tinnitus/basics/definition/con-20021487">http://www.mayoclinic.org/diseases-conditions/tinnitus/basics/definition/con-20021487</a></span>
+</li>
+<li id="_note-2">
+<a href="#_ref-2" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5421307/">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5421307/</a></span>
+</li>
+<li id="_note-3">
+<a href="#_ref-3" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://my.clevelandclinic.org/health/diseases/8613-ear-infection-otitis-media">https://my.clevelandclinic.org/health/diseases/8613-ear-infection-otitis-media</a></span>
+</li>
+<li id="_note-4">
+<a href="#_ref-4" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.mayoclinic.org/diseases-conditions/tinnitus/diagnosis-treatment/drc-20350162">https://www.mayoclinic.org/diseases-conditions/tinnitus/diagnosis-treatment/drc-20350162</a></span>
+</li>
+<li id="_note-5">
+<a href="#_ref-5" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.health.harvard.edu/staying-healthy/got-an-ear-full-heres-some-advice-for-ear-wax-removal">https://www.health.harvard.edu/staying-healthy/got-an-ear-full-heres-some-advice-for-ear-wax-removal</a></span>
+</li>
+<li id="_note-6">
+<a href="#_ref-6" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.tinnitusjournal.com/articles/tinnitus-in-temporomandibular-joint-disorders-is-it-a-specific-somatosensory-tinnitus-subtype.html">https://www.tinnitusjournal.com/articles/tinnitus-in-temporomandibular-joint-disorders-is-it-a-specific-somatosensory-tinnitus-subtype.html</a></span>
+</li>
+<li id="_note-7">
+<a href="#_ref-7" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.ucsfhealth.org/conditions/tinnitus/treatment.html">https://www.ucsfhealth.org/conditions/tinnitus/treatment.html</a></span>
+</li>
+<li id="_note-8">
+<a href="#_ref-8" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.ncbi.nlm.nih.gov/pubmed/19045972">https://www.ncbi.nlm.nih.gov/pubmed/19045972</a></span>
+</li>
+<li id="_note-9">
+<a href="#_ref-9" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.mayoclinic.org/diseases-conditions/tinnitus/diagnosis-treatment/drc-20350162">https://www.mayoclinic.org/diseases-conditions/tinnitus/diagnosis-treatment/drc-20350162</a></span>
+</li>
+</ol></div>
+</div>
+<div id="aiinfo" class="section articleinfo sticky"><div id="articleinfo" class="section_text"><a id="info_link" href="#aiinfo">More References (8)</a></div></div>
+<div class="section references aidata sourcesandcitations sticky"><div id="references_second" class="section_text"><ol class="firstref references" start="10">
+<li id="_note-10">
+<a href="#_ref-10" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7156891/">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7156891/</a></span>
+</li>
+<li id="_note-11">
+<a href="#_ref-11" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://pubmed.ncbi.nlm.nih.gov/8343245/">https://pubmed.ncbi.nlm.nih.gov/8343245/</a></span>
+</li>
+<li id="_note-12">
+<a href="#_ref-12" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3157487/">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3157487/</a></span>
+</li>
+<li id="_note-13">
+<a href="#_ref-13" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://nyulangone.org/conditions/tinnitus-in-adults/prevention">https://nyulangone.org/conditions/tinnitus-in-adults/prevention</a></span>
+</li>
+<li id="_note-14">
+<a href="#_ref-14" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.health.harvard.edu/diseases-and-conditions/tinnitus-ringing-in-the-ears-and-what-to-do-about-it">https://www.health.harvard.edu/diseases-and-conditions/tinnitus-ringing-in-the-ears-and-what-to-do-about-it</a></span>
+</li>
+<li id="_note-15">
+<a href="#_ref-15" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="http://www.webmd.com/a-to-z-guides/ringing-in-the-ears-tinnitus-home-treatment">http://www.webmd.com/a-to-z-guides/ringing-in-the-ears-tinnitus-home-treatment</a></span>
+</li>
+<li id="_note-16">
+<a href="#_ref-16" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.tinnitus.org.uk/food-drink-and-tinnitus">https://www.tinnitus.org.uk/food-drink-and-tinnitus</a></span>
+</li>
+<li id="_note-17">
+<a href="#_ref-17" target="_blank">↑</a> <span class="reference-text"><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.ata.org/">https://www.ata.org/</a></span>
+</li>
+</ol></div></div>
+<div class="section aboutthisarticle sticky" id="aboutthisarticle">
+
+	<h2 id="sp_h2"><span class="mw-headline">About This Article</span></h2>
+
+	<div id="social_proof_mobile">
+		<a name="social_proof_anchor" id="social_proof_anchor"></a>
+		<div class="sp_inner">
+				<div class="sp_top_box sp_person sp_expert">
+				
+					<div class="coauthor_avatar_badge"></div>
+				
+					<div class="ar_avatar" style="max-width: 50px"><picture><source type="image/webp" srcset="/images/thumb/6/66/Luba_Leev5.jpg/-crop-100-100-100px-Luba_Leev5.jpg.webp"></source><img src="/images/thumb/6/66/Luba_Leev5.jpg/-crop-100-100-100px-Luba_Leev5.jpg" alt="Luba Lee, FNP-BC, MS" loading="lazy" width="50" height="50" style="max-width: 50px"></picture></div>
+				
+				
+				
+				
+					<div class="sp_expert_text ">
+						<div>
+							<div class="sp_coauthor_label">
+								Medically reviewed by:
+							</div>
+							<div class="sp_expert_name"><a href="/Author/Luba-Lee-FNP-BC-MS" class="sp_namelink">Luba Lee, FNP-BC, MS</a></div>
+							<div class="sp_expert_blurb">Master's Degree, Nursing, University of Tennessee Knoxville</div>
+						</div>
+					</div>
+				
+				</div>
+			<div id="sp_expert_desc">
+			This article was medically reviewed by <a href="/Author/Luba-Lee-FNP-BC-MS">Luba Lee, FNP-BC, MS</a>. Luba Lee, FNP-BC is a board certified Family Nurse Practitioner (FNP) and educator in Tennessee with over a decade of clinical experience. Luba has certifications in Pediatric Advanced Life Support (PALS), Emergency Medicine, Advanced Cardiac Life Support (ACLS), Team Building, and Critical Care Nursing. She received her Master of Science in Nursing (MSN) from the University of Tennessee in 2006.  This article has been viewed 3,337,197 times.
+			</div>
+
+
+
+				
+				<div class="sp_box sp_box_hoverable sp_helpful_hoverable sp_helpful_box  " data-helpful="68">
+				
+					<div class="sp_star_section_upper">
+						<div class="sp_star_section_hoverable">
+							<div class="sp_star_container star1">
+								<div class="sp_helpful_icon_star pretty_star" style="width:100%"></div>
+							</div>
+							<div class="sp_star_container star2">
+								<div class="sp_helpful_icon_star pretty_star" style="width:100%"></div>
+							</div>
+							<div class="sp_star_container star3">
+								<div class="sp_helpful_icon_star pretty_star" style="width:100%"></div>
+							</div>
+							<div class="sp_star_container star4">
+								<div class="sp_helpful_icon_star pretty_star" style="width:40%"></div>
+							</div>
+							<div class="sp_star_container star5">
+								<div class="sp_helpful_icon_star pretty_star" style="width:0%"></div>
+							</div>
+						</div>
+					</div>				
+					<div class="sp_helpful_lower">
+						<div class="sp_star_rating_text"></div>
+						<div class="sp_helpful_rating_count">103 votes - 68%</div>
+						<div class="helpfulness_text"></div>
+					</div>
+				
+				
+				</div>
+				
+				<div class="sp_box sp_stats_box ">
+					<div class="sp_text">
+						Co-authors:  <span class="sp_text_data">39</span>
+					</div>
+					<div class="sp_text">
+						<span id="sp_modified">Updated: <span class="sp_text_data">August 27, 2021</span></span>
+					</div>
+					<div class="sp_text">
+						Views: <span class="sp_text_data">3,337,197</span>
+					</div>
+				</div>
+
+
+				<div class="sp_box sp_fullbox">
+					Categories: <span dir="ltr"><a href="/Category:Tinnitus" title="Category:Tinnitus">Tinnitus</a></span>
+				</div>
+<div class="sp_box sp_fullbox sp_disclaimer">
+<p><b>Medical Disclaimer</b>
+</p>
+<p>The content of this article is not intended to be a substitute for professional medical advice, examination, diagnosis, or treatment. You should always contact your doctor or other qualified healthcare professional before starting, changing, or stopping any kind of health treatment.
+</p>
+<div id="disclaimer_readmore_link">
+<p>    <a href="/wikiHow:Terms-of-Use#Medical-Information" title="wikiHow:Terms of Use">Read More...</a>
+</p>
+</div>
+</div>
+
+			<div class="clearall"></div>
+		</div>
+
+	</div>
+<div id="summary_wrapper" class="section_text">
+<a href="#summary_wrapper" class="collapse_link">Article Summary<span id="summary_close">X</span></a><p class="text_summary_wrapper" id="summary_text">To stop ringing in your ears, start by covering your ears with your palms so your fingers are pointed toward the back of your head. Then, put your index fingers on your middle fingers and snap them down onto your head. Do this about 40 times and then check to see if the ringing has subsided. If you have chronic ringing in your ears, try taking gingko extract 3 times a day with your meals which may help reduce the ringing. <span id="summary_last_sentence">To learn how to prevent ringing in your ears, scroll down!</span><span id="summary_position" class="sumpos_bottom"></span><div class="s-help-wrap" data-type="summarytexthelp">
+<span class="s-help-prompt">Did this summary help you?</span><button class="s-help-response" data-value="1" data-type="summarytexthelp" data-prompt-text="We are so glad to have helped!" data-finish-prompt="Thank you! &lt;a href='#' class='firststeplink'&gt;Return to the article to learn more...&lt;/a&gt;" data-textarea-prompt="Please describe what was helpful in the video..." type="submit">Yes</button><button class="s-help-response" data-value="0" data-type="summarytexthelp" data-prompt-text="Sorry that the video wasn't helpful." data-finish-prompt="Sorry the summary wasn't helpful. &lt;a href='#' class='firststeplink'&gt;Return to the article to learn more...&lt;/a&gt;" data-textarea-prompt="Please tell us what you would have liked to see in the video..." type="submit">No</button><div class="s-help-feedback-wrap">
+<textarea class="s-help-textarea"></textarea><input type="button" class="s-help-submit button primary" value="Submit">
+</div>
+</div></p>
+</div>
+<div id="other_languages" class="section_text">
+<a href="#other_languages" class="collapse_link">In other languages</a><div id="language_links">
+<div class="language_link">
+<span>Español:</span><a href="https://es.wikihow.com/eliminar-el-zumbido-en-los-o%C3%ADdos">eliminar el zumbido en los oídos</a>
+</div>
+<div class="language_link">
+<span>Italiano:</span><a href="https://www.wikihow.it/Eliminare-il-Ronzio-nelle-Orecchie">Eliminare il Ronzio nelle Orecchie</a>
+</div>
+<div class="language_link">
+<span>Français:</span><a href="https://fr.wikihow.com/arr%C3%AAter-les-sifflements-dans-les-oreilles">arrêter les sifflements dans les oreilles</a>
+</div>
+<div class="language_link">
+<span>Русский:</span><a href="https://ru.wikihow.com/%D0%BF%D1%80%D0%B5%D0%BA%D1%80%D0%B0%D1%82%D0%B8%D1%82%D1%8C-%D0%B7%D0%B2%D0%BE%D0%BD-%D0%B2-%D1%83%D1%88%D0%B0%D1%85">прекратить звон в ушах</a>
+</div>
+<div class="language_link">
+<span>中文:</span><a href="https://zh.wikihow.com/%E6%B6%88%E9%99%A4%E8%80%B3%E9%B8%A3">消除耳鸣</a>
+</div>
+<div class="language_link">
+<span>Nederlands:</span><a href="https://nl.wikihow.com/Oorsuizen-stoppen">Oorsuizen stoppen</a>
+</div>
+<div class="language_link">
+<span>Čeština:</span><a href="https://www.wikihow.cz/Jak-zastavit-zvon%C4%9Bn%C3%AD-v-u%C5%A1%C3%ADch">Jak zastavit zvonění v uších</a>
+</div>
+<div class="language_link">
+<span>Bahasa Indonesia:</span><a href="https://id.wikihow.com/Menghilangkan-Telinga-Berdengung">Menghilangkan Telinga Berdengung</a>
+</div>
+<div class="language_link">
+<span>العربية:</span><a href="https://ar.wikihow.com/%D8%A7%D9%84%D8%AA%D8%AE%D9%84%D9%91%D8%B5-%D9%85%D9%86-%D8%B7%D9%86%D9%8A%D9%86-%D8%A7%D9%84%D8%A3%D8%B0%D9%86%D9%8A%D9%86">التخلّص من طنين الأذنين</a>
+</div>
+<div class="language_link">
+<span>हिन्दी:</span><a href="https://hi.wikihow.com/%E0%A4%95%E0%A4%BE%E0%A4%A8-%E0%A4%95%E0%A5%87-%E0%A4%85%E0%A4%82%E0%A4%A6%E0%A4%B0-%E0%A4%AC%E0%A4%9C%E0%A4%A8%E0%A5%87-%E0%A4%B5%E0%A4%BE%E0%A4%B2%E0%A5%80-%E0%A4%98%E0%A4%82%E0%A4%9F%E0%A5%80-%E0%A4%95%E0%A5%8B-%E0%A4%B0%E0%A5%8B%E0%A4%95%E0%A5%87%E0%A4%82">कान के अंदर बजने वाली घंटी को रोकें</a>
+</div>
+<div class="language_link">
+<span>日本語:</span><a href="https://www.wikihow.jp/%E8%80%B3%E9%B3%B4%E3%82%8A%E3%82%92%E6%AD%A2%E3%82%81%E3%82%8B">耳鳴りを止める</a>
+</div>
+<div class="language_link">
+<span>ไทย:</span><a href="https://th.wikihow.com/%E0%B9%81%E0%B8%81%E0%B9%89%E0%B8%AD%E0%B8%B2%E0%B8%81%E0%B8%B2%E0%B8%A3%E0%B8%AB%E0%B8%B9%E0%B8%AD%E0%B8%B7%E0%B9%89%E0%B8%AD">แก้อาการหูอื้อ</a>
+</div>
+<div class="language_link">
+<span>Tiếng Việt:</span><a href="https://www.wikihow.vn/Ng%E1%BB%ABng-ti%E1%BA%BFng-%E1%BB%93n-trong-tai">Ngừng tiếng ồn trong tai</a>
+</div>
+<div class="language_link">
+<span>한국어:</span><a href="https://ko.wikihow.com/%EC%9D%B4%EB%AA%85%EC%9D%84-%EB%A9%88%EC%B6%94%EB%8A%94-%EB%B0%A9%EB%B2%95">이명을 멈추는 방법</a>
+</div>
+<div class="language_link">
+<span>Türkçe:</span><a href="https://www.wikihow.com.tr/Kulak-%C3%87%C4%B1nlamas%C4%B1-Nas%C4%B1l-Giderilir">Kulak Çınlaması Nasıl Giderilir</a>
+</div>
+</div>
+</div>
+
+	<ul id="end_options" class="section_text">
+<li><a href="#" id="printLink">Print</a></li>
+<li><a href="#" id="gatThankAuthors">Send fan mail to authors</a></li>
+	<div class="clearall"></div>
+</ul>
+<div class="page_stats section_text">Thanks to all authors for creating a page that has been read 3,337,197 times.<div class="clearall"></div>
+</div>
+</div>
+<div id="userreviews_mobile" class="section sticky">
+	<h2 id="ur_h2"><span class="mw-headline">Reader Success Stories</span></h2>
+
+	<div id="ur_mobile" class="section_text">
+
+		<ul>
+<li class="ur_review ur_review">
+				
+				<div class="ur_user">
+
+
+					<picture class="ur_avatar"><source type="image/webp" srcset="/images/thumb/f/f5/CommunityAvatar4.png/-crop-72-72-72px-CommunityAvatar4.png.webp"></source><img src="/images/thumb/f/f5/CommunityAvatar4.png/-crop-72-72-72px-CommunityAvatar4.png" width="36" height="36" style="max-width:36px" loading="lazy" alt="Lily K."></picture><div class="ur_author">
+						<p class="ur_name">Lily K.</p>
+						<p class="ur_date">May 22</p>
+					</div>
+				</div>
+
+				<div class="ur_review_text">
+					"I had ringing in my ears, but after using the method for tapping your fingers on your skull, the ringing subsided.<span class="ur_review_more" hidden> Thank you!"</span><span class="ur_ellipsis">..." </span><a href="#" class="ur_review_show">more</a>
+				</div>
+
+				<div class="ur_rating">
+						<span>Rated this article: </span>
+							<div class="ur_star ur_rating_on"></div>
+							<div class="ur_star ur_rating_on"></div>
+							<div class="ur_star ur_rating_on"></div>
+							<div class="ur_star ur_rating_on"></div>
+							<div class="ur_star ur_rating_on"></div>
+						<div class="clearall"></div>
+				</div>
+
+
+			</li>
+			<div id="ur_the_rest" class="ur_the_rest" hidden></div> 
+		</ul>
+<div class="ur_nav_container">
+
+				<a id="ur_lower_show" class="ur_more" href="#">More reader stories</a>
+
+				<a id="ur_lower_hide" class="ur_hide" href="#">Hide reader stories</a>
+
+			</div>
+
+		<a href="#" class="ur_share">Share your story</a>
+
+		<div class="clearall"></div>
+</div>
+	</div>
+
+<div id="article_rating_mobile" class="section_text">
+	<h2 id="article_rating_header"><span class="mw-headline">Did this article help you?</span></h2>
+	<div id="article_rating">
+		<button id="gatAccuracyYes" pageid="543713" role="button" tabindex="0" class="button secondary vote_up aritem">Yes</button>
+		<button id="gatAccuracyNo" pageid="543713" role="button" tabindex="1" class="button secondary vote_down aritem">No</button>
+	</div>
+	<div class="clearall"></div>
+</div>
+<div id="pagebottom">
+<div class="wh_ad_inner" data-service="adsense" data-smallslot="3788982605" data-smallheight="250" data-type="pagebottom" data-small="1" data-channels="8596984590" data-smallchannels="2811805837" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="0" data-gptdisplaylate="1">
+<div id="pagebottom_ad_1"></div>
+<div class="al_method">Advertisement</div>
+</div>
+<script>WH.ads.addBodyAd('pagebottom_ad_1')</script>
+</div>
+</div></div><div id="sidebar"><div id="cookie_notice" class="sidebox notice_bgcolor"><a href="#" id="cookie_notice_x"></a>Cookies make wikiHow better. By continuing to use our site, you agree to our <a href="/wikiHow:Cookie-Policy" target="_blank">cookie policy</a>.</div><div id="social_proof_sidebox" class="sidebox ">
+		<div class="sp_top_box sp_person sp_expert">
+		
+			<div class="coauthor_avatar_badge"></div>
+		
+			<div class="ar_avatar" style="max-width: 50px"><picture><source type="image/webp" srcset="/images/thumb/6/66/Luba_Leev5.jpg/-crop-100-100-100px-Luba_Leev5.jpg.webp"/><img src="/images/thumb/6/66/Luba_Leev5.jpg/-crop-100-100-100px-Luba_Leev5.jpg" alt="Luba Lee, FNP-BC, MS" loading="lazy" width="50" height="50" style="max-width: 50px"/></picture></div>
+		
+		
+		
+		
+			<div class="sp_expert_text ">
+				<div>
+					<div class="sp_coauthor_label">
+						Medically reviewed by:
+					</div>
+					<div class="sp_expert_name"><a href="/Author/Luba-Lee-FNP-BC-MS" class="sp_namelink">Luba Lee, FNP-BC, MS</a></div>
+					<div class="sp_expert_blurb">Master's Degree, Nursing, University of Tennessee Knoxville</div>
+				</div>
+			</div>
+		
+		</div>
+
+	<div class="sp_inner">
+
+
+			
+			<div class="sp_box sp_box_hoverable sp_helpful_hoverable sp_helpful_box  " data-helpful="68">
+			
+				<div class="sp_star_section_upper">
+					<div class="sp_star_section_hoverable">
+						<div class="sp_star_container star1">
+							<div class="sp_helpful_icon_star pretty_star" style="width:100%"></div>
+						</div>
+						<div class="sp_star_container star2">
+							<div class="sp_helpful_icon_star pretty_star" style="width:100%"></div>
+						</div>
+						<div class="sp_star_container star3">
+							<div class="sp_helpful_icon_star pretty_star" style="width:100%"></div>
+						</div>
+						<div class="sp_star_container star4">
+							<div class="sp_helpful_icon_star pretty_star" style="width:40%"></div>
+						</div>
+						<div class="sp_star_container star5">
+							<div class="sp_helpful_icon_star pretty_star" style="width:0%"></div>
+						</div>
+					</div>
+				</div>			
+				<div class="sp_helpful_lower">
+					<div class="sp_star_rating_text"></div>
+					<div class="sp_helpful_rating_count">103 votes - 68%</div>
+					<div class="helpfulness_text">Click a star to vote</div>
+				</div>
+			
+			
+				<div class='sp_popup_container'>
+					<div class='hint_box'>% of people told us that this article helped them.</div>
+				</div>
+			</div>
+			
+
+		<div class="sp_box sp_stats_box ">
+			<div class="sp_text">
+				Co-authors:  <span class="sp_text_data">39</span>
+			</div>
+			<div class="sp_text">
+				<span id="sp_modified">Updated: <span class="sp_text_data">August 27, 2021</span></span>
+			</div>
+			<div class="sp_text">
+				Views:&nbsp;<span class="sp_text_data">3,337,197</span>
+			</div>
+		</div>
+
+		<div class="clearall"></div>
+	</div>
+</div>
+
+<div id="userreviews" class="sidebox">
+	<div id="reviews">
+		<div class="ur_review ur_review0">
+			<div class="ur_user">
+
+				<picture class="ur_avatar">
+					<source type="image/webp" srcset="/images/thumb/f/f2/CommunityAvatar3.png/-crop-72-72-72px-CommunityAvatar3.png.webp" />
+					<img src="/images/thumb/f/f2/CommunityAvatar3.png/-crop-72-72-72px-CommunityAvatar3.png" width="36" height="36" style="max-width:36px" loading="lazy" alt="Lily K." />
+				</picture>
+
+				<div class="ur_author">
+					<p class="ur_name">Lily K.</p>
+					<p class="ur_date">May 22</p>
+				</div>
+
+			</div>
+
+			<div class="ur_review_text">
+				"I had ringing in my ears, but after using the method for tapping your fingers on your skull, the ringing subsided.<span class='ur_review_more' hidden> Thank you!"</span><span class='ur_ellipsis'>..." </span><a href='#' class='ur_review_show'>more</a>
+			</div>
+
+			<div class="ur_rating">
+					<span>Rated this article: </span>
+						<div class="ur_star ur_rating_on"></div>
+						<div class="ur_star ur_rating_on"></div>
+						<div class="ur_star ur_rating_on"></div>
+						<div class="ur_star ur_rating_on"></div>
+						<div class="ur_star ur_rating_on"></div>
+					<div class="clearall"></div>
+			</div>
+
+		</div>
+
+		<div class="ur_the_rest" hidden>
+
+		<div class="ur_review ur_review1">
+			<div class="ur_user">
+
+				<picture class="ur_avatar">
+					<source type="image/webp" srcset="/images/thumb/f/f5/CommunityAvatar4.png/-crop-72-72-72px-CommunityAvatar4.png.webp" />
+					<img src="/images/thumb/f/f5/CommunityAvatar4.png/-crop-72-72-72px-CommunityAvatar4.png" width="36" height="36" style="max-width:36px" loading="lazy" alt="Traci Kinne-Brown" />
+				</picture>
+
+				<div class="ur_author">
+					<p class="ur_name">Traci Kinne-Brown</p>
+					<p class="ur_date">Aug 29, 2017</p>
+				</div>
+
+			</div>
+
+			<div class="ur_review_text">
+				"I have had hearing loss and ringing in my ears for the greater part of my life. I thought I knew all there is to<span class='ur_review_more' hidden> know about tinnitus. But after reading your article, I realized how much I didn't know. All the information has been very helpful. Thank you so much!"</span><span class='ur_ellipsis'>..." </span><a href='#' class='ur_review_show'>more</a>
+			</div>
+
+			<div class="ur_rating">
+			</div>
+
+		</div>
+
+		
+
+		<div class="ur_review ur_review2">
+			<div class="ur_user">
+
+				<picture class="ur_avatar">
+					<source type="image/webp" srcset="/images/thumb/f/f5/CommunityAvatar4.png/-crop-72-72-72px-CommunityAvatar4.png.webp" />
+					<img src="/images/thumb/f/f5/CommunityAvatar4.png/-crop-72-72-72px-CommunityAvatar4.png" width="36" height="36" style="max-width:36px" loading="lazy" alt="Sharon Remedios" />
+				</picture>
+
+				<div class="ur_author">
+					<p class="ur_name">Sharon Remedios</p>
+					<p class="ur_date">May 5, 2016</p>
+				</div>
+
+			</div>
+
+			<div class="ur_review_text">
+				"I've been hearing impaired since childhood, resulting in the micro-hairs and eardrums being severely damaged. Since<span class='ur_review_more' hidden> then, I've had re-occurring tinnitus, but lately its become harder to ignore. &quot;Sound suppression&quot; works wonders! Even low music helps. :)"</span><span class='ur_ellipsis'>..." </span><a href='#' class='ur_review_show'>more</a>
+			</div>
+
+			<div class="ur_rating">
+			</div>
+
+		</div>
+
+		
+
+		<div class="ur_review ur_review3">
+			<div class="ur_user">
+
+				<picture class="ur_avatar">
+					<source type="image/webp" srcset="/images/thumb/f/f2/CommunityAvatar3.png/-crop-72-72-72px-CommunityAvatar3.png.webp" />
+					<img src="/images/thumb/f/f2/CommunityAvatar3.png/-crop-72-72-72px-CommunityAvatar3.png" width="36" height="36" style="max-width:36px" loading="lazy" alt="Gary Hayes" />
+				</picture>
+
+				<div class="ur_author">
+					<p class="ur_name">Gary Hayes</p>
+					<p class="ur_date">Dec 29, 2017</p>
+				</div>
+
+			</div>
+
+			<div class="ur_review_text">
+				"The tips regarding vitamins as a possible treatment. Everyone on the Internet is selling some type of fake cure.<span class='ur_review_more' hidden> Everything from their books on the topic to what to eat for breakfast if you subscribe to their newsletter. There is no cure yet."</span><span class='ur_ellipsis'>..." </span><a href='#' class='ur_review_show'>more</a>
+			</div>
+
+			<div class="ur_rating">
+			</div>
+
+		</div>
+
+		
+
+		<div class="ur_review ur_review4">
+			<div class="ur_user">
+
+				<picture class="ur_avatar">
+					<source type="image/webp" srcset="/images/thumb/0/0a/CommunityAvatar1.png/-crop-72-72-72px-CommunityAvatar1.png.webp" />
+					<img src="/images/thumb/0/0a/CommunityAvatar1.png/-crop-72-72-72px-CommunityAvatar1.png" width="36" height="36" style="max-width:36px" loading="lazy" alt="Ed Wisdom" />
+				</picture>
+
+				<div class="ur_author">
+					<p class="ur_name">Ed Wisdom</p>
+					<p class="ur_date">Jun 6, 2016</p>
+				</div>
+
+			</div>
+
+			<div class="ur_review_text">
+				"The ringing is so intense that sometimes it;s unbearable and totally unreal. Since the shotgun solution is not<span class='ur_review_more' hidden> advisable, I found reading side effects from medicines, stress, and a healthy diet to improve my health is good advice. Thank you."</span><span class='ur_ellipsis'>..." </span><a href='#' class='ur_review_show'>more</a>
+			</div>
+
+			<div class="ur_rating">
+			</div>
+
+		</div>
+
+		
+
+		</div> 
+
+		<div class="ur_nav_container">
+					<a href="#" class="ur_share">Share yours!</a>
+					<a href="#" class="ur_more ur_nav">More success stories</a>
+					<a href="#" class="ur_hide ur_nav">Hide success stories</a>
+		</div>
+	</div>
+	
+</div>
+<div class="wh_ad_inner rr_container" data-service="adsense" data-slot="5490902193" data-instantload="0" data-width="300" data-height="600" style="height:2000px" data-innerclass="w_label al_grey" data-type="rightrail" data-large="1" data-channels="8596984590" data-largechannels="5788212177 9818776313" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="0" data-gptdisplaylate="1"><div id="rightrail0_ad_1" class="w_label al_grey blockthrough"></div></div><script>WH.ads.addBodyAd('rightrail0_ad_1')</script><div id="side_related_articles" class="sidebox related_articles">
+	<h3>Related Articles</h3><a class="related-wh" href="/Get-Rid-of-an-Ear-Ache"><div class="content-spacer"><img id="f36afd07ffbb6b2ba9518a64b4281b57" class="scrolldefer content-fill" alt="Get Rid of an Ear Ache" width="127" height="140" data-src="https://www.wikihow.com/images/thumb/7/73/Get-Rid-of-an-Ear-Ache-Step-10-Version-6.jpg/-crop-127-140-127px-Get-Rid-of-an-Ear-Ache-Step-10-Version-6.jpg"/><span class="related-wh-title"><div class="related-wh-howto">How to</div>Get Rid of an Ear Ache</span></div><script>WH.shared.addScrollLoadItem('f36afd07ffbb6b2ba9518a64b4281b57')</script><noscript><img src="https://www.wikihow.com/images/thumb/7/73/Get-Rid-of-an-Ear-Ache-Step-10-Version-6.jpg/-crop-127-140-127px-Get-Rid-of-an-Ear-Ache-Step-10-Version-6.jpg"/></noscript></a><a class="related-wh" href="/Cure-an-Earache"><div class="content-spacer"><img id="3b7ce45142dddeae1a48aeb909d9e15a" class="scrolldefer content-fill" alt="Cure an Earache" width="127" height="140" data-src="https://www.wikihow.com/images/thumb/8/89/Cure-an-Earache-Step-12-Version-3.jpg/-crop-127-140-127px-Cure-an-Earache-Step-12-Version-3.jpg"/><span class="related-wh-title"><div class="related-wh-howto">How to</div>Cure an Earache</span></div><script>WH.shared.addScrollLoadItem('3b7ce45142dddeae1a48aeb909d9e15a')</script><noscript><img src="https://www.wikihow.com/images/thumb/8/89/Cure-an-Earache-Step-12-Version-3.jpg/-crop-127-140-127px-Cure-an-Earache-Step-12-Version-3.jpg"/></noscript></a><a class="related-wh" href="/Treat-Tinnitus"><div class="content-spacer"><img id="d38bb2088badcb40d89c2e839035899b" class="scrolldefer content-fill" alt="Treat Tinnitus" width="127" height="140" data-src="https://www.wikihow.com/images/thumb/c/cd/Cure-Tinnitus-Step-16.jpg/-crop-127-140-127px-Cure-Tinnitus-Step-16.jpg"/><span class="related-wh-title"><div class="related-wh-howto">How to</div>Treat Tinnitus</span></div><script>WH.shared.addScrollLoadItem('d38bb2088badcb40d89c2e839035899b')</script><noscript><img src="https://www.wikihow.com/images/thumb/c/cd/Cure-Tinnitus-Step-16.jpg/-crop-127-140-127px-Cure-Tinnitus-Step-16.jpg"/></noscript></a><a class="related-wh" href="/Reduce-Tinnitus-Naturally"><div class="content-spacer"><img id="481807baf425e4ca6bd20ef7a9f06d3f" class="scrolldefer content-fill" alt="Reduce Tinnitus Naturally" width="127" height="140" data-src="https://www.wikihow.com/images/thumb/d/d9/Recognize-Hearing-Loss-Step-19.jpg/-crop-127-140-127px-Recognize-Hearing-Loss-Step-19.jpg"/><span class="related-wh-title"><div class="related-wh-howto">How to</div>Reduce Tinnitus Naturally</span></div><script>WH.shared.addScrollLoadItem('481807baf425e4ca6bd20ef7a9f06d3f')</script><noscript><img src="https://www.wikihow.com/images/thumb/d/d9/Recognize-Hearing-Loss-Step-19.jpg/-crop-127-140-127px-Recognize-Hearing-Loss-Step-19.jpg"/></noscript></a><div class="clearall"></div>
+</div><div class="wh_ad_inner rr_container" data-service="dfp" data-adunitpath="/10095428/engl/engl_gam_lgm_rght2" data-size="[[300, 250],[300, 600],[120,600],[160,600]]" data-prebidload="1" data-apsload="1" data-refreshable="1" data-viewablerefresh="1" data-first-refresh-time="30000" data-refresh-time="28000" data-aps-timeout="800" data-width="300" data-height="600" style="height:3300px" data-innerclass="w_label al_grey" data-type="rightrail" data-large="1" data-channels="8596984590" data-mobilechannels="7928712280,6429618073" data-observerloading="1" data-sizes-array="[[300, 250],[300, 600],[120,600],[160,600]]" data-gptdisplaylate="1"><div id="rightrail1_ad_1" class="w_label al_grey blockthrough"></div></div><script>WH.ads.addBodyAd('rightrail1_ad_1')</script></div><br class="clearall"></div><br class="clearall"><script type="application/ld+json">{
+    "@context": "http:\/\/schema.org",
+    "@type": "Article",
+    "headline": "How to Stop Ringing in Ears",
+    "name": "How to Stop Ringing in Ears",
+    "mainEntityOfPage": {
+        "@type": "WebPage",
+        "id": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears"
+    },
+    "image": {
+        "@type": "ImageObject",
+        "url": "https:\/\/www.wikihow.com\/images\/thumb\/4\/4a\/Stop-Ringing-in-Ears-Step-9-Version-2.jpg\/aid543713-v4-1200px-Stop-Ringing-in-Ears-Step-9-Version-2.jpg",
+        "width": 1200,
+        "height": 900
+    },
+    "author": {
+        "@context": "http:\/\/schema.org",
+        "@type": "Organization",
+        "name": "wikiHow",
+        "url": "https:\/\/www.wikihow.com",
+        "logo": {
+            "@type": "ImageObject",
+            "url": "https:\/\/www.wikihow.com\/skins\/owl\/images\/wikihow_logo_nobg_60.png",
+            "width": 326,
+            "height": 60
+        },
+        "sameAs": [
+            "https:\/\/www.facebook.com\/wikiHow\/",
+            "https:\/\/twitter.com\/wikiHow",
+            "https:\/\/www.instagram.com\/wikihow\/",
+            "https:\/\/www.linkedin.com\/company\/wikihow\/",
+            "https:\/\/www.youtube.com\/user\/WikiHow"
+        ]
+    },
+    "datePublished": "2009-02-04",
+    "dateModified": "2021-08-27",
+    "publisher": {
+        "@context": "http:\/\/schema.org",
+        "@type": "Organization",
+        "name": "wikiHow",
+        "url": "https:\/\/www.wikihow.com",
+        "logo": {
+            "@type": "ImageObject",
+            "url": "https:\/\/www.wikihow.com\/skins\/owl\/images\/wikihow_logo_nobg_60.png",
+            "width": 326,
+            "height": 60
+        },
+        "sameAs": [
+            "https:\/\/www.facebook.com\/wikiHow\/",
+            "https:\/\/twitter.com\/wikiHow",
+            "https:\/\/www.instagram.com\/wikihow\/",
+            "https:\/\/www.linkedin.com\/company\/wikihow\/",
+            "https:\/\/www.youtube.com\/user\/WikiHow"
+        ]
+    },
+    "contributor": {
+        "@type": "Person",
+        "name": "Luba Lee, FNP-BC, MS"
+    },
+    "description": "Ringing, buzzing, or roaring in the ears is often used to describe tinnitus, which can be extremely annoying and occur without any reason. Tinnitus may signify underlying nerve damage or an issue with your circulatory system, or there may..."
+}</script><script type="application/ld+json">{
+    "@context": "http:\/\/schema.org",
+    "@type": "HowTo",
+    "headline": "How to Stop Ringing in Ears",
+    "name": "How to Stop Ringing in Ears",
+    "image": {
+        "@type": "ImageObject",
+        "url": "https:\/\/www.wikihow.com\/images\/thumb\/4\/4a\/Stop-Ringing-in-Ears-Step-9-Version-2.jpg\/aid543713-v4-1200px-Stop-Ringing-in-Ears-Step-9-Version-2.jpg",
+        "width": 1200,
+        "height": 900
+    },
+    "author": {
+        "@context": "http:\/\/schema.org",
+        "@type": "Organization",
+        "name": "wikiHow",
+        "url": "https:\/\/www.wikihow.com",
+        "logo": {
+            "@type": "ImageObject",
+            "url": "https:\/\/www.wikihow.com\/skins\/owl\/images\/wikihow_logo_nobg_60.png",
+            "width": 326,
+            "height": 60
+        },
+        "sameAs": [
+            "https:\/\/www.facebook.com\/wikiHow\/",
+            "https:\/\/twitter.com\/wikiHow",
+            "https:\/\/www.instagram.com\/wikihow\/",
+            "https:\/\/www.linkedin.com\/company\/wikihow\/",
+            "https:\/\/www.youtube.com\/user\/WikiHow"
+        ]
+    },
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "bestRating": 100,
+        "ratingCount": 103,
+        "ratingValue": 68
+    },
+    "datePublished": "2009-02-04",
+    "dateModified": "2021-08-27",
+    "publisher": {
+        "@context": "http:\/\/schema.org",
+        "@type": "Organization",
+        "name": "wikiHow",
+        "url": "https:\/\/www.wikihow.com",
+        "logo": {
+            "@type": "ImageObject",
+            "url": "https:\/\/www.wikihow.com\/skins\/owl\/images\/wikihow_logo_nobg_60.png",
+            "width": 326,
+            "height": 60
+        },
+        "sameAs": [
+            "https:\/\/www.facebook.com\/wikiHow\/",
+            "https:\/\/twitter.com\/wikiHow",
+            "https:\/\/www.instagram.com\/wikihow\/",
+            "https:\/\/www.linkedin.com\/company\/wikihow\/",
+            "https:\/\/www.youtube.com\/user\/WikiHow"
+        ]
+    },
+    "contributor": {
+        "@type": "Person",
+        "name": "Luba Lee, FNP-BC, MS"
+    },
+    "step": [
+        {
+            "@type": "HowToSection",
+            "name": "Treating Momentary Ringing in the Ears",
+            "itemListElement": [
+                {
+                    "@type": "HowToStep",
+                    "text": "Try the skull-thumping trick. If you're coming home from a concert or a club, and your ears won't stop ringing, it's because you've damaged some of the little hairs in your cochlea, which causes inflammation and stimulation of nerves. Your brain interprets this inflammation as constant ringing or buzzing, and this trick can help make that annoying sound go away. While some people think skull-thumping has a positive effect, more research needs to be done to determine whether it is effective.\nCover your ears with your palms. Your fingers should be pointed back and resting on the back of your skull. Point your middle fingers toward each other at the very back of your skull.\nRest your index fingers on top of your middle fingers.\nUsing a snapping motion, flip your index fingers down off your middle fingers and onto the back of the skull. This motion will sound like the beating of drums. Because the fingers will also hit your skull, the noise may be quite loud. This is normal.\nContinue snapping your fingers onto the back of your skull 40 to 50 times. After 40 or 50 times, see if the ringing has subsided.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/4\/42\/Stop-Ringing-in-Ears-Step-1-Version-3.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-1-Version-3.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-00"
+                },
+                {
+                    "@type": "HowToStep",
+                    "text": "Try waiting it out. Ringing in the ears that is caused by exposure to loud noises usually goes away after a few hours. Take your mind off it by resting and staying away from anything that might exacerbate the symptoms. If the ringing doesn't go away after 24 hours, visit the doctor for further treatment.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/9\/95\/Stop-Ringing-in-Ears-Step-2-Version-3.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-2-Version-3.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-01"
+                },
+                {
+                    "@type": "HowToStep",
+                    "text": "Avoid loud noises and protect your ears when you are exposed to noise. Being exposed to loud noises over and over again can lead to recurring episodes of tinnitus. If you are often exposed to loud noises in your environment, make sure to wear ear protection. \nGet some foam earplugs that fit in your ears or get a pair of over-the-ear ear protectors.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/5\/58\/Choose-Earplugs-Step-12.jpg\/v4-460px-Choose-Earplugs-Step-12.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-02"
+                }
+            ]
+        },
+        {
+            "@type": "HowToSection",
+            "name": "Treating Chronic Ringing in the Ears",
+            "itemListElement": [
+                {
+                    "@type": "HowToStep",
+                    "text": "See your doctor about treating underlying conditions. Much of the time, tinnitus, or ringing in the ears, is caused by a treatable condition. Treating this underlying condition may help remove some or all of the ringing.\nHave your doctor remove earwax from your ear. Alternately, do it safely yourself. Removing an excess buildup of earwax can help relieve symptoms of tinnitus.\nFluid buildup due to a perforated membrane or allergies may lead to tinnitus.\nHave your doctor re-examine the interactions of your medications. If you take several medications, talk with your doctor about possible side-effects that could be causing the ringing in your ears.\nMake sure to tell your doctor about any other symptoms you are having. Temporomandibular joint dysfunction (Costen\u2019s syndrome) may be associated with tinnitus.\nA flutter or spasm of the tensor tympani or stapedius muscle in the inner ear may also result in tinnitus.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/7\/77\/Stop-Ringing-in-Ears-Step-3-Version-3.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-3-Version-3.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-13"
+                },
+                {
+                    "@type": "HowToStep",
+                    "text": "Look into biofeedback therapy for your tinnitus. If you are depressed, stressed, or fatigued, then you may be more susceptible to normal head sounds. Look into biofeedback therapy from a counselor who can help you to tune into the feelings and situations that cause or worsen your tinnitus. This may help you to stop tinnitus when it starts and prevent it from coming back.\nResearch has shown that biofeedback therapy can be very effective for treating tinnitus.\nAsk your doctor for a referral to a therapist who has experience with biofeedback for tinnitus.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/e\/ec\/Cure-Tinnitus-Step-4-Version-4.jpg\/v4-460px-Cure-Tinnitus-Step-4-Version-4.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-14"
+                },
+                {
+                    "@type": "HowToStep",
+                    "text": "Treat tinnitus with noise-suppression tactics. Several different noise-suppression tactics are used by doctors to mask the sound of ringing in your ears. These tactics include the following devices and techniques.\nMake use of white noise machines. White noise machines that produce \"background\" sounds, such as rain falling or wind whooshing, may help drown out the ringing in your ears. Fans, humidifiers, dehumidifiers and air conditioners also serve as effective white noise machines.\nMake use of masking devices. Masking devices are fitted over your ears and produce a continuous wave of white noise to mask the chronic ringing.\nWear hearing aids. This is especially effective if you have hearing problems in addition to tinnitus.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/d\/da\/Stop-Ringing-in-Ears-Step-4-Version-3.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-4-Version-3.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-15"
+                },
+                {
+                    "@type": "HowToStep",
+                    "text": "Take medications to relieve some of the tinnitus symptoms. Although medications probably won't stop the ringing, taking medications can make the ringing sound less noticeable.\nTalk to your doctor about tricyclic antidepressants. Tricyclic antidepressants can be effective for severe tinnitus, but have some undesirable side-effects, such as dry mouth, blurred vision, constipation and heart problems. Although some studies support the use of tricyclic antidepressants for tinnitus, more research needs to be done to determine whether it is effective.\nTalk to your doctor about Alprazolam. Better known as Xanax, Alprazolam has been shown to be effective in reducing tinnitus buzzing, but it is habit-forming and also has undesirable side-effects. Although some studies support the use of alprazolam for tinnitus, more research needs to be done to determine whether it is effective.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/b\/b9\/Stop-Ringing-in-Ears-Step-5-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-5-Version-2.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-16"
+                },
+                {
+                    "@type": "HowToStep",
+                    "text": "Try ginkgo extract. Taking ginkgo extract 3 times a day (with meals) may help increase blood flow to the head and neck, reducing the ringing caused by blood pressure. Try taking ginkgo for 2 months before evaluating the effectiveness of the treatment. Although some studies support the use of ginkgo biloba for tinnitus more research needs to be done to determine whether it is effective.\nFollow the manufacturer\u2019s instructions for how much to take.\nMake sure to ask your doctor first to ensure that it is safe for you to take ginkgo extract.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/f\/f5\/Stop-Ringing-in-Ears-Step-6-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-6-Version-2.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-17"
+                }
+            ]
+        },
+        {
+            "@type": "HowToSection",
+            "name": "Preventing Tinnitus",
+            "itemListElement": [
+                {
+                    "@type": "HowToStep",
+                    "text": "Avoid situations in which damage to the cochlea could cause tinnitus. Because tinnitus is so hard to treat, the most effective option is to avoid causing it in the first place, or avoid making the symptoms worse. The following may exacerbate the symptoms of tinnitus:\nLoud noises. Concerts are the main culprit, but construction work, traffic, airplanes, gunshots, fireworks, and other loud noises can also be harmful.\nSwimming. Water and chlorine can get stuck in your inner ear while swimming, causing or intensifying your tinnitus. Keep this from happening by wearing earplugs while swimming.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/f\/fa\/Stop-Ringing-in-Ears-Step-7-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-7-Version-2.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-28"
+                },
+                {
+                    "@type": "HowToStep",
+                    "text": "Find an outlet for your stress. If you have constant ringing in your ears, any stress might make the condition worse. Find ways such as exercise, meditation, and massage therapy to relieve your stress.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/c\/c4\/Stop-Ringing-in-Ears-Step-8-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-8-Version-2.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-29"
+                },
+                {
+                    "@type": "HowToStep",
+                    "text": "Consume less alcohol and nicotine. These substances increase the stress put on blood vessels by dilating them. This happens especially in the inner ear. Limit your intake of alcoholic beverages and tobacco products to reduce the symptoms.",
+                    "image": "https:\/\/www.wikihow.com\/images\/thumb\/4\/4a\/Stop-Ringing-in-Ears-Step-9-Version-2.jpg\/v4-460px-Stop-Ringing-in-Ears-Step-9-Version-2.jpg",
+                    "url": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears#step-id-210"
+                }
+            ]
+        }
+    ],
+    "description": "Ringing, buzzing, or roaring in the ears is often used to describe tinnitus, which can be extremely annoying and occur without any reason. Tinnitus may signify underlying nerve damage or an issue with your circulatory system, or there may..."
+}</script><script type="application/ld+json">{
+    "@context": "http:\/\/schema.org",
+    "@type": "FAQPage",
+    "headline": "How to Stop Ringing in Ears",
+    "name": "How to Stop Ringing in Ears",
+    "mainEntity": [
+        {
+            "@type": "Question",
+            "name": "I have ringing in ears at night only when l lie down. What could this be? What can I do?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Most people do experience some form of ringing in their ears especially in quiet settings.  Most tinnitus results from conditions that cause hearing loss.  Stress, fatigue and physical exertion may worsen the ringing in the ears. Managing daily stress well, taking care of your body through good nutrition and exercise, avoiding exposure to loud noises should help to minimize ringing in your ears.  Also, try using some sort of white noise device such as an air filter, special noise machine, peaceful nature sounds, or music."
+            }
+        },
+        {
+            "@type": "Question",
+            "name": "What is the remedy for tinnitus?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "The remedy depends on the cause of the tinnitus.  There are several drugs that are used to help relieve constant ringing such as nicotinic acid, vasodilators, tranquilizers, antidepressants and seizure medications. Many times treatment is unsuccessful. Biofeedback may help in certain cases when tinnitus is related to stress.  There is also tinnitus retraining therapy.  You may want to explore information and support provided by the American Tinnitus Association."
+            }
+        }
+    ]
+}</script><script type="application/ld+json">{
+    "@context": "http:\/\/schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item": {
+                "@id": "https:\/\/www.wikihow.com",
+                "name": "wikiHow"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 2,
+            "item": {
+                "@id": "https:\/\/www.wikihow.com\/Category:Health",
+                "name": "Health"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 3,
+            "item": {
+                "@id": "https:\/\/www.wikihow.com\/Category:Ear-Health",
+                "name": "Ear Health"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 4,
+            "item": {
+                "@id": "https:\/\/www.wikihow.com\/Category:Tinnitus",
+                "name": "Tinnitus"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 5,
+            "item": {
+                "@id": "https:\/\/www.wikihow.com\/Stop-Ringing-in-Ears",
+                "name": "How to Stop Ringing in Ears"
+            }
+        }
+    ]
+}</script>
+<div id="fb-root" ></div>
+<div id="footer" role="navigation">
+	
+	<div id="footer_inner">
+
+		<a href='/Main-Page' id="footer_logo">
+			<img src='/skins/owl/images/wikihow_logo_intl.png' width='162' height='42' alt='wikiHow' />
+			
+		</a>
+
+		<div id="footer_crumbs">
+			<ul class="breadcrumbs">
+				<li><a href="/Special:CategoryListing" title="Special:CategoryListing">Categories</a></li><li><a href="/Category:Health" title="Category:Health">Health</a></li><li><a href="/Category:Ear-Health" title="Category:Ear Health">Ear Health</a></li><li><a href="/Category:Tinnitus" title="Category:Tinnitus">Tinnitus</a></li>
+			</ul>
+		</div>
+
+		<div id="footer_top_divider" class="footer_divider"></div>
+		<div id="footer_vertical_divider"></div>
+				<div id="footer_newsletter">
+					<div id="footer_subscribe_icon"></div>
+					<div id="footer_subscribe_title">wikiHow Newsletter</div>
+					<div id="footer_subscribe_confirm_text">You're all set!</div>
+					<div id="footer_subscribe_text">Helpful how-tos delivered to<br/>your inbox every week!</div>
+					<input class="news_sub_element" id="footer_subscribe_email" placeholder="Enter your email"/>
+					<a href="#" id="footer_subscribe_button" class="button news_sub_element">Sign me up!</a>
+					<div id="footer_subscribe_notice"  class="news_sub_element">By signing up you are agreeing to receive emails according to our privacy policy.</div>
+				</div>
+				<div id="footer_newsletter_divider" class="footer_divider"></div>
+
+		<div id="search_footer" class="wh_search " role="search">
+	<div class="cse_x" role="button"></div>
+			<form action="/wikiHowTo" id="cse-search-box-bottom">
+		<div>
+			<input type="text" class="cse_q search_box" id='search_field_bottom' name="search" value=""
+				placeholder="How to Stop Ringing in Ears"
+				x-webkit-speech aria-label="Search here"
+			/>
+			<input type="submit" value="" class="cse_sa" alt="" />
+		</div>
+	</form>
+</div>
+<!--end search-->
+
+
+		<div id="footer_links">
+			<ul>
+				<li><a href="/Main-Page" title="Main Page">Home</a></li>
+				<li><a href="/About-wikiHow" class="mw-redirect" title="About wikiHow">About wikiHow</a></li>
+				<li><a target="_blank" rel="noreferrer noopener" class="external text" href="https://www.wikihow.com/Experts">Experts</a></li>
+				<li><a href="https://blog.wikihow.com/">Blog</a></li>
+				<li><a href="/wikiHow:Jobs" title="wikiHow:Jobs">Jobs</a></li>
+				<li><a href="/wikiHow:Contact-Us" title="wikiHow:Contact Us">Contact Us</a></li>
+				<li><a href="/Special:Sitemap" title="Special:Sitemap">Site Map</a></li>
+				<li><a href="/wikiHow:Terms-of-Use" title="wikiHow:Terms of Use">Terms of Use</a></li>
+				<li><a href="/wikiHow:Privacy-Policy" title="wikiHow:Privacy Policy">Privacy Policy</a></li>
+				<li><a id="footer_ccpa" href="#">Do Not Sell My Info</a></li>
+				<li><a id="footer_ccpa_optout" href="#">Not Selling Info</a></li>
+				<li><a target="_blank" rel="noreferrer noopener" class="external text" href="https://www.wikihow.com/wikiHow:Contribute">Contribute</a></li>
+			</ul>
+		</div>
+
+		<div id="sf">
+	<div>
+		<p>Follow Us</p>
+		<a id="sf_ig" class="sf_icon" href="https://www.instagram.com/wikihow/" target="_blank" title="Instagram"></a><a id="sf_fb" class="sf_icon" href="https://www.facebook.com/wikiHow/" target="_blank" title="Facebook"></a><a id="sf_tt" class="sf_icon" href="https://twitter.com/wikihow" target="_blank" title="Twitter"></a><a id="sf_yt" class="sf_icon" href="https://www.youtube.com/wikihow" target="_blank" title="YouTube"></a><a id="sf_nl" class="sf_icon" href="https://www.wikihow.com/Newsletters" target="_blank" title="Newsletter"></a>
+	</div>
+</div>
+
+		
+		
+	</div>
+
+</div>
+<div id='sliderbox' class=" green default" data-color="green">
+	<div id='slider_container'>
+		<button id='slider_close_button' on="tap:sliderbox.hide">&times;</button>
+		<div class='slider_content'>
+				<p id='slider_small_headline'>wikiHow Tech Help Pro:</p>
+			<p id='slider_big_headline'>Level up your tech skills and stay ahead of the curve</p>
+					<a id="slider_button" class='button slider_button' rel="nofollow" data-event_type="tech_help_10" href="https://www.wikihow.com/Tech-Help-Pro?id=sdapl">Let's go!</a>
+
+		</div>
+	</div>
+</div>
+
+
+
+
+<script type="text/javascript" src="https://www.wikihow.com/extensions/min/f/_ads/gads.js"></script>
+
+<script type="text/javascript" src="https://www.wikihow.com/x/zscsucgm?"></script>
+
+<script>
+	window.WH = window.WH || {};
+	WH.hasAdBlockers = ( window._ads !== 2 );
+</script>
+<div id="article_courses_banner" hidden>
+	<a href="#" id="acb_close">X</a>
+	<div>
+		<div>
+			<h4 id="acb_header"></h4>
+			<p id="acb_text"></p>
+		</div>
+		<div>
+			<a class="button" href="/Course/Explore?utm_source=wikihow&amp;utm_medium=banner&amp;utm_campaign=coursebanner" id="acb_button"></a>
+		</div>
+	</div>
+</div><div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+	<div class="pswp__bg"></div>
+	<div class="pswp__scroll-wrap">
+		<div class="pswp__container">
+			<div class="pswp__item"></div>
+			<div class="pswp__item"></div>
+			<div class="pswp__item"></div>
+		</div>
+		<div class="pswp__ui pswp__ui--hidden">
+			<div class="pswp__top-bar">
+				<div class="pswp__method_high"></div>
+				<div class="pswp__button pswp__button--close" title="Close (Esc)"></div>
+				<div class="pswp__button pswp__button--share" title="Share"></div>
+				<div class="pswp__button pswp__button--fs" title="Toggle fullscreen"></div>
+				<div class="pswp__button pswp__button--zoom" title="Zoom in/out"></div>
+				<div class="pswp__preloader">
+					<div class="pswp__preloader__icn">
+						<div class="pswp__preloader__cut">
+							<div class="pswp__preloader__donut"></div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+				<div class="pswp__share-tooltip"></div>
+			</div>
+			<div class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+			</div>
+			<div class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+			</div>
+			<div class="pswp__caption">
+				<div class="pswp__caption__center"></div>
+				<div class="pswp__caption__info"></div>
+			</div>
+			<div class="pswp__method"></div>
+			<div class="pswp__counter"></div>
+		</div>
+	</div>
+</div>
+</div></div><div id="servedtime" style="display:none" data-app="app0">515</div><script async="" src="/load.php?debug=false&amp;lang=en&amp;modules=startup&amp;only=scripts&amp;siterev=tmCgL&amp;skin=wh&amp;target=mobile"></script>
+<noscript> <style> .mwimg a.image{display:none}#header_logo{display:none}#cse-search-box{display:none}#cse-search-box-noscript{display:block !important}#cse-search-box-noscript .cse_q{color:#FFF;background-color:#B3CE9C}.wh_search .cse_q{width:88%}#mw-mf-main-menu-button{display:none;visibility:hidden}.header .search{display:none}#search_footer .cse_sa{background-image:url(/extensions/wikihow/mobile/images/white_mag.png);background-size:22px}.related_box{display:block;background:#EEE;border:5px solid #FFF;vertical-align:bottom;width:127px;background-size:180px;float:left;height:120px;position:relative}.related_box p{line-height:15px !important;font-size:13px;background-color:rgba(67,95,44,.4);color:#FFF;font-weight:bold;padding:8px;margin:0 !important;position:absolute;bottom:0}#noscript_header_logo{display:table-cell;vertical-align:middle;background-position:50% 77%;background-repeat:no-repeat;background-image:url(/extensions/wikihow/mobile/images/wikihow_logo_230.png);background-size:105px;width:auto;height:51px;padding:0 14px}.articleinfo{display:none}#iorg_free_data{z-index:50;width:100%;position:fixed}#ara_recommendations{display:none}</style> </noscript>
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgPageParseReport":{"limitreport":{"cputime":"0.042","walltime":"0.087","ppvisitednodes":{"value":372,"limit":1000000},"ppgeneratednodes":{"value":1286,"limit":1000000},"postexpandincludesize":{"value":1308,"limit":2097152},"templateargumentsize":{"value":0,"limit":2097152},"expansiondepth":{"value":3,"limit":40},"expensivefunctioncount":{"value":0,"limit":100},"unstrip-depth":{"value":0,"limit":20},"unstrip-size":{"value":8353,"limit":5000000},"timingprofile":["100.00%   20.890      1 -total"," 93.21%   19.472      1 Template:Reflist","  6.32%    1.321      1 Summary:Stop-Ringing-in-Ears"]},"cachereport":{"timestamp":"20210903103124","ttl":86400,"transientcontent":false}}});});</script><script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":515});});</script><script>if ( WH.shared.isDesktopSize && WH.hasAdBlockers ) {
+	var newScript = document.createElement('script');
+	newScript.async = true;
+	newScript.type = 'text/javascript';
+
+	// 'videoplayerhub.com' is sometimes blocked, as it appears in:
+	// https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_trackingservers.txt
+	newScript.src = 'https://wikihow-com.videoplayerhub.com/galleryloader.js';
+	var node = document.getElementsByTagName('script')[0];
+	node.parentNode.insertBefore(newScript, node);
+	var size = false;
+	var eventData = {
+		'size':size,
+	};
+	WH.event('galleryloader_init', eventData);
+}
+</script></body></html>


### PR DESCRIPTION
ini jam 03:20, aku belom tidur dic. wkwkwkwk dah teler

gonna ease your reviewing life so you can continue to watch anime or whatever the f you're doing.

I added a few new handlers:
- food network
- stackexchange
- wikihow

fixed a bug where the HTML tags were not rendered properly by doing
```js
if (content.length > 500) {
  content = `${sanitize(content.substring(0, 500))}...\n\nSee more on: ${result.url}`;
}
```

and uh, I kinda modify the valid source to omit `www.` beginnings:
```js
.filter((url) => VALID_SOURCES[url.hostname.replace('www.', '')]);
```

anyway, here's some screenshots

<img src="https://user-images.githubusercontent.com/7274326/132061248-c5a2f296-8fdd-4d8c-a8f2-559039384122.png" width="400px">

<img src="https://user-images.githubusercontent.com/7274326/132061262-a3d926ce-af35-4c17-8b4e-323a5b0c9402.png" width="400px">

<img src="https://user-images.githubusercontent.com/7274326/132061297-4a464256-b615-44f6-9f17-e4564e8a29c3.png" width="400px">
<img src="https://user-images.githubusercontent.com/7274326/132061285-9771f909-bbc9-4d2a-9993-84bbe193b327.png" width="400px">
