### PR TITLE
feat: implement dukun master

### DIFF
--- a/src/services/dukun/dukun.template.hbs
+++ b/src/services/dukun/dukun.template.hbs
@@ -1,10 +1,10 @@
 {{#expect dukun, others}}
 
-<b>Dukun Perguruan Jason Wihardja</b>\n
+<b>Perguruan Dukun Jason Wihardja</b>\n
 
 {{#each dukun as d}}
 ● {{ [d.firstName, d.lastName].join(' ') }} ({{ d.points }} poin)
-{{/each}}
+{{/each}}\n
 
 {{#if others > 0 }}
 dan {{ others }} dukun lainnya..


### PR DESCRIPTION
- no need for assigning a person as `/dukun master` because it might create chaos and war between us
- if a point was given to someone (in this case, a dukun) in which their resulting (added) points would be equal or more than the dukun master's points, their points will be the current dukun master's point - 1
- so in essence, the dukun master's points should be increased first in order to allow the other dukun to increase their own points.
- fixed a bug on showing the remaining dukun on the dukun leaderboard
- also fixed another bug where the username, user first name, user last name, and updatedAt columns were not updated during the upsert query.