### PR TITLE
Allow sequence expression

### DIFF
--- a/src/services/eval/parser.js
+++ b/src/services/eval/parser.js
@@ -34,6 +34,7 @@ export function isAllowed(ast, locals = []) {
     case 'Literal':
       return true;
     case 'TemplateLiteral':
+    case 'SequenceExpression':
       return ast.expressions.every((expression) => isAllowed(expression, locals));
     case 'Identifier':
       if (allowedBuiltInObjects.has(ast.name) || locals.includes(ast.name)) {

--- a/tests/eval.test.js
+++ b/tests/eval.test.js
@@ -167,6 +167,11 @@ test('should not be able to evaluate empty string', async () => {
   assert.equal(result, 'Tidak bisa mengevaluasi code');
 });
 
+test('should be able to evaluate sequence expression', async () => {
+  const result = await safeEval('(1, 2, 3)');
+  assert.equal(result, '3');
+});
+
 test('should not be able to pass module ast into isAllowed', () => {
   let result;
   try {


### PR DESCRIPTION
Allows following expression in `/eval`:
```
/eval (1, 2, 3)

Output:
3
```

Closes #89 