### PR TITLE
fix: text variable passed to sanitize()

### DIFF
--- a/src/services/search/index.js
+++ b/src/services/search/index.js
@@ -49,8 +49,8 @@ async function search(context, mongo) {
 
   let items = $(".web-result")
     .map((_, el) => {
-      const title = $(el).find(".result__title > a").first().text();
-      const titleText = title !== "" ? title : "Title unavailable.";
+      const title = $(el).find(".result__title > a").first();
+      const titleText = title.text() !== "" ? title.text() : "Title unavailable.";
       const url = title.attr("href");
       const decodedHref = decodeURIComponent(cleanURL(url));
       const snippet = $(el)

--- a/src/services/search/index.js
+++ b/src/services/search/index.js
@@ -49,7 +49,7 @@ async function search(context, mongo) {
 
   let items = $(".web-result")
     .map((_, el) => {
-      const title = $(el).find(".result__title > a").first();
+      const title = $(el).find(".result__title > a").first().text();
       const titleText = title !== "" ? title : "Title unavailable.";
       const url = title.attr("href");
       const decodedHref = decodeURIComponent(cleanURL(url));


### PR DESCRIPTION
linked issue: https://teknologi-umum.sentry.io/share/issue/5197971de9a048cabe1b931f032b8889/

Summary: 
In `src/services/search/index.js` line 52 
```js
const title = $(el).find(".result__title > a").first();
const titleText = title !== "" ? title : "Title unavailable.";
```
the returned value from `.first()` is still of `Cheerio<Element>` type where sanitize-html's sanitize() only accepts strings.

Fix: get the text content by appending `.text()`